### PR TITLE
Using Span<T> instead of T[]

### DIFF
--- a/src/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/src/ARMeilleure/Decoders/OpCodeTable.cs
@@ -1405,7 +1405,7 @@ namespace ARMeilleure.Decoders
             int xMask = 0;
             int xBits = 0;
 
-            int[] xPos = new int[encoding.Length];
+            Span<int> xPos = new int[encoding.Length];
 
             int blacklisted = 0;
 

--- a/src/Ryujinx.Ava/UI/Models/SaveModel.cs
+++ b/src/Ryujinx.Ava/UI/Models/SaveModel.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.Ava.UI.Models
         private string GetSizeString()
         {
             const int scale = 1024;
-            string[] orders = { "GiB", "MiB", "KiB" };
+            Span<string> orders = new []{ "GiB", "MiB", "KiB" };
             long max = (long)Math.Pow(scale, orders.Length);
 
             foreach (string order in orders)

--- a/src/Ryujinx.Common/SystemInfo/LinuxSystemInfo.cs
+++ b/src/Ryujinx.Common/SystemInfo/LinuxSystemInfo.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.Common.SystemInfo
                 string line;
                 while ((line = file.ReadLine()) != null)
                 {
-                    string[] kvPair = line.Split(':', 2, StringSplitOptions.TrimEntries);
+                    Span<string> kvPair = line.Split(':', 2, StringSplitOptions.TrimEntries);
 
                     if (kvPair.Length < 2) continue;
 

--- a/src/Ryujinx.Graphics.Host1x/Host1xDevice.cs
+++ b/src/Ryujinx.Graphics.Host1x/Host1xDevice.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.Graphics.Host1x
         private void Process(Command command)
         {
             SetNvdecContext(command.ContextId);
-            int[] commandBuffer = command.Buffer;
+            Span<int> commandBuffer = command.Buffer;
 
             for (int index = 0; index < commandBuffer.Length; index++)
             {

--- a/src/Ryujinx.Graphics.OpenGL/Image/TextureCopyIncompatible.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Image/TextureCopyIncompatible.cs
@@ -194,7 +194,7 @@ void main()
             {
                 int csHandle = GL.CreateShader(ShaderType.ComputeShader);
 
-                string[] formatTable = new[] { "r8ui", "r16ui", "r32ui", "rg8ui", "rg16ui", "rg32ui", "rgba8ui", "rgba16ui", "rgba32ui" };
+                Span<string> formatTable = new[] { "r8ui", "r16ui", "r32ui", "rg8ui", "rg16ui", "rg32ui", "rgba8ui", "rgba16ui", "rgba32ui" };
 
                 string srcFormat = formatTable[srcIndex];
                 string dstFormat = formatTable[dstIndex];

--- a/src/Ryujinx.Graphics.OpenGL/Image/TextureCopyMS.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Image/TextureCopyMS.cs
@@ -219,7 +219,7 @@ void main()
             return GetShader(ComputeShaderNonMSToMS, _nonMSToMSProgramHandles, bytesPerPixel);
         }
 
-        private int GetShader(string code, int[] programHandles, int bytesPerPixel)
+        private int GetShader(string code, Span<int> programHandles, int bytesPerPixel)
         {
             int index = BitOperations.Log2((uint)bytesPerPixel);
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
                 int arity = (int)(info.Type & InstType.ArityMask);
 
-                string[] expr = new string[arity];
+                Span<string> expr = new string[arity];
 
                 for (int index = 0; index < arity; index++)
                 {

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -148,7 +148,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 int offset = 0;
 
                 SpvInstruction[] structFieldTypes = new SpvInstruction[buffer.Type.Fields.Length];
-                int[] structFieldOffsets = new int[buffer.Type.Fields.Length];
+                Span<int> structFieldOffsets = new int[buffer.Type.Fields.Length];
 
                 for (int fieldIndex = 0; fieldIndex < buffer.Type.Fields.Length; fieldIndex++)
                 {

--- a/src/Ryujinx.Graphics.Shader/Decoders/InstTable.cs
+++ b/src/Ryujinx.Graphics.Shader/Decoders/InstTable.cs
@@ -337,7 +337,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
             int xMask = 0;
             int xBits = 0;
 
-            int[] xPos = new int[encodingPart.Length];
+            Span<int> xPos = new int[encodingPart.Length];
 
             for (int index = 0; index < encodingPart.Length; index++, bit--)
             {

--- a/src/Ryujinx.Graphics.Texture/ETC2Decoder.cs
+++ b/src/Ryujinx.Graphics.Texture/ETC2Decoder.cs
@@ -208,7 +208,7 @@ namespace Ryujinx.Graphics.Texture
                                 DecodeBlock(tile, colorBlock);
 
                                 byte alphaBase = (byte)alphaBlock;
-                                int[] alphaTable = _etc2AlphaLut[(alphaBlock >> 8) & 0xf];
+                                Span<int> alphaTable = _etc2AlphaLut[(alphaBlock >> 8) & 0xf];
                                 int alphaMultiplier = (int)(alphaBlock >> 12) & 0xf;
                                 ulong alphaIndices = BinaryPrimitives.ReverseEndianness(alphaBlock);
 

--- a/src/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/src/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -585,7 +585,7 @@ namespace Ryujinx.HLE.FileSystem
                     {
                         // Clean up the name and get the NcaId
 
-                        string[] pathComponents = entry.FullName.Replace(".cnmt", "").Split('/');
+                        Span<string> pathComponents = entry.FullName.Replace(".cnmt", "").Split('/');
 
                         string ncaId = pathComponents[pathComponents.Length - 1];
 

--- a/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.FileSystem
 
         public string SwitchPathToSystemPath(string switchPath)
         {
-            string[] parts = switchPath.Split(":");
+            Span<string> parts = switchPath.Split(":");
 
             if (parts.Length != 2)
             {

--- a/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageHeap.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageHeap.cs
@@ -96,7 +96,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         {
         }
 
-        public KPageHeap(ulong address, ulong size, int[] blockShifts)
+        public KPageHeap(ulong address, ulong size, Span<int> blockShifts)
         {
             _heapAddress = address;
             _heapSize = size;
@@ -266,7 +266,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
             return GetBlockSize(index) / KPageTableBase.PageSize;
         }
 
-        private static int CalculateManagementOverheadSize(ulong regionSize, int[] blockShifts)
+        private static int CalculateManagementOverheadSize(ulong regionSize, Span<int> blockShifts)
         {
             int overheadSize = 0;
 

--- a/src/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -533,7 +533,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 return KernelResult.UserCopyFailed;
             }
 
-            int[] handles = new int[handlesCount];
+            Span<int> handles = new int[handlesCount];
 
             if (!KernelTransfer.UserToKernelArray<int>(handlesPtr, handles))
             {
@@ -652,7 +652,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 return result;
             }
 
-            int[] handles = new int[handlesCount];
+            Span<int> handles = new int[handlesCount];
 
             if (!KernelTransfer.UserToKernelArray<int>(handlesPtr, handles))
             {

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
@@ -3,6 +3,7 @@ using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Services.Audio.AudioIn;
+using System;
 using System.Text;
 
 namespace Ryujinx.HLE.HOS.Services.Audio
@@ -25,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         // ListAudioIns() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioIns(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioIns(false);
+            Span<string> deviceNames = _impl.ListAudioIns(false);
 
             ulong position = context.Request.ReceiveBuff[0].Position;
             ulong size = context.Request.ReceiveBuff[0].Size;
@@ -96,7 +97,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         // ListAudioInsAuto() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioInsAuto(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioIns(false);
+            Span<string> deviceNames = _impl.ListAudioIns(false);
 
             (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
@@ -163,7 +164,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         // ListAudioInsAutoFiltered() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioInsAutoFiltered(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioIns(true);
+            Span<string> deviceNames = _impl.ListAudioIns(true);
 
             (ulong position, ulong size) = context.Request.GetBufferType0x22();
 

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
@@ -3,6 +3,7 @@ using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Services.Audio.AudioOut;
+using System;
 using System.Text;
 
 namespace Ryujinx.HLE.HOS.Services.Audio
@@ -25,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         // ListAudioOuts() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioOuts(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioOuts();
+            Span<string> deviceNames = _impl.ListAudioOuts();
 
             ulong position = context.Request.ReceiveBuff[0].Position;
             ulong size = context.Request.ReceiveBuff[0].Size;
@@ -96,7 +97,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         // ListAudioOutsAuto() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioOutsAuto(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioOuts();
+            Span<string> deviceNames = _impl.ListAudioOuts();
 
             (ulong position, ulong size) = context.Request.GetBufferType0x22();
 

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDevice.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDevice.cs
@@ -2,6 +2,7 @@
 using Ryujinx.Audio.Renderer.Server;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Kernel.Threading;
+using System;
 
 namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 {
@@ -112,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return _registry.ActiveDevice.GetOutputDeviceName();
         }
 
-        public string[] ListAudioDeviceName()
+        public Span<string> ListAudioDeviceName()
         {
             int deviceCount = _sessions.Length;
 
@@ -121,7 +122,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
                 deviceCount--;
             }
 
-            string[] result = new string[deviceCount];
+            Span<string> result = new string[deviceCount];
 
             int i = 0;
 
@@ -140,11 +141,11 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return result;
         }
 
-        public string[] ListAudioOutputDeviceName()
+        public Span<string> ListAudioOutputDeviceName()
         {
             int deviceCount = _sessions.Length;
 
-            string[] result = new string[deviceCount];
+            Span<string> result = new string[deviceCount];
 
             for (int i = 0; i < deviceCount; i++)
             {

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // ListAudioDeviceName() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioDeviceName(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioDeviceName();
+            Span<string> deviceNames = _impl.ListAudioDeviceName();
 
             ulong position = context.Request.ReceiveBuff[0].Position;
             ulong size = context.Request.ReceiveBuff[0].Size;
@@ -142,7 +142,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // ListAudioDeviceNameAuto() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioDeviceNameAuto(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioDeviceName();
+            Span<string> deviceNames = _impl.ListAudioDeviceName();
 
             (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
@@ -287,7 +287,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // ListAudioOutputDeviceName() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioOutputDeviceName(ServiceCtx context)
         {
-            string[] deviceNames = _impl.ListAudioOutputDeviceName();
+            Span<string> deviceNames = _impl.ListAudioOutputDeviceName();
 
             ulong position = context.Request.ReceiveBuff[0].Position;
             ulong size = context.Request.ReceiveBuff[0].Size;

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/IAudioDevice.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/IAudioDevice.cs
@@ -1,10 +1,11 @@
 ﻿using Ryujinx.HLE.HOS.Kernel.Threading;
+using System;
 
 namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 {
     interface IAudioDevice
     {
-        string[] ListAudioDeviceName();
+        Span<string> ListAudioDeviceName();
         ResultCode SetAudioDeviceOutputVolume(string name, float volume);
         ResultCode GetAudioDeviceOutputVolume(string name,  out float volume);
         string GetActiveAudioDeviceName();
@@ -13,6 +14,6 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         KEvent QueryAudioDeviceInputEvent();
         KEvent QueryAudioDeviceOutputEvent();
         string GetActiveAudioOutputDeviceName();
-        string[] ListAudioOutputDeviceName();
+        Span<string> ListAudioOutputDeviceName();
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -44,7 +44,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                         continue;
                     }
 
-                    string[] entry = line.Split(new[] { ' ', '\t' }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                    Span<string> entry = line.Split(new[] { ' ', '\t' }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
                     // Hosts file example entry:
                     // 127.0.0.1  localhost loopback

--- a/src/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZone.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZone.cs
@@ -1328,7 +1328,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
             calendarTime.Minute = (sbyte)(remainingSeconds / SecondsPerMinute);
             calendarTime.Second = (sbyte)(remainingSeconds % SecondsPerMinute);
 
-            int[] ip = MonthsLengths[IsLeap((int)year)];
+            Span<int> ip = MonthsLengths[IsLeap((int)year)];
 
             for (calendarTime.Month = 0; dayOfYear >= ip[calendarTime.Month]; ++calendarTime.Month)
             {

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -608,7 +608,7 @@ namespace Ryujinx.Headless.SDL2
 
             if (Directory.Exists(path))
             {
-                string[] romFsFiles = Directory.GetFiles(path, "*.istorage");
+                Span<string> romFsFiles = Directory.GetFiles(path, "*.istorage");
 
                 if (romFsFiles.Length == 0)
                 {

--- a/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.Input.SDL2
 
         private int GetJoystickIndexByGamepadId(string id)
         {
-            string[] data = id.Split("-");
+            Span<string> data = id.Split("-");
 
             if (data.Length != 6 || !int.TryParse(data[0], out int joystickIndex))
             {

--- a/src/Ryujinx.Tests/HLE/SoftwareKeyboardTests.cs
+++ b/src/Ryujinx.Tests/HLE/SoftwareKeyboardTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Ryujinx.HLE.HOS.Applets;
+using System;
 using System.Text;
 
 namespace Ryujinx.Tests.HLE
@@ -21,7 +22,7 @@ namespace Ryujinx.Tests.HLE
         [Test]
         public void StripUnicodeControlCodes_Passthrough()
         {
-            string[] prompts = new string[]
+            Span<string> prompts = new string[]
             {
                 "Please name him.",
                 "Name her, too.",

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -754,7 +754,7 @@ namespace Ryujinx.Ui
 
             if (Directory.Exists(path))
             {
-                string[] romFsFiles = Directory.GetFiles(path, "*.istorage");
+                Span<string> romFsFiles = Directory.GetFiles(path, "*.istorage");
 
                 if (romFsFiles.Length == 0)
                 {
@@ -1321,7 +1321,7 @@ namespace Ryujinx.Ui
         {
             if (!_gameLoaded || !ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateExitDialog())
             {
-                SaveWindowSizePosition();        
+                SaveWindowSizePosition();
                 End();
             }
             else
@@ -1337,9 +1337,9 @@ namespace Ryujinx.Ui
 
             Move(ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX, ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY);
 
-            if (ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized) 
-            { 
-                Maximize(); 
+            if (ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized)
+            {
+                Maximize();
             }
         }
 
@@ -1354,7 +1354,7 @@ namespace Ryujinx.Ui
             ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX.Value = windowXPos;
             ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY.Value = windowYPos;
 
-            SaveConfig();        
+            SaveConfig();
         }
 
         private void StopEmulation_Pressed(object sender, EventArgs args)
@@ -1633,7 +1633,7 @@ namespace Ryujinx.Ui
                 _virtualFileSystem,
                 _emulationContext.Processes.ActiveApplication.ProgramId,
                 _emulationContext.Processes.ActiveApplication.ApplicationControlProperties
-                    .Title[(int)_emulationContext.System.State.DesiredTitleLanguage].NameString.ToString(), 
+                    .Title[(int)_emulationContext.System.State.DesiredTitleLanguage].NameString.ToString(),
                 _currentEmulatedGamePath);
 
             window.Destroyed += CheatWindow_Destroyed;


### PR DESCRIPTION
`Span<T>` is a struct introduced in .NET Core which provides a way to work with contiguous blocks of memory in a safe and efficient way. This can provide significant performance improvements, particularly in scenarios where you would otherwise be forced to allocate and deallocate large arrays frequently. Here are some of the benefits of using `Span<T>`:

- **Performance Improvement**: `Span<T>` allows you to operate on portions of data without copying data or allocating additional arrays. This can drastically reduce unnecessary allocations and therefore, improve memory utilization and overall performance.

- **Safe Operations**: `Span<T>` provides a safe way to refer to contiguous regions of arbitrary memory, whether that memory is part of an array, a portion of an array, a stack-allocated span of memory, or even an unmanaged block of memory. This provides a safe way to work with memory without having to directly deal with pointers.

- **Enhanced Array Segmentation**: With an array (`T[]`), if you want to work with a segment of the array, you would need to make a new array and copy the segment into it. `Span<T>` allows you to "slice" the data and work with a portion of it, without creating a new array, which can be much more efficient.

- **Versatility**: `Span<T>` can point to managed memory (arrays), stack memory (span local variables), and native memory (from interop). So it's more versatile than just arrays.

- **Stack Allocation**: With `Span<T>`, you can create slices of data structures on the stack, avoiding heap allocations altogether in some cases. This can provide performance benefits because stack allocations are cheaper than heap allocations.

However, `Span<T>` has some limitations. For example, it can't be stored in class fields, array elements, or other places that might cause it to be stored beyond the scope in which it was created, because it's a stack-only type. This is to ensure safety and prevent memory leaks.

In scenarios where you need to store data for longer periods or across asynchronous boundaries, you might need to use `Memory<T>` or traditional arrays. Also, since `Span<T>` is a recent addition to the .NET ecosystem, older libraries might not support it and may require arrays instead.

Benchmark:

```cs
[SimpleJob]
[MemoryDiagnoser]
[RankColumn]
public class Test
{
    [Benchmark]
    public void Array()
    {
        int[] array = new[] { 1, 2, 3 };
        for (int i = 0; i < array.Length; i++)
        {
            var x = array[i];
        }
    }

    [Benchmark]
    public void Span()
    {
        Span<int> span = new[] { 1, 2, 3 };
        for (int i = 0; i < span.Length; i++)
        {
            var x = span[i];
        }
    }
}
```

Results:
```sh
| Method |     Mean |     Error |    StdDev |   Median | Rank |   Gen0 | Allocated |
|------- |---------:|----------:|----------:|---------:|-----:|-------:|----------:|
|  Array | 5.108 ns | 0.1344 ns | 0.2423 ns | 5.003 ns |    1 | 0.0127 |      40 B |
|   Span | 5.043 ns | 0.1210 ns | 0.1132 ns | 5.004 ns |    1 | 0.0127 |      40 B |
```