### PR TITLE
MemoryManagement: Change return types for Commit/Decommit to void

### DIFF
--- a/src/ARMeilleure/Memory/IJitMemoryBlock.cs
+++ b/src/ARMeilleure/Memory/IJitMemoryBlock.cs
@@ -6,7 +6,7 @@ namespace ARMeilleure.Memory
     {
         IntPtr Pointer { get; }
 
-        bool Commit(ulong offset, ulong size);
+        void Commit(ulong offset, ulong size);
 
         void MapAsRx(ulong offset, ulong size);
         void MapAsRwx(ulong offset, ulong size);

--- a/src/Ryujinx.Cpu/Jit/JitMemoryBlock.cs
+++ b/src/Ryujinx.Cpu/Jit/JitMemoryBlock.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Cpu.Jit
             _impl = new MemoryBlock(size, flags);
         }
 
-        public bool Commit(ulong offset, ulong size) => _impl.Commit(offset, size);
+        public void Commit(ulong offset, ulong size) => _impl.Commit(offset, size);
         public void MapAsRx(ulong offset, ulong size) => _impl.Reprotect(offset, size, MemoryPermission.ReadAndExecute);
         public void MapAsRwx(ulong offset, ulong size) => _impl.Reprotect(offset, size, MemoryPermission.ReadWriteExecute);
 

--- a/src/Ryujinx.Memory/MemoryBlock.cs
+++ b/src/Ryujinx.Memory/MemoryBlock.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Ryujinx.Memory
@@ -101,12 +100,12 @@ namespace Ryujinx.Memory
         /// </summary>
         /// <param name="offset">Starting offset of the range to be committed</param>
         /// <param name="size">Size of the range to be committed</param>
-        /// <returns>True if the operation was successful, false otherwise</returns>
+        /// <exception cref="SystemException">Throw when the operation was not successful</exception>
         /// <exception cref="ObjectDisposedException">Throw when the memory block has already been disposed</exception>
         /// <exception cref="InvalidMemoryRegionException">Throw when either <paramref name="offset"/> or <paramref name="size"/> are out of range</exception>
-        public bool Commit(ulong offset, ulong size)
+        public void Commit(ulong offset, ulong size)
         {
-            return MemoryManagement.Commit(GetPointerInternal(offset, size), size, _forJit);
+            MemoryManagement.Commit(GetPointerInternal(offset, size), size, _forJit);
         }
 
         /// <summary>
@@ -115,12 +114,12 @@ namespace Ryujinx.Memory
         /// </summary>
         /// <param name="offset">Starting offset of the range to be decommitted</param>
         /// <param name="size">Size of the range to be decommitted</param>
-        /// <returns>True if the operation was successful, false otherwise</returns>
+        /// <exception cref="SystemException">Throw when the operation was not successful</exception>
         /// <exception cref="ObjectDisposedException">Throw when the memory block has already been disposed</exception>
         /// <exception cref="InvalidMemoryRegionException">Throw when either <paramref name="offset"/> or <paramref name="size"/> are out of range</exception>
-        public bool Decommit(ulong offset, ulong size)
+        public void Decommit(ulong offset, ulong size)
         {
-            return MemoryManagement.Decommit(GetPointerInternal(offset, size), size);
+            MemoryManagement.Decommit(GetPointerInternal(offset, size), size);
         }
 
         /// <summary>

--- a/src/Ryujinx.Memory/MemoryManagement.cs
+++ b/src/Ryujinx.Memory/MemoryManagement.cs
@@ -36,15 +36,15 @@ namespace Ryujinx.Memory
             }
         }
 
-        public static bool Commit(IntPtr address, ulong size, bool forJit)
+        public static void Commit(IntPtr address, ulong size, bool forJit)
         {
             if (OperatingSystem.IsWindows())
             {
-                return MemoryManagementWindows.Commit(address, (IntPtr)size);
+                MemoryManagementWindows.Commit(address, (IntPtr)size);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
-                return MemoryManagementUnix.Commit(address, size, forJit);
+                MemoryManagementUnix.Commit(address, size, forJit);
             }
             else
             {
@@ -52,15 +52,15 @@ namespace Ryujinx.Memory
             }
         }
 
-        public static bool Decommit(IntPtr address, ulong size)
+        public static void Decommit(IntPtr address, ulong size)
         {
             if (OperatingSystem.IsWindows())
             {
-                return MemoryManagementWindows.Decommit(address, (IntPtr)size);
+                MemoryManagementWindows.Decommit(address, (IntPtr)size);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
-                return MemoryManagementUnix.Decommit(address, size);
+                MemoryManagementUnix.Decommit(address, size);
             }
             else
             {

--- a/src/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/src/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Memory
             return ptr;
         }
 
-        public static bool Commit(IntPtr address, ulong size, bool forJit)
+        public static void Commit(IntPtr address, ulong size, bool forJit)
         {
             MmapProts prot = MmapProts.PROT_READ | MmapProts.PROT_WRITE;
 
@@ -81,11 +81,9 @@ namespace Ryujinx.Memory
             {
                 throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
             }
-
-            return true;
         }
 
-        public static bool Decommit(IntPtr address, ulong size)
+        public static void Decommit(IntPtr address, ulong size)
         {
             // Must be writable for madvise to work properly.
             if (mprotect(address, size, MmapProts.PROT_READ | MmapProts.PROT_WRITE) != 0)
@@ -102,8 +100,6 @@ namespace Ryujinx.Memory
             {
                 throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
             }
-
-            return true;
         }
 
         public static bool Reprotect(IntPtr address, ulong size, MemoryPermission permission)

--- a/src/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/src/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -2,8 +2,6 @@
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Text;
-
 using static Ryujinx.Memory.MemoryManagerUnixHelper;
 
 namespace Ryujinx.Memory
@@ -12,7 +10,7 @@ namespace Ryujinx.Memory
     [SupportedOSPlatform("macos")]
     static class MemoryManagementUnix
     {
-        private static readonly ConcurrentDictionary<IntPtr, ulong> _allocations = new ConcurrentDictionary<IntPtr, ulong>();
+        private static readonly ConcurrentDictionary<IntPtr, ulong> _allocations = new();
 
         public static IntPtr Allocate(ulong size, bool forJit)
         {
@@ -142,7 +140,7 @@ namespace Ryujinx.Memory
 
             if (OperatingSystem.IsMacOS())
             {
-                byte[] memName = Encoding.ASCII.GetBytes("Ryujinx-XXXXXX");
+                byte[] memName = "Ryujinx-XXXXXX"u8.ToArray();
 
                 fixed (byte* pMemName = memName)
                 {
@@ -160,7 +158,7 @@ namespace Ryujinx.Memory
             }
             else
             {
-                byte[] fileName = Encoding.ASCII.GetBytes("/dev/shm/Ryujinx-XXXXXX");
+                byte[] fileName = "/dev/shm/Ryujinx-XXXXXX"u8.ToArray();
 
                 fixed (byte* pFileName = fileName)
                 {

--- a/src/Ryujinx.Memory/MemoryManagementWindows.cs
+++ b/src/Ryujinx.Memory/MemoryManagementWindows.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Memory
     {
         public const int PageSize = 0x1000;
 
-        private static readonly PlaceholderManager _placeholders = new PlaceholderManager();
+        private static readonly PlaceholderManager _placeholders = new();
 
         public static IntPtr Allocate(IntPtr size)
         {

--- a/src/Ryujinx.Memory/MemoryManagementWindows.cs
+++ b/src/Ryujinx.Memory/MemoryManagementWindows.cs
@@ -55,14 +55,20 @@ namespace Ryujinx.Memory
             return ptr;
         }
 
-        public static bool Commit(IntPtr location, IntPtr size)
+        public static void Commit(IntPtr location, IntPtr size)
         {
-            return WindowsApi.VirtualAlloc(location, size, AllocationType.Commit, MemoryProtection.ReadWrite) != IntPtr.Zero;
+            if (WindowsApi.VirtualAlloc(location, size, AllocationType.Commit, MemoryProtection.ReadWrite) == IntPtr.Zero)
+            {
+                throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
+            }
         }
 
-        public static bool Decommit(IntPtr location, IntPtr size)
+        public static void Decommit(IntPtr location, IntPtr size)
         {
-            return WindowsApi.VirtualFree(location, size, AllocationType.Decommit);
+            if (!WindowsApi.VirtualFree(location, size, AllocationType.Decommit))
+            {
+                throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
+            }
         }
 
         public static void MapView(IntPtr sharedMemory, ulong srcOffset, IntPtr location, IntPtr size, MemoryBlock owner)


### PR DESCRIPTION
This PR makes the memory mangement behavior for `Commit()` and `Decommit()` between Unix and Windows consistent again.

This behavior has been inconsistent since I added `SystemException`s  should these methods fail to Unix only.
See: #4702

Now both implementations throw `SystemException`s and the return types were changed to `void` since we always return `true` if they don't fail.