### PR TITLE
"Where" should be used before "OrderBy"

### DIFF
--- a/src/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -140,7 +140,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             FunctionMatch.RunPass(program);
 
-            foreach (DecodedFunction function in program.OrderBy(x => x.Address).Where(x => !x.IsCompilerGenerated))
+            foreach (DecodedFunction function in program.Where(x => !x.IsCompilerGenerated).OrderBy(x => x.Address))
             {
                 program.AddFunctionAndSetId(function);
             }


### PR DESCRIPTION
Benchmark:

```cs
private IList<int> data;
private static readonly Random Random = new Random();

[Params(1_000_000)]
public int NumberOfEntries;

[GlobalSetup]
public void Setup() =>
    data = Enumerable.Range(0, NumberOfEntries).Select(x => Random.Next(0, NumberOfEntries)).ToList();

[Benchmark(Baseline = true)]
public void OrderByThenWhere() =>
    _ = data.OrderBy(x => x).Where(x => x % 2 == 0 ).ToList();  // OrderBy followed by Where

[Benchmark]
public void WhereThenOrderBy() =>
    _ = data.Where(x => x % 2 == 0 ).OrderBy(x => x).ToList();  // Where followed by OrderBy
```

Results:

<html>
<body>
<!--StartFragment-->

Method | Runtime | Mean | StdDev | Ratio
-- | -- | -- | -- | --
OrderByThenWhere | .NET 7.0 | 175.36 ms | 5.101 ms | 1.00
WhereThenOrderBy | .NET 7.0 | 85.58 ms | 1.697 ms | 0.48

<!--EndFragment-->
</body>
</html>