### PR TITLE
Make LM skip instead of crashing for invalid messages

### DIFF
--- a/src/Ryujinx.Common/Memory/SpanReader.cs
+++ b/src/Ryujinx.Common/Memory/SpanReader.cs
@@ -24,6 +24,24 @@ namespace Ryujinx.Common.Memory
             return value;
         }
 
+        public bool TryRead<T>(out T value) where T : unmanaged
+        {
+            int valueSize = Unsafe.SizeOf<T>();
+
+            if (valueSize > _input.Length)
+            {
+                value = default;
+
+                return false;
+            }
+
+            value = MemoryMarshal.Cast<byte, T>(_input)[0];
+
+            _input = _input.Slice(valueSize);
+
+            return true;
+        }
+
         public ReadOnlySpan<byte> GetSpan(int size)
         {
             ReadOnlySpan<byte> data = _input.Slice(0, size);


### PR DESCRIPTION
On #4701, I fixed some `IndexOutOfRangeException` crashes on LM service caused by invalid sizes that would make it try to read more data than what is in the message buffer, but it would only apply to cases where it reads a string with variable length. This extends it to all reads. A new `TryRead` method was added to `SpanReader` that will return false if the value can't be read due to it not fitting in the span. In the cases where `TryRead` returns false, it returns immediately and prints whatever we have.

Fixes a crash that I found while trying to start a new match on Mortal Kombat 11 (base version).