### PR TITLE
Non-derived "private" classes and records should be "sealed"

### DIFF
--- a/src/ARMeilleure/CodeGen/Arm64/PreAllocator.cs
+++ b/src/ARMeilleure/CodeGen/Arm64/PreAllocator.cs
@@ -10,7 +10,7 @@ namespace ARMeilleure.CodeGen.Arm64
 {
     static class PreAllocator
     {
-        private class ConstantDict
+        private sealed class ConstantDict
         {
             private readonly Dictionary<(ulong, OperandType), Operand> _constants;
 

--- a/src/ARMeilleure/CodeGen/RegisterAllocators/CopyResolver.cs
+++ b/src/ARMeilleure/CodeGen/RegisterAllocators/CopyResolver.cs
@@ -8,7 +8,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
 {
     class CopyResolver
     {
-        private class ParallelCopy
+        private sealed class ParallelCopy
         {
             private readonly struct Copy
             {

--- a/src/ARMeilleure/CodeGen/RegisterAllocators/LinearScanAllocator.cs
+++ b/src/ARMeilleure/CodeGen/RegisterAllocators/LinearScanAllocator.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
         private List<(IntrusiveList<Operation>, Operation)> _operationNodes;
         private int _operationsCount;
 
-        private class AllocationContext
+        private sealed class AllocationContext
         {
             public RegisterMasks Masks { get; }
 

--- a/src/ARMeilleure/Common/ArenaAllocator.cs
+++ b/src/ARMeilleure/Common/ArenaAllocator.cs
@@ -6,7 +6,7 @@ namespace ARMeilleure.Common
 {
     unsafe sealed class ArenaAllocator : Allocator
     {
-        private class PageInfo
+        private sealed class PageInfo
         {
             public byte* Pointer;
             public byte Unused;

--- a/src/ARMeilleure/Instructions/NativeInterface.cs
+++ b/src/ARMeilleure/Instructions/NativeInterface.cs
@@ -7,7 +7,7 @@ namespace ARMeilleure.Instructions
 {
     static class NativeInterface
     {
-        private class ThreadContext
+        private sealed class ThreadContext
         {
             public ExecutionContext Context { get; }
             public IMemoryManager Memory { get; }

--- a/src/ARMeilleure/Translation/SsaConstruction.cs
+++ b/src/ARMeilleure/Translation/SsaConstruction.cs
@@ -10,7 +10,7 @@ namespace ARMeilleure.Translation
 {
     static partial class Ssa
     {
-        private class DefMap
+        private sealed class DefMap
         {
             private readonly Dictionary<int, Operand> _map;
             private readonly BitMap _phiMasks;

--- a/src/Ryujinx.Audio/Renderer/Common/NodeStates.cs
+++ b/src/Ryujinx.Audio/Renderer/Common/NodeStates.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.Audio.Renderer.Common
 {
     public class NodeStates
     {
-        private class Stack
+        private sealed class Stack
         {
             private Memory<int> _storage;
             private int _index;

--- a/src/Ryujinx.Audio/Renderer/Dsp/AudioProcessor.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/AudioProcessor.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
             RenderEnd,
         }
 
-        private class RendererSession
+        private sealed class RendererSession
         {
             public CommandList CommandList;
             public int RenderingLimit;

--- a/src/Ryujinx.Ava/Input/AvaloniaKeyboard.cs
+++ b/src/Ryujinx.Ava/Input/AvaloniaKeyboard.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Ava.Input
         public bool                IsConnected => true;
         public GamepadFeaturesFlag Features    => GamepadFeaturesFlag.None;
 
-        private class ButtonMappingEntry
+        private sealed class ButtonMappingEntry
         {
             public readonly Key                  From;
             public readonly GamepadButtonInputId To;

--- a/src/Ryujinx.Common/Utilities/JsonHelper.cs
+++ b/src/Ryujinx.Common/Utilities/JsonHelper.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.Common.Utilities
             JsonSerializer.Serialize(stream, value, typeInfo);
         }
 
-        private class SnakeCaseNamingPolicy : JsonNamingPolicy
+        private sealed class SnakeCaseNamingPolicy : JsonNamingPolicy
         {
             public override string ConvertName(string name)
             {

--- a/src/Ryujinx.Cpu/AddressSpace.cs
+++ b/src/Ryujinx.Cpu/AddressSpace.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Cpu
             Shared,
         }
 
-        private class Mapping : IntrusiveRedBlackTreeNode<Mapping>, IComparable<Mapping>
+        private sealed class Mapping : IntrusiveRedBlackTreeNode<Mapping>, IComparable<Mapping>
         {
             public ulong Address { get; private set; }
             public ulong Size { get; private set; }
@@ -70,7 +70,7 @@ namespace Ryujinx.Cpu
             }
         }
 
-        private class PrivateMapping : IntrusiveRedBlackTreeNode<PrivateMapping>, IComparable<PrivateMapping>
+        private sealed class PrivateMapping : IntrusiveRedBlackTreeNode<PrivateMapping>, IComparable<PrivateMapping>
         {
             public ulong Address { get; private set; }
             public ulong Size { get; private set; }

--- a/src/Ryujinx.Cpu/AppleHv/HvAddressSpaceRange.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvAddressSpaceRange.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Cpu.AppleHv
         private const int PageMask = PageSize - 1;
         private const int AllLevelsMask = PageMask | (LevelMask << PageBits) | (LevelMask << (PageBits + LevelBits));
 
-        private class PtLevel
+        private sealed class PtLevel
         {
             public ulong Address => Allocation.Ipa + Allocation.Offset;
             public int EntriesCount;

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Holds shader stage buffer state and binding information.
         /// </summary>
-        private class BuffersPerStage
+        private sealed class BuffersPerStage
         {
             /// <summary>
             /// Shader buffer binding information.

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Reference type wrapping a value.
         /// </summary>
-        private class Box<T>
+        private sealed class Box<T>
         {
             /// <summary>
             /// Wrapped value.

--- a/src/Ryujinx.Graphics.Host1x/ThiDevice.cs
+++ b/src/Ryujinx.Graphics.Host1x/ThiDevice.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.Host1x
             }
         }
 
-        private class MethodCallAction : CommandAction
+        private sealed class MethodCallAction : CommandAction
         {
             public int Method { get; }
 
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Host1x
             }
         }
 
-        private class SyncptIncrAction : CommandAction
+        private sealed class SyncptIncrAction : CommandAction
         {
             public SyncptIncrAction(long contextId, uint syncptIncrHandle) : base(contextId, (int)syncptIncrHandle)
             {

--- a/src/Ryujinx.Graphics.OpenGL/Sync.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Sync.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Graphics.OpenGL
 {
     class Sync : IDisposable
     {
-        private class SyncHandle
+        private sealed class SyncHandle
         {
             public ulong ID;
             public IntPtr Handle;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
         private readonly Dictionary<int, Instruction> _funcArgs = new();
         private readonly Dictionary<int, (StructuredFunction, Instruction)> _functions = new();
 
-        private class BlockState
+        private sealed class BlockState
         {
             private int _entryCount;
             private readonly List<Instruction> _labels = new();

--- a/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/PhiNode.cs
+++ b/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/PhiNode.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
 
         private readonly HashSet<BasicBlock> _blocks;
 
-        private class PhiSource
+        private sealed class PhiSource
         {
             public BasicBlock Block { get; }
             public Operand Operand { get; set; }

--- a/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
-        private class BlockLabel
+        private sealed class BlockLabel
         {
             public readonly Operand Label;
             public BrxTarget BrxTarget;

--- a/src/Ryujinx.Graphics.Shader/Translation/FunctionMatch.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/FunctionMatch.cs
@@ -116,7 +116,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             Label,
         }
 
-        private class TreeNode
+        private sealed class TreeNode
         {
             public readonly InstOp Op;
             public readonly List<TreeNodeUse> Uses;
@@ -364,7 +364,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
-        private class PatternTreeNode<T> : IPatternTreeNode
+        private sealed class PatternTreeNode<T> : IPatternTreeNode
         {
             public List<PatternTreeNodeUse> Uses { get; }
             private readonly Func<T, bool> _match;

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             Shared,
         }
 
-        private class GtsContext
+        private sealed class GtsContext
         {
             private readonly struct Entry
             {

--- a/src/Ryujinx.Graphics.Shader/Translation/Ssa.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Ssa.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Graphics.Shader.Translation
     {
         private const int GprsAndPredsCount = RegisterConsts.GprsCount + RegisterConsts.PredsCount;
 
-        private class DefMap
+        private sealed class DefMap
         {
             private readonly Dictionary<Register, Operand> _map;
 
@@ -62,7 +62,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
-        private class LocalDefMap
+        private sealed class LocalDefMap
         {
             private readonly Operand[] _map;
             private readonly int[] _uses;

--- a/src/Ryujinx.Graphics.Vulkan/SyncManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/SyncManager.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Graphics.Vulkan
 {
     class SyncManager
     {
-        private class SyncHandle
+        private sealed class SyncHandle
         {
             public ulong ID;
             public MultiFenceHolder Waitable;

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
     {
         public const int MaxThreadSleep = 100;
 
-        private class SleepSubstepData
+        private sealed class SleepSubstepData
         {
             public readonly int SleepMilliseconds;
             public readonly int SleepCount;

--- a/src/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
     {
         public static readonly long DefaultTimeIncrementNanoseconds = ConvertGuestTicksToNanoseconds(2);
 
-        private class WaitingObject
+        private sealed class WaitingObject
         {
             public IKFutureSchedulerObject Object { get; }
             public long TimePoint { get; }

--- a/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageHeap.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageHeap.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 {
     class KPageHeap
     {
-        private class Block
+        private sealed class Block
         {
             private KPageBitmap _bitmap = new KPageBitmap();
             private ulong _heapAddress;

--- a/src/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         private KProcess _owner;
 
-        private class Image
+        private sealed class Image
         {
             public ulong BaseAddress { get; }
             public ulong Size { get; }

--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -89,7 +89,7 @@ namespace Ryujinx.HLE.HOS
         }
 
         // Title independent mods
-        private class PatchCache
+        private sealed class PatchCache
         {
             public List<Mod<DirectoryInfo>> NsoPatches { get; }
             public List<Mod<DirectoryInfo>> NroPatches { get; }

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/AddressSpaceContext.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/AddressSpaceContext.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu.Types
             }
         }
 
-        private class MappedMemory : Range
+        private sealed class MappedMemory : Range
         {
             public ulong PhysicalAddress { get; }
             public bool  VaAllocated     { get; }

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         public long RenderLayerId { get; private set; }
 
-        private class Layer
+        private sealed class Layer
         {
             public int                    ProducerBinderId;
             public IGraphicBufferProducer Producer;
@@ -51,7 +51,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             public LayerState             State;
         }
 
-        private class TextureCallbackInformation
+        private sealed class TextureCallbackInformation
         {
             public Layer      Layer;
             public BufferItem Item;

--- a/src/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
     {
         private readonly ViServiceType _serviceType;
 
-        private class DisplayState
+        private sealed class DisplayState
         {
             public int RetrievedEventsCount;
         }

--- a/src/Ryujinx.Headless.SDL2/OpenGL/OpenGLWindow.cs
+++ b/src/Ryujinx.Headless.SDL2/OpenGL/OpenGLWindow.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Headless.SDL2.OpenGL
             CheckResult(SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_STEREO, 0));
         }
 
-        private class OpenToolkitBindingsContext : IBindingsContext
+        private sealed class OpenToolkitBindingsContext : IBindingsContext
         {
             public IntPtr GetProcAddress(string procName)
             {
@@ -46,7 +46,7 @@ namespace Ryujinx.Headless.SDL2.OpenGL
             }
         }
 
-        private class SDL2OpenGLContext : IOpenGLContext
+        private sealed class SDL2OpenGLContext : IOpenGLContext
         {
             private readonly IntPtr _context;
             private readonly IntPtr _window;

--- a/src/Ryujinx.Horizon/Sdk/Sf/Cmif/ServerDomainManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Cmif/ServerDomainManager.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Cmif
 {
     class ServerDomainManager
     {
-        private class EntryManager
+        private sealed class EntryManager
         {
             public class Entry
             {
@@ -78,7 +78,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Cmif
             }
         }
 
-        private class Domain : DomainServiceObject, IDisposable
+        private sealed class Domain : DomainServiceObject, IDisposable
         {
             private readonly ServerDomainManager _manager;
             private readonly LinkedList<EntryManager.Entry> _entries;

--- a/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Input.SDL2
 {
     class SDL2Keyboard : IKeyboard
     {
-        private class ButtonMappingEntry
+        private sealed class ButtonMappingEntry
         {
             public readonly GamepadButtonInputId To;
             public readonly Key From;

--- a/src/Ryujinx.Input/Assigner/GamepadButtonAssigner.cs
+++ b/src/Ryujinx.Input/Assigner/GamepadButtonAssigner.cs
@@ -114,7 +114,7 @@ namespace Ryujinx.Input.Assigner
             }
         }
 
-        private class JoystickButtonDetector
+        private sealed class JoystickButtonDetector
         {
             private readonly Dictionary<GamepadButtonInputId, InputSummary> _stats;
 
@@ -164,7 +164,7 @@ namespace Ryujinx.Input.Assigner
             }
         }
 
-        private class InputSummary
+        private sealed class InputSummary
         {
             public float Min, Max, Sum, Avg;
 

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Input.HLE
 {
     public class NpadController : IDisposable
     {
-        private class HLEButtonMappingEntry
+        private sealed class HLEButtonMappingEntry
         {
             public readonly GamepadButtonInputId DriverInputId;
             public readonly ControllerKeys HLEInput;
@@ -51,7 +51,7 @@ namespace Ryujinx.Input.HLE
             new(GamepadButtonInputId.SingleRightTrigger1, ControllerKeys.SrRight),
         };
 
-        private class HLEKeyboardMappingEntry
+        private sealed class HLEKeyboardMappingEntry
         {
             public readonly Key TargetKey;
             public readonly byte Target;

--- a/src/Ryujinx.ShaderTools/Program.cs
+++ b/src/Ryujinx.ShaderTools/Program.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.ShaderTools
 {
     class Program
     {
-        private class GpuAccessor : IGpuAccessor
+        private sealed class GpuAccessor : IGpuAccessor
         {
             private readonly byte[] _data;
 
@@ -24,7 +24,7 @@ namespace Ryujinx.ShaderTools
             }
         }
 
-        private class Options
+        private sealed class Options
         {
             [Option("compute", Required = false, Default = false, HelpText = "Indicate that the shader is a compute shader.")]
             public bool Compute { get; set; }

--- a/src/Ryujinx/Input/GTK3/GTK3Keyboard.cs
+++ b/src/Ryujinx/Input/GTK3/GTK3Keyboard.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Input.GTK3
 {
     public class GTK3Keyboard : IKeyboard
     {
-        private class ButtonMappingEntry
+        private sealed class ButtonMappingEntry
         {
             public readonly GamepadButtonInputId To;
             public readonly Key From;


### PR DESCRIPTION
I know https://github.com/Ryujinx/Ryujinx/pull/5180 was closed because the devs core team thought the change was too large, but I think at least this small PR should be merged because classes and records with either `private` or `file` access modifiers aren’t visible outside of their assemblies or files, so if they’re not extended inside their scope, they should be made explicitly non-extensible with the addition of the `sealed` keyword.

Benchmark:

```cs
[Params(1_000_000)]
public int Iterations { get; set; }

private readonly UnsealedClass unsealedType = new UnsealedClass();
private readonly SealedClass sealedType = new SealedClass();

[Benchmark(Baseline = true)]
public void UnsealedType()
{
    for (int i = 0; i < Iterations; i++)
    {
        unsealedType.DoNothing();
    }
}

[Benchmark]
public void SealedType()
{
    for (int i = 0; i < Iterations; i++)
    {
        sealedType.DoNothing();
    }
}

private class BaseType
{
    public virtual void DoNothing() { }
}

private class UnsealedClass : BaseType
{
    public override void DoNothing() { }
}

private sealed class SealedClass : BaseType
{
    public override void DoNothing() { }
}
```

Results:

<html>
<body>
<!--StartFragment-->

Method | Runtime | Mean | StdDev | Ratio
-- | -- | -- | -- | --
UnsealedType | .NET 7.0 | 1,074.5 us | 3.15 us | 1.00
SealedType | .NET 7.0 | 216.1 us | 1.19 us | 0.20

<!--EndFragment-->
</body>
</html>