### PR TITLE
"Find" method should be used instead of the "FirstOrDefault" extension

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -264,7 +264,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         private void SelectLastScannedAmiibo()
         {
-            AmiiboApi scanned = _amiiboList.FirstOrDefault(amiibo => amiibo.GetId() == LastScannedAmiiboId);
+            AmiiboApi scanned = _amiiboList.Find(amiibo => amiibo.GetId() == LastScannedAmiiboId);
 
             SeriesSelectedIndex = AmiiboSeries.IndexOf(scanned.AmiiboSeries);
             AmiiboSelectedIndex = AmiiboList.IndexOf(scanned);
@@ -325,7 +325,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             AmiiboApi selected = _amiibos[_amiiboSelectedIndex];
 
-            string imageUrl = _amiiboList.FirstOrDefault(amiibo => amiibo.Equals(selected)).Image;
+            string imageUrl = _amiiboList.Find(amiibo => amiibo.Equals(selected)).Image;
 
             string usageString = "";
 

--- a/src/Ryujinx.HLE/Loaders/Processes/Extensions/FileSystemExtensions.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/Extensions/FileSystemExtensions.cs
@@ -8,6 +8,7 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Loaders.Executables;
 using Ryujinx.Memory;
+using System;
 using System.Linq;
 using static Ryujinx.HLE.HOS.ModLoader;
 
@@ -99,7 +100,7 @@ namespace Ryujinx.HLE.Loaders.Processes.Extensions
 
                 if (string.IsNullOrWhiteSpace(programName))
                 {
-                    programName = nacpData.Value.Title.ItemsRo.ToArray().FirstOrDefault(x => x.Name[0] != 0).NameString.ToString();
+                    programName = Array.Find(nacpData.Value.Title.ItemsRo.ToArray(), x => x.Name[0] != 0).NameString.ToString();
                 }
             }
 

--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
@@ -9,6 +9,7 @@ using LibHac.Tools.FsSystem.NcaUtils;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Loaders.Executables;
 using Ryujinx.HLE.Loaders.Processes.Extensions;
+using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
@@ -176,7 +177,7 @@ namespace Ryujinx.HLE.Loaders.Processes
 
                     if (string.IsNullOrWhiteSpace(programName))
                     {
-                        programName = nacpData.Value.Title.ItemsRo.ToArray().FirstOrDefault(x => x.Name[0] != 0).NameString.ToString();
+                        programName = Array.Find(nacpData.Value.Title.ItemsRo.ToArray(), x => x.Name[0] != 0).NameString.ToString();
                     }
 
                     if (nacpData.Value.PresenceGroupId != 0)

--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -6,6 +6,7 @@ using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.HLE.Loaders.Processes.Extensions;
 using Ryujinx.Horizon.Common;
+using System;
 using System.Linq;
 
 namespace Ryujinx.HLE.Loaders.Processes
@@ -59,7 +60,7 @@ namespace Ryujinx.HLE.Loaders.Processes
 
                 if (string.IsNullOrWhiteSpace(Name))
                 {
-                    Name = ApplicationControlProperties.Title.ItemsRo.ToArray().FirstOrDefault(x => x.Name[0] != 0).NameString.ToString();
+                    Name = Array.Find(ApplicationControlProperties.Title.ItemsRo.ToArray(), x => x.Name[0] != 0).NameString.ToString();
                 }
 
                 DisplayVersion = ApplicationControlProperties.DisplayVersionString.ToString();

--- a/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.Ui.Windows
 
         private void SelectLastScannedAmiibo()
         {
-            bool isSet = _amiiboSeriesComboBox.SetActiveId(_amiiboList.FirstOrDefault(amiibo => amiibo.Head + amiibo.Tail == LastScannedAmiiboId).AmiiboSeries);
+            bool isSet = _amiiboSeriesComboBox.SetActiveId(_amiiboList.Find(amiibo => amiibo.Head + amiibo.Tail == LastScannedAmiiboId).AmiiboSeries);
             isSet = _amiiboCharsComboBox.SetActiveId(LastScannedAmiiboId);
 
             if (isSet == false)
@@ -305,7 +305,7 @@ namespace Ryujinx.Ui.Windows
 
             _amiiboImage.Pixbuf = new Gdk.Pixbuf(_amiiboLogoBytes);
 
-            string imageUrl = _amiiboList.FirstOrDefault(amiibo => amiibo.Head + amiibo.Tail == _amiiboCharsComboBox.ActiveId).Image;
+            string imageUrl = _amiiboList.Find(amiibo => amiibo.Head + amiibo.Tail == _amiiboCharsComboBox.ActiveId).Image;
 
             var usageStringBuilder = new StringBuilder();
 


### PR DESCRIPTION
Both the `List.Find` method and `IEnumerable.FirstOrDefault` method can be used to find the first element that satisfies a given condition in a collection. However, `List.Find` can be faster than `IEnumerable.FirstOrDefault` for `List` objects. For small collections, the performance difference may be minor, but for large collections, it can make a noticeable difference. The same applies for `ImmutableList` and arrays too.

Benchmark:

```cs
private List<string> data;
private Random random = new Random();

[Params(1_000)]
public int N { get; set; }

[GlobalSetup]
public void Setup() =>
    data = Enumerable.Range(0, N).Select(x => Guid.NewGuid().ToString()).ToList();

[Benchmark(Baseline = true)]
public void FirstOrDefault()
{
    for (var i = 0; i < N; i++)
    {
        var value = data[random.Next(N - 1)];
        _ = data.FirstOrDefault(x => x == value);   // Enumerable.FirstOrDefault()
    }
}

[Benchmark]
public void Find()
{
    for (var i = 0; i < N; i++)
    {
        var value = data[random.Next(N - 1)];
        _ = data.Find(x => x == value);             // List<T>.Find()
    }
}
```

Results:

<html>
<body>
<!--StartFragment-->

Method | Runtime | Mean | StdDev | Ratio | Allocated
-- | -- | -- | -- | -- | --
FirstOrDefault | .NET 7.0 | 5.373 ms | 0.1049 ms | 1.00 | 125 KB
Find | .NET 7.0 | 1.691 ms | 0.0334 ms | 0.32 | 85.94 KB
FirstOrDefault | .NET Framework 4.6.2 | 5.035 ms | 0.0421 ms | 1.00 | 125.38 KB
Find | .NET Framework 4.6.2 | 1.779 ms | 0.0107 ms | 0.35 | 86.2 KB

<!--EndFragment-->
</body>
</html>