### PR TITLE
"Exists" method should be used instead of the "Any" extension

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -512,7 +512,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if at least one of the handles is dirty</returns>
         private bool CheckDirty()
         {
-            return Handles.Any(handle => handle.Dirty);
+            return Array.Exists(Handles, handle => handle.Dirty);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -256,7 +256,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             await Task.WhenAll(_shaders.Select(shader => shader.CompileTask));
 
-            if (_shaders.Any(shader => shader.CompileStatus == ProgramLinkStatus.Failure))
+            if (Array.Exists(_shaders, shader => shader.CompileStatus == ProgramLinkStatus.Failure))
             {
                 LinkStatus = ProgramLinkStatus.Failure;
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KAddressArbiter.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KAddressArbiter.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             WakeThreads(_condVarThreads, count, TryAcquireMutex, x => x.CondVarAddress == address);
 
-            if (!_condVarThreads.Any(x => x.CondVarAddress == address))
+            if (!_condVarThreads.Exists(x => x.CondVarAddress == address))
             {
                 KernelTransfer.KernelToUser(address, 0);
             }

--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         {
             VirtualAmiiboFile virtualAmiiboFile = LoadAmiiboFile(amiiboId);
 
-            if (virtualAmiiboFile.ApplicationAreas.Any(item => item.ApplicationAreaId == applicationAreaId))
+            if (virtualAmiiboFile.ApplicationAreas.Exists(item => item.ApplicationAreaId == applicationAreaId))
             {
                 _openedApplicationAreaId = applicationAreaId;
 
@@ -124,7 +124,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         {
             VirtualAmiiboFile virtualAmiiboFile = LoadAmiiboFile(amiiboId);
 
-            if (virtualAmiiboFile.ApplicationAreas.Any(item => item.ApplicationAreaId == applicationAreaId))
+            if (virtualAmiiboFile.ApplicationAreas.Exists(item => item.ApplicationAreaId == applicationAreaId))
             {
                 return false;
             }
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         {
             VirtualAmiiboFile virtualAmiiboFile = LoadAmiiboFile(amiiboId);
 
-            if (virtualAmiiboFile.ApplicationAreas.Any(item => item.ApplicationAreaId == _openedApplicationAreaId))
+            if (virtualAmiiboFile.ApplicationAreas.Exists(item => item.ApplicationAreaId == _openedApplicationAreaId))
             {
                 for (int i = 0; i < virtualAmiiboFile.ApplicationAreas.Count; i++)
                 {


### PR DESCRIPTION
Both the `List.Exists` method and `IEnumerable.Any` method can be used to find the first element that satisfies a predicate in a collection. However, `List.Exists` can be faster than `IEnumerable.Any` for `List` objects, as well as requires significantly less memory. For small collections, the performance difference may be negligible, but for large collections, it can be noticeable. The same applies to `ImmutableList` and arrays too.

Benchmark:

```cs
private List<int> data;
private readonly Random random = new Random();

[Params(1_000)]
public int N { get; set; }

[GlobalSetup]
public void Setup() =>
    data = Enumerable.Range(0, N).Select(x => 43).ToList();

[Benchmark(Baseline = true)]
public void Any()
{
    for (var i = 0; i < N; i++)
    {
        _ = data.Any(x => x % 2 == 0);          // Enumerable.Any
    }
}

[Benchmark]
public void Exists()
{
    for (var i = 0; i < N; i++)
    {
        _ = data.Exists(x => x % 2 == 0);       // List<T>.Exists
    }
}
```

Results:

<html>
<body>
<!--StartFragment-->

Method | Runtime | Mean | StdDev | Ratio | Allocated
-- | -- | -- | -- | -- | --
Any | .NET 7.0 | 6.670 ms | 0.1413 ms | 1.00 | 40004 B
Exists | .NET 7.0 | 1.364 ms | 0.0270 ms | 0.20 | 1 B
Any | .NET Framework 4.6.2 | 5.380 ms | 0.0327 ms | 1.00 | 40128 B
Exists | .NET Framework 4.6.2 | 1.575 ms | 0.0348 ms | 0.29 | -

<!--EndFragment-->
</body>
</html>