### PR TITLE
GetHashCode should not reference mutable fields

### DIFF
--- a/src/ARMeilleure/State/V128.cs
+++ b/src/ARMeilleure/State/V128.cs
@@ -13,8 +13,8 @@ namespace ARMeilleure.State
         // _e0 & _e1 could be marked as readonly, however they are not readonly because we modify them through the Unsafe
         // APIs. This also means that one should be careful when changing the layout of this struct.
 
-        private ulong _e0;
-        private ulong _e1;
+        private readonly ulong _e0;
+        private readonly ulong _e1;
 
         /// <summary>
         /// Gets a new <see cref="V128"/> with all bits set to zero.

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/CreateId.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/CreateId.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
     [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 0x10)]
     struct CreateId : IEquatable<CreateId>
     {
-        public UInt128 Raw;
+        public readonly UInt128 Raw;
 
         public bool IsNull => Raw == UInt128.Zero;
         public bool IsValid => !IsNull && ((Raw >> 64) & 0xC0) == 0x80;

--- a/src/Ryujinx.Tests.Unicorn/SimdValue.cs
+++ b/src/Ryujinx.Tests.Unicorn/SimdValue.cs
@@ -4,8 +4,8 @@ namespace Ryujinx.Tests.Unicorn
 {
     public struct SimdValue : IEquatable<SimdValue>
     {
-        private ulong _e0;
-        private ulong _e1;
+        private readonly ulong _e0;
+        private readonly ulong _e1;
 
         public SimdValue(ulong e0, ulong e1)
         {

--- a/src/Spv.Generator/ConstantKey.cs
+++ b/src/Spv.Generator/ConstantKey.cs
@@ -5,7 +5,7 @@ namespace Spv.Generator
 {
     internal struct ConstantKey : IEquatable<ConstantKey>
     {
-        private Instruction _constant;
+        private readonly Instruction _constant;
 
         public ConstantKey(Instruction constant)
         {

--- a/src/Spv.Generator/DeterministicStringKey.cs
+++ b/src/Spv.Generator/DeterministicStringKey.cs
@@ -5,7 +5,7 @@ namespace Spv.Generator
 {
     internal class DeterministicStringKey : IEquatable<DeterministicStringKey>
     {
-        private string _value;
+        private readonly string _value;
 
         public DeterministicStringKey(string value)
         {

--- a/src/Spv.Generator/LiteralString.cs
+++ b/src/Spv.Generator/LiteralString.cs
@@ -8,7 +8,7 @@ namespace Spv.Generator
     {
         public OperandType Type => OperandType.String;
 
-        private string _value;
+        private readonly string _value;
 
         public LiteralString(string value)
         {

--- a/src/Spv.Generator/TypeDeclarationKey.cs
+++ b/src/Spv.Generator/TypeDeclarationKey.cs
@@ -5,7 +5,7 @@ namespace Spv.Generator
 {
     internal struct TypeDeclarationKey : IEquatable<TypeDeclarationKey>
     {
-        private Instruction _typeDeclaration;
+        private readonly Instruction _typeDeclaration;
 
         public TypeDeclarationKey(Instruction typeDeclaration)
         {


### PR DESCRIPTION
`GetHashCode` is used to file an object in a `Dictionary` or `Hashtable`. If `GetHashCode` uses non-`readonly` fields and those fields change after the object is stored, the object immediately becomes mis-filed in the `Hashtable`. Any subsequent test to see if the object is in the `Hashtable` will return a false negative.