### PR TITLE
Ensure shader local and shared memory sizes are not zero

### DIFF
--- a/src/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/src/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -247,6 +247,17 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 {
                     block.AddPushOp(op);
                 }
+                else if (op.Name == InstName.Ldl || op.Name == InstName.Stl)
+                {
+                    config.SetUsedFeature(FeatureFlags.LocalMemory);
+                }
+                else if (op.Name == InstName.Atoms ||
+                         op.Name == InstName.AtomsCas ||
+                         op.Name == InstName.Lds ||
+                         op.Name == InstName.Sts)
+                {
+                    config.SetUsedFeature(FeatureFlags.SharedMemory);
+                }
 
                 block.OpCodes.Add(op);
 

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -27,6 +27,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Atoms(EmitterContext context)
         {
+            if (context.Config.Stage != ShaderStage.Compute)
+            {
+                context.Config.GpuAccessor.Log($"Atoms instruction is not valid on \"{context.Config.Stage}\" stage.");
+                return;
+            }
+
             InstAtoms op = context.GetOp<InstAtoms>();
 
             Operand offset = context.ShiftRightU32(GetSrcReg(context, op.SrcA), Const(2));
@@ -114,6 +120,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Lds(EmitterContext context)
         {
+            if (context.Config.Stage != ShaderStage.Compute)
+            {
+                context.Config.GpuAccessor.Log($"Lds instruction is not valid on \"{context.Config.Stage}\" stage.");
+                return;
+            }
+
             InstLds op = context.GetOp<InstLds>();
 
             EmitLoad(context, StorageKind.SharedMemory, op.LsSize, GetSrcReg(context, op.SrcA), op.Dest, Imm24ToSInt(op.Imm24));
@@ -144,6 +156,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Sts(EmitterContext context)
         {
+            if (context.Config.Stage != ShaderStage.Compute)
+            {
+                context.Config.GpuAccessor.Log($"Sts instruction is not valid on \"{context.Config.Stage}\" stage.");
+                return;
+            }
+
             InstSts op = context.GetOp<InstSts>();
 
             EmitStore(context, StorageKind.SharedMemory, op.LsSize, GetSrcReg(context, op.SrcA), op.Dest, Imm24ToSInt(op.Imm24));

--- a/src/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         RtLayer = 1 << 5,
         IaIndexing = 1 << 7,
         OaIndexing = 1 << 8,
-        FixedFuncAttr = 1 << 9
+        FixedFuncAttr = 1 << 9,
+        LocalMemory = 1 << 10,
+        SharedMemory = 1 << 11
     }
 }

--- a/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -126,9 +126,10 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public ShaderConfig(ShaderStage stage, IGpuAccessor gpuAccessor, TranslationOptions options, int localMemorySize)
         {
-            Stage       = stage;
-            GpuAccessor = gpuAccessor;
-            Options     = options;
+            Stage           = stage;
+            GpuAccessor     = gpuAccessor;
+            Options         = options;
+            LocalMemorySize = localMemorySize;
 
             _transformFeedbackDefinitions = new Dictionary<TransformFeedbackVariable, TransformFeedbackOutput>();
 
@@ -143,7 +144,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             _usedTextures = new Dictionary<TextureInfo, TextureMeta>();
             _usedImages   = new Dictionary<TextureInfo, TextureMeta>();
 
-            ResourceManager = new ResourceManager(stage, gpuAccessor, new ShaderProperties(), localMemorySize);
+            ResourceManager = new ResourceManager(stage, gpuAccessor, new ShaderProperties());
 
             if (!gpuAccessor.QueryHostSupportsTransformFeedback() && gpuAccessor.QueryTransformFeedbackEnabled())
             {
@@ -192,7 +193,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             ThreadsPerInputPrimitive = header.ThreadsPerInputPrimitive;
             OutputTopology           = header.OutputTopology;
             MaxOutputVertices        = header.MaxOutputVertexCount;
-            LocalMemorySize          = header.ShaderLocalMemoryLowSize + header.ShaderLocalMemoryHighSize + (header.ShaderLocalMemoryCrsSize / ThreadsPerWarp);
             ImapTypes                = header.ImapTypes;
             OmapTargets              = header.OmapTargets;
             OmapSampleMask           = header.OmapSampleMask;


### PR DESCRIPTION
Currently, if the local or shared memory sizes are 0, they are not declared at all, since declaring an array of size 0 is invalid (and it would not make sense to use it if the size is 0). For shaders where local memory is used but for some reason the size is 0, this will currently throw an exception and it will try to get the `MemoryDefinition` on the dictionary for memory that doesn't actually exist. To prevent those crashes, this change ensures that we will always declare local and shared memory if they are used. In the cases where it is used and size is 0, it uses a default size instead, just to ensure it is not 0.

This change also warns an early exists if an attempt is made to use shared memory instruction in anything other than a compute shader, as this memory type is only valid on compute.

Should fix the error reported at: https://github.com/Ryujinx/Ryujinx-Games-List/issues/1535#issuecomment-1594654250
I did not actually test this game, instead I simulated the size being 0 on another game that uses local memory.