### PR TITLE
Prefer indexing instead of "Enumerable" methods on types implementing "IList"

### DIFF
--- a/src/Ryujinx.Ui.LocaleGenerator/LocaleGenerator.cs
+++ b/src/Ryujinx.Ui.LocaleGenerator/LocaleGenerator.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Ui.LocaleGenerator
 
             context.RegisterSourceOutput(contents, (spc, content) =>
             {
-                var lines = content.Split('\n').Where(x => x.Trim().StartsWith("\"")).Select(x => x.Split(':').First().Trim().Replace("\"", ""));
+                var lines = content.Split('\n').Where(x => x.Trim().StartsWith("\"")).Select(x => x.Split(':')[0].Trim().Replace("\"", ""));
                 string enumSource = "namespace Ryujinx.Ava.Common.Locale;\n";
                 enumSource += "internal enum LocaleKeys\n{\n";
                 foreach (var line in lines)


### PR DESCRIPTION
Benchmark:

```cs
private List<byte> data;
private Random random;

[Params(1_000_000)]
public int SampleSize;

[Params(1_000)]
public int LoopSize;

[GlobalSetup]
public void Setup()
{
    random = new Random(42);
    var bytes = new byte[SampleSize];
    random.NextBytes(bytes);
    data = bytes.ToList();
}

[Benchmark]
public void First()
{
    for (int i = 0; i < LoopSize; i++)
    {
        _ = data.First();
    }
}

[Benchmark]
public void First_Index()
{
    for (int i = 0; i < LoopSize; i++)
    {
        _ = data[0];
    }
}
```

Results:

<html>
<body>
<!--StartFragment-->

Method | Runtime | Mean | StdDev
-- | -- | -- | --
First | .NET 7.0 | 7,790.2 ns | 165.70 ns
First_Index | .NET 7.0 | 398.5 ns | 5.36 ns

<!--EndFragment-->
</body>
</html>