### PR TITLE
Set COMPlus_DefaultStackSize to 2M in macOS

### DIFF
--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -39,10 +39,15 @@
     <key>CSResourcesFileMapped</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>Copyright © 2018 - 2022 Ryujinx Team and Contributors.</string>
+    <string>Copyright © 2018 - 2023 Ryujinx Team and Contributors.</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
     <key>LSMinimumSystemVersion</key>
     <string>11.0</string>
+    <key>LSEnvironment</key>
+    <dict>
+        <key>COMPlus_DefaultStackSize</key>
+        <string>200000</string>
+    </dict>
 </dict>
 </plist>

--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -134,7 +134,7 @@ namespace Ryujinx.Ava
             _inputManager           = inputManager;
             _accountManager         = accountManager;
             _userChannelPersistence = userChannelPersistence;
-            _renderingThread        = new Thread(RenderLoop, 1 * 1024 * 1024) { Name = "GUI.RenderThread" };
+            _renderingThread        = new Thread(RenderLoop) { Name = "GUI.RenderThread" };
             _lastCursorMoveTime     = Stopwatch.GetTimestamp();
             _glLogLevel             = ConfigurationState.Instance.Logger.GraphicsDebugLevel;
             _topLevel               = topLevel;


### PR DESCRIPTION
Echo #5291, we can directly increase the stack size by setting the environment variable in `Ryujinx.app/Contents/Info.plist`.

Using this method, Mortal Kombat 11 still needs stack size of at least 2MB to run properly. Splatoon 3 doesn't need that much, but it's dominated by higher demand.

Update the copyright date by the way.

My environment:
OS: macOS 12.5.1
CPU: Apple M2
RAM: 24G

Some screenshop:
![截圖 2023-06-23 下午9 21 07](https://github.com/Ryujinx/Ryujinx/assets/5186176/3a76e77d-f935-432c-98c0-60f3dbdcf285)
![截圖 2023-06-23 下午4 59 12](https://github.com/Ryujinx/Ryujinx/assets/5186176/852cd55a-3ff2-49a0-a641-a1d14ac97d89)
