### PR TITLE
Add an alternative backend parallel compilation queue for macOS

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -134,7 +134,7 @@ namespace Ryujinx.Ava
             _inputManager           = inputManager;
             _accountManager         = accountManager;
             _userChannelPersistence = userChannelPersistence;
-            _renderingThread        = new Thread(RenderLoop, 1 * 1024 * 1024) { Name = "GUI.RenderThread" };
+            _renderingThread        = new Thread(RenderLoop, 2 * 1024 * 1024) { Name = "GUI.RenderThread" };
             _lastCursorMoveTime     = Stopwatch.GetTimestamp();
             _glLogLevel             = ConfigurationState.Instance.Logger.GraphicsDebugLevel;
             _topLevel               = topLevel;

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCompilationQueue.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCompilationQueue.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.Graphics.Vulkan
     class ShaderCompilationQueue
     {
         private const int MaxParallelCompilations = 8;
-        private const int MaxThreadStackSize = 1 * 1024 * 1024; // MB
+        private const int MaxThreadStackSize = 2 * 1024 * 1024; // MB
 
         private struct Request
         {

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCompilationQueue.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCompilationQueue.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    class ShaderCompilationQueue
+    {
+        private const int MaxParallelCompilations = 8;
+        private const int MaxThreadStackSize = 1 * 1024 * 1024; // MB
+
+        private struct Request
+        {
+            public readonly ulong Id;
+            public readonly Action Callback;
+
+            public Request(ulong id, Action callback)
+            {
+                Id = id;
+                Callback = callback;
+            }
+        }
+
+        private readonly Thread[] _workerThreads;
+        private readonly CancellationTokenSource _cts;
+        private readonly BlockingCollection<Request>[] _queues;
+        private readonly ulong[] _finishedIds;
+        private ulong _currentId;
+        private int _currentQueueIndex;
+
+        public ShaderCompilationQueue()
+        {
+            _workerThreads = new Thread[MaxParallelCompilations];
+            _queues = new BlockingCollection<Request>[MaxParallelCompilations];
+            _finishedIds = new ulong[MaxParallelCompilations];
+
+            _cts = new CancellationTokenSource();
+
+            for (int i = 0; i < MaxParallelCompilations; i++)
+            {
+                _queues[i] = new BlockingCollection<Request>();
+
+                Thread thread = new Thread(DoWork, MaxThreadStackSize) { Name = $"BackgroundShaderCompiler.{i}" };
+                thread.IsBackground = true;
+                thread.Start(i);
+
+                _workerThreads[i] = thread;
+            }
+        }
+
+        private void DoWork(object threadId)
+        {
+            int queueIndex = (int)threadId;
+
+            try
+            {
+                var queue = _queues[queueIndex];
+
+                foreach (var request in queue.GetConsumingEnumerable(_cts.Token))
+                {
+                    request.Callback();
+
+                    lock (queue)
+                    {
+                        _finishedIds[queueIndex] = request.Id;
+
+                        Monitor.PulseAll(queue);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        public ShaderCompilationRequest Add(Action callback)
+        {
+            ulong newId = Interlocked.Increment(ref _currentId);
+
+            // Let's keep rotating between the queues to increase the chances
+            // that the selected queue thread is currently idle.
+            int queueIndex = Interlocked.Increment(ref _currentQueueIndex) % MaxParallelCompilations;
+
+            _queues[queueIndex].Add(new Request(newId, callback));
+
+            return new ShaderCompilationRequest(this, queueIndex, newId);
+        }
+
+        public void Wait(int queueIndex, ulong id)
+        {
+            var queue = _queues[queueIndex];
+
+            lock (queue)
+            {
+                while (_finishedIds[queueIndex] < id)
+                {
+                    Monitor.Wait(queue);
+                }
+            }
+        }
+
+        public bool IsCompleted(int queueIndex, ulong id)
+        {
+            var queue = _queues[queueIndex];
+
+            lock (queue)
+            {
+                return _finishedIds[queueIndex] >= id;
+            }
+        }
+
+        public void Dispose()
+        {
+            for (int i = 0; i < MaxParallelCompilations; i++)
+            {
+                _queues[i].CompleteAdding();
+            }
+
+            _cts.Cancel();
+
+            for (int i = 0; i < MaxParallelCompilations; i++)
+            {
+                _workerThreads[i].Join();
+
+                _queues[i].Dispose();
+            }
+
+            _cts.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCompilationRequest.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCompilationRequest.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    struct ShaderCompilationRequest
+    {
+        private readonly Task _task;
+        private readonly ShaderCompilationQueue _queue;
+        private readonly int _queueIndex;
+        private readonly ulong _requestId;
+
+        public bool IsCompleted
+        {
+            get
+            {
+                if (_task != null)
+                {
+                    return _task.IsCompleted;
+                }
+                else
+                {
+                    return _queue.IsCompleted(_queueIndex, _requestId);
+                }
+            }
+        }
+
+        public ShaderCompilationRequest(Task task)
+        {
+            _task = task;
+            _queue = null;
+            _queueIndex = 0;
+            _requestId = 0;
+        }
+
+        public ShaderCompilationRequest(ShaderCompilationQueue queue, int queueIndex, ulong requestId)
+        {
+            _task = null;
+            _queue = queue;
+            _queueIndex = queueIndex;
+            _requestId = requestId;
+        }
+
+        public void Wait()
+        {
+            if (_task != null)
+            {
+                _task.Wait();
+            }
+            else
+            {
+                _queue.Wait(_queueIndex, _requestId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Due to the way how SPIRV-Cross works, some shaders with deeply nested if/else blocks can cause a stack overflow depending on the stack size. SPIRV-Cross is apparently using recursive function calls in some function where it visits blocks in the code (which is bad in general IMO). To work around this issue, this change basically implements a custom thread pool. Since we create the threads ourselves, we can specify a custom stack size that is large enough to make SPIRV-Cross happy.

The obvious downside with that change is that we need to create our own thread pool, which is most likely going to perform worse than .NET one (also the current implementation is pretty basic, it has 8 queues and adds compilation requests to them in a rotating way, maybe it should have a better method for balancing the load).

An alternative to this would passing some value to the backend that indicates the amount of nesting the shader has. The backend would use that value to decide if it should use `Task`s to compile shaders in parallel, or if it should just compile it on the render thread (which already has an increased stack size).

Suggestions are welcome. I didn't really want to upstream that since I think not using `Task`s here is a pretty significant downside.  But as we come very close to upstreaming all the changes, and there's a general desire to tell everyone to switch to more up-to-date builds instead of using macos1 for specific games, I felt it was worth PRing it, even if just to start discussion about a better way to solve this problem.

We will need tests to ensure shader compilation is not slower on macOS with this change.

Affected games
---
This fixes a stack overflow on Mortal Kombat 11. I also opened #5290 to fix a different crash that I found while testing it. For this game, I had to increase the stack size to 2MB (on macos1, I used 1MB as that was enough for Splatoon 3).
<img width="1392" alt="Captura de Tela 2023-06-12 às 00 44 35" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/09b3d245-8e00-4d38-be58-d79ae3727ac9">
Also fixes the stack overflow crash when starting Splatoon 3.
<img width="1392" alt="Captura de Tela 2023-06-12 às 00 47 00" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/06a56fa2-5f26-45af-93ab-8e82fa34537d">
<img width="1392" alt="Captura de Tela 2023-06-12 às 00 48 15" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/d34d2124-df4e-4ed5-83be-47949b543030">
<img width="1392" alt="Captura de Tela 2023-06-12 às 00 48 46" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/dcec9e1e-bf22-4443-a356-af8d1073bf78">
Contributes to #4062, closes #5282.