### PR TITLE
Fix Arm32 double to int/uint conversion on Arm64

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitSimdHelper32Arm64.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSimdHelper32Arm64.cs
@@ -192,11 +192,10 @@ namespace ARMeilleure.Instructions
             EmitVectorTernaryOpSimd32(context, (d, n, m) => context.AddIntrinsic(inst, d, n, m));
         }
 
-        public static void EmitScalarUnaryOpSimd32(ArmEmitterContext context, Func1I scalarFunc)
+        public static void EmitScalarUnaryOpSimd32(ArmEmitterContext context, Func1I scalarFunc, bool doubleSize)
         {
             OpCode32SimdS op = (OpCode32SimdS)context.CurrOp;
 
-            bool doubleSize = (op.Size & 1) != 0;
             int shift = doubleSize ? 1 : 2;
             Operand m = GetVecA32(op.Vm >> shift);
             Operand d = GetVecA32(op.Vd >> shift);
@@ -215,8 +214,13 @@ namespace ARMeilleure.Instructions
         {
             OpCode32SimdS op = (OpCode32SimdS)context.CurrOp;
 
-            inst |= ((op.Size & 1) != 0 ? Intrinsic.Arm64VDouble : Intrinsic.Arm64VFloat) | Intrinsic.Arm64V128;
-            EmitScalarUnaryOpSimd32(context, (m) => (inst == 0) ? m : context.AddIntrinsic(inst, m));
+            EmitScalarUnaryOpF32(context, inst, (op.Size & 1) != 0);
+        }
+
+        public static void EmitScalarUnaryOpF32(ArmEmitterContext context, Intrinsic inst, bool doubleSize)
+        {
+            inst |= (doubleSize ? Intrinsic.Arm64VDouble : Intrinsic.Arm64VFloat) | Intrinsic.Arm64V128;
+            EmitScalarUnaryOpSimd32(context, (m) => (inst == 0) ? m : context.AddIntrinsic(inst, m), doubleSize);
         }
 
         public static void EmitScalarBinaryOpSimd32(ArmEmitterContext context, Func2I scalarFunc)

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -30,7 +30,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 5281; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 5292; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This fixes the implementation of the VCVT Arm32 instruction, when doing conversion from double to int or uint (32-bit) on Arm64. The problem is that it was using the Arm64 scalar conversion instructions, but Arm64 only does double to long/ulong or float to int/uint conversion. Meanwhile, Arm32 does double to int/uint and float to int/uint. To fix the issue, this uses the instruction that puts the value on a GPR instead of SIMD register, since those instructions does allow to specify the destination type as well. A similar thing was already being done for the conversion instruction that rounds towards zero.

This fixes bad audio on Prinny Presents NIS Classics Volume 3: La Pucelle: Ragnarok / Rhapsody: A Musical Adventure on Arm64 platforms.