### PR TITLE
Empty "case" clauses that fall through to the "default" should be omitted

### DIFF
--- a/src/ARMeilleure/Instructions/SoftFloat.cs
+++ b/src/ARMeilleure/Instructions/SoftFloat.cs
@@ -229,6 +229,9 @@ namespace ARMeilleure.Instructions
             switch (context.Fpcr.GetRoundingMode())
             {
                 default:
+                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
+
+                case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
                     break;
@@ -412,6 +415,9 @@ namespace ARMeilleure.Instructions
             switch (context.Fpcr.GetRoundingMode())
             {
                 default:
+                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
+
+                case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
                     break;
@@ -584,6 +590,9 @@ namespace ARMeilleure.Instructions
             switch (context.Fpcr.GetRoundingMode())
             {
                 default:
+                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
+
+                case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
                     break;
@@ -1430,7 +1439,8 @@ namespace ARMeilleure.Instructions
 
                 switch (fpcr.GetRoundingMode())
                 {
-                    default:                                  overflowToInf = true;  break;
+                    default:                                  throw new ArgumentException($"Invalid rounding mode \"{fpcr.GetRoundingMode()}\".");
+                    case FPRoundingMode.ToNearest:            overflowToInf = true;  break;
                     case FPRoundingMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
                     case FPRoundingMode.TowardsMinusInfinity: overflowToInf = sign;  break;
                     case FPRoundingMode.TowardsZero:          overflowToInf = false; break;
@@ -2841,7 +2851,8 @@ namespace ARMeilleure.Instructions
 
                 switch (fpcr.GetRoundingMode())
                 {
-                    default:                                  overflowToInf = true;  break;
+                    default:                                  throw new ArgumentException($"Invalid rounding mode \"{fpcr.GetRoundingMode()}\".");
+                    case FPRoundingMode.ToNearest:            overflowToInf = true;  break;
                     case FPRoundingMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
                     case FPRoundingMode.TowardsMinusInfinity: overflowToInf = sign;  break;
                     case FPRoundingMode.TowardsZero:          overflowToInf = false; break;

--- a/src/ARMeilleure/Instructions/SoftFloat.cs
+++ b/src/ARMeilleure/Instructions/SoftFloat.cs
@@ -229,7 +229,6 @@ namespace ARMeilleure.Instructions
             switch (context.Fpcr.GetRoundingMode())
             {
                 default:
-                case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
                     break;
@@ -413,7 +412,6 @@ namespace ARMeilleure.Instructions
             switch (context.Fpcr.GetRoundingMode())
             {
                 default:
-                case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
                     break;
@@ -586,7 +584,6 @@ namespace ARMeilleure.Instructions
             switch (context.Fpcr.GetRoundingMode())
             {
                 default:
-                case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
                     break;
@@ -1433,8 +1430,7 @@ namespace ARMeilleure.Instructions
 
                 switch (fpcr.GetRoundingMode())
                 {
-                    default:
-                    case FPRoundingMode.ToNearest:            overflowToInf = true;  break;
+                    default:                                  overflowToInf = true;  break;
                     case FPRoundingMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
                     case FPRoundingMode.TowardsMinusInfinity: overflowToInf = sign;  break;
                     case FPRoundingMode.TowardsZero:          overflowToInf = false; break;
@@ -2845,8 +2841,7 @@ namespace ARMeilleure.Instructions
 
                 switch (fpcr.GetRoundingMode())
                 {
-                    default:
-                    case FPRoundingMode.ToNearest:            overflowToInf = true;  break;
+                    default:                                  overflowToInf = true;  break;
                     case FPRoundingMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
                     case FPRoundingMode.TowardsMinusInfinity: overflowToInf = sign;  break;
                     case FPRoundingMode.TowardsZero:          overflowToInf = false; break;

--- a/src/ARMeilleure/Instructions/SoftFloat.cs
+++ b/src/ARMeilleure/Instructions/SoftFloat.cs
@@ -228,9 +228,6 @@ namespace ARMeilleure.Instructions
 
             switch (context.Fpcr.GetRoundingMode())
             {
-                default:
-                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
-
                 case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
@@ -250,6 +247,9 @@ namespace ARMeilleure.Instructions
                     roundUp       = false;
                     overflowToInf = false;
                     break;
+
+                default:
+                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
             }
 
             if (roundUp)
@@ -414,9 +414,6 @@ namespace ARMeilleure.Instructions
 
             switch (context.Fpcr.GetRoundingMode())
             {
-                default:
-                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
-
                 case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
@@ -436,6 +433,9 @@ namespace ARMeilleure.Instructions
                     roundUp       = false;
                     overflowToInf = false;
                     break;
+
+                default:
+                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
             }
 
             if (roundUp)
@@ -589,9 +589,6 @@ namespace ARMeilleure.Instructions
 
             switch (context.Fpcr.GetRoundingMode())
             {
-                default:
-                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
-
                 case FPRoundingMode.ToNearest:
                     roundUp       = (error > 0.5d || (error == 0.5d && (intMant & 1u) == 1u));
                     overflowToInf = true;
@@ -611,6 +608,9 @@ namespace ARMeilleure.Instructions
                     roundUp       = false;
                     overflowToInf = false;
                     break;
+
+                default:
+                    throw new ArgumentException($"Invalid rounding mode \"{context.Fpcr.GetRoundingMode()}\".");
             }
 
             if (roundUp)
@@ -1439,11 +1439,24 @@ namespace ARMeilleure.Instructions
 
                 switch (fpcr.GetRoundingMode())
                 {
-                    default:                                  throw new ArgumentException($"Invalid rounding mode \"{fpcr.GetRoundingMode()}\".");
-                    case FPRoundingMode.ToNearest:            overflowToInf = true;  break;
-                    case FPRoundingMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
-                    case FPRoundingMode.TowardsMinusInfinity: overflowToInf = sign;  break;
-                    case FPRoundingMode.TowardsZero:          overflowToInf = false; break;
+                    case FPRoundingMode.ToNearest:
+                        overflowToInf = true;
+                        break;
+
+                    case FPRoundingMode.TowardsPlusInfinity:
+                        overflowToInf = !sign;
+                        break;
+
+                    case FPRoundingMode.TowardsMinusInfinity:
+                        overflowToInf = sign;
+                        break;
+
+                    case FPRoundingMode.TowardsZero:
+                        overflowToInf = false;
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Invalid rounding mode \"{fpcr.GetRoundingMode()}\".");
                 }
 
                 result = overflowToInf ? FPInfinity(sign) : FPMaxNormal(sign);
@@ -2851,11 +2864,24 @@ namespace ARMeilleure.Instructions
 
                 switch (fpcr.GetRoundingMode())
                 {
-                    default:                                  throw new ArgumentException($"Invalid rounding mode \"{fpcr.GetRoundingMode()}\".");
-                    case FPRoundingMode.ToNearest:            overflowToInf = true;  break;
-                    case FPRoundingMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
-                    case FPRoundingMode.TowardsMinusInfinity: overflowToInf = sign;  break;
-                    case FPRoundingMode.TowardsZero:          overflowToInf = false; break;
+                    case FPRoundingMode.ToNearest:
+                        overflowToInf = true;
+                        break;
+
+                    case FPRoundingMode.TowardsPlusInfinity:
+                        overflowToInf = !sign;
+                        break;
+
+                    case FPRoundingMode.TowardsMinusInfinity:
+                        overflowToInf = sign;
+                        break;
+
+                    case FPRoundingMode.TowardsZero:
+                        overflowToInf = false;
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Invalid rounding mode \"{fpcr.GetRoundingMode()}\".");
                 }
 
                 result = overflowToInf ? FPInfinity(sign) : FPMaxNormal(sign);


### PR DESCRIPTION
Empty `case` clauses that fall through to the default are useless. Whether or not such a `case` is present, the `default` clause will be invoked. Such `case`s simply clutter the code, and should be removed.