### PR TITLE
Mutable fields should not be "public static"

### DIFF
--- a/src/Ryujinx.Audio/Constants.cs
+++ b/src/Ryujinx.Audio/Constants.cs
@@ -164,7 +164,7 @@ namespace Ryujinx.Audio
         /// <summary>
         /// The default coefficients used for standard 5.1 surround to stereo downmixing.
         /// </summary>
-        public static float[] DefaultSurroundToStereoCoefficients = new float[4]
+        public static readonly float[] DefaultSurroundToStereoCoefficients = new float[4]
         {
             1.0f,
             0.707f,


### PR DESCRIPTION
`public static` mutable fields of classes which are accessed directly should be protected to the degree possible. This can be done by reducing the accessibility of the field or by changing the return type to an immutable type.