### PR TITLE
infra: Add PR triage action

### DIFF
--- a/.github/assign/audio.yml
+++ b/.github/assign/audio.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+
+reviewers:
+  - marysaka
+
+filterLabels:
+  include:
+    - audio

--- a/.github/assign/cpu.yml
+++ b/.github/assign/cpu.yml
@@ -1,0 +1,11 @@
+addReviewers: true
+
+reviewers:
+  - gdkchan
+  - riperiperi
+  - marysaka
+  - LDj3SNuD
+
+filterLabels:
+  include:
+    - cpu

--- a/.github/assign/global.yml
+++ b/.github/assign/global.yml
@@ -1,0 +1,4 @@
+addReviewers: true
+
+reviewers:
+  - Developers

--- a/.github/assign/gpu.yml
+++ b/.github/assign/gpu.yml
@@ -1,0 +1,10 @@
+addReviewers: true
+
+reviewers:
+  - gdkchan
+  - riperiperi
+  - marysaka
+
+filterLabels:
+  include:
+    - gpu

--- a/.github/assign/gui.yml
+++ b/.github/assign/gui.yml
@@ -1,0 +1,11 @@
+addReviewers: true
+
+reviewers:
+  - Ack77
+  - emmauss
+  - TSRBerry
+  - marysaka
+
+filterLabels:
+  include:
+    - gui

--- a/.github/assign/horizon.yml
+++ b/.github/assign/horizon.yml
@@ -1,0 +1,11 @@
+addReviewers: true
+
+reviewers:
+  - gdkchan
+  - Ack77
+  - marysaka
+  - TSRBerry
+
+filterLabels:
+  include:
+    - horizon

--- a/.github/assign/infra.yml
+++ b/.github/assign/infra.yml
@@ -1,0 +1,9 @@
+addReviewers: true
+
+reviewers:
+  - marysaka
+  - TSRBerry
+
+filterLabels:
+  include:
+    - infra

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,33 @@
+audio: 'src/Ryujinx.Audio*'
+
+cpu:
+  - 'src/ARMeilleure//*'
+  - 'src/Ryujinx.Cpu/*'
+  - 'src/Ryujinx.Memory/*'
+
+gpu:
+  - 'src/Ryujinx.Graphics.*'
+  - 'src/Spv.Generator/*'
+  - 'src/Ryujinx.ShaderTools/*'
+
+'graphics-backend:opengl': 'src/Ryujinx.Graphics.OpenGL/*'
+'graphics-backend:vulkan':
+  - 'src/Ryujinx.Graphics.Vulkan/*'
+  - 'src/Spv.Generator/*'
+
+gui:
+  - 'src/Ryujinx/*'
+  - 'src/Ryujinx.Ui.Common/*'
+  - 'src/Ryujinx.Ui.LocaleGenerator/*'
+  - 'src/Ryujinx.Ava/*'
+
+horizon:
+  - 'src/Ryujinx.HLE/*'
+  - 'src/Ryujinx.Horizon*'
+
+kernel: 'src/Ryujinx.HLE/HOS/Kernel/*'
+
+infra:
+  - '.github/*'
+  - 'distribution/*'
+  - 'Directory.Packages.props'

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -1,0 +1,51 @@
+name: "Pull Request Triage"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update labels based on changes
+        uses: actions/labeler@v4
+        with:
+          sync-labels: true
+          dot: true
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/audio.yml'
+        if: github.event.action == 'opened'
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/cpu.yml'
+        if: github.event.action == 'opened'
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/gpu.yml'
+        if: github.event.action == 'opened'
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/gui.yml'
+        if: github.event.action == 'opened'
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/horizon.yml'
+        if: github.event.action == 'opened'
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/infra.yml'
+        if: github.event.action == 'opened'
+
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/assign/global.yml'
+        if: github.event.action == 'opened'


### PR DESCRIPTION
This is a bare minimal triage action that handle big categories.

Allow a big time save (aka less triage of PRs) to be more efficient.

Because kentaro-m/auto-assign-action doesn't allow to filter per label per team, I had to duplicate call of the action.

In the future we could also label all services correctly but I didn't felt this was required for a first iteration.