### PR TITLE
"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"

### DIFF
--- a/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Ast/TemplateArguments.cs
+++ b/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Ast/TemplateArguments.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Diagnostics.Demangler.Ast
 
             writer.Write(Params);
 
-            if (Params.EndsWith(">"))
+            if (Params.EndsWith('>'))
             {
                 writer.Write(" ");
             }

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                     }
 
                     // Ignore comments and empty lines
-                    if (line.StartsWith("#") || line.Trim().Length == 0)
+                    if (line.StartsWith('#') || line.Trim().Length == 0)
                     {
                         continue;
                     }


### PR DESCRIPTION
Benchmark:

```cs
private List<string> data;

[Params(1_000_000)]
public int N { get; set; }

[GlobalSetup]
public void Setup() =>
    data = Enumerable.Range(0, N).Select(_ => Guid.NewGuid().ToString()).ToList();

[Benchmark]
public void StartsWith_String()
{
    _ = data.Where(guid => guid.StartsWith("d")).ToList();
}

[Benchmark]
public void StartsWith_Char()
{
    _ = data.Where(guid => guid.StartsWith('d')).ToList();
}

[Benchmark]
public void EndsWith_String()
{
    _ = data.Where(guid => guid.EndsWith("d")).ToList();
}

[Benchmark]
public void EndsWith_Char()
{
    _ = data.Where(guid => guid.EndsWith('d')).ToList();
}
```

Results:

<html>
<body>
<!--StartFragment-->

Method | Mean | StdDev | Median
-- | -- | -- | --
StartsWith_String | 30.965 ms | 3.2732 ms | 29.932 ms
StartsWith_Char | 7.568 ms | 0.3235 ms | 7.534 ms
EndsWith_String | 30.421 ms | 5.1136 ms | 28.101 ms
EndsWith_Char | 8.067 ms | 0.7092 ms | 7.935 ms

<!--EndFragment-->
</body>
</html>