### PR TITLE
misc: memory: Migrate from OutOfMemoryException to SystemException entirely

### DIFF
--- a/src/Ryujinx.Cpu/AddressSpace.cs
+++ b/src/Ryujinx.Cpu/AddressSpace.cs
@@ -199,7 +199,7 @@ namespace Ryujinx.Cpu
 
                     break;
                 }
-                catch (OutOfMemoryException)
+                catch (SystemException)
                 {
                     baseMemory?.Dispose();
                     mirrorMemory?.Dispose();

--- a/src/Ryujinx.Memory/MemoryBlock.cs
+++ b/src/Ryujinx.Memory/MemoryBlock.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Memory
         /// </summary>
         /// <param name="size">Size of the memory block in bytes</param>
         /// <param name="flags">Flags that controls memory block memory allocation</param>
-        /// <exception cref="OutOfMemoryException">Throw when there's no enough memory to allocate the requested size</exception>
+        /// <exception cref="SystemException">Throw when there's an error while allocating the requested size</exception>
         /// <exception cref="PlatformNotSupportedException">Throw when the current platform is not supported</exception>
         public MemoryBlock(ulong size, MemoryAllocationFlags flags = MemoryAllocationFlags.None)
         {
@@ -66,7 +66,7 @@ namespace Ryujinx.Memory
         /// </summary>
         /// <param name="size">Size of the memory block in bytes</param>
         /// <param name="sharedMemory">Shared memory to use as backing storage for this block</param>
-        /// <exception cref="OutOfMemoryException">Throw when there's no enough address space left to map the shared memory</exception>
+        /// <exception cref="SystemException">Throw when there's an error while mapping the shared memory</exception>
         /// <exception cref="PlatformNotSupportedException">Throw when the current platform is not supported</exception>
         private MemoryBlock(ulong size, IntPtr sharedMemory)
         {
@@ -82,7 +82,7 @@ namespace Ryujinx.Memory
         /// </summary>
         /// <returns>A new memory block that shares storage with this one</returns>
         /// <exception cref="NotSupportedException">Throw when the current memory block does not support mirroring</exception>
-        /// <exception cref="OutOfMemoryException">Throw when there's no enough address space left to map the shared memory</exception>
+        /// <exception cref="SystemException">Throw when there's an error while mapping the shared memory</exception>
         /// <exception cref="PlatformNotSupportedException">Throw when the current platform is not supported</exception>
         public MemoryBlock CreateMirror()
         {

--- a/src/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/src/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -147,12 +147,12 @@ namespace Ryujinx.Memory
                     fd = shm_open((IntPtr)pMemName, 0x2 | 0x200 | 0x800 | 0x400, 384); // O_RDWR | O_CREAT | O_EXCL | O_TRUNC, 0600
                     if (fd == -1)
                     {
-                        throw new OutOfMemoryException();
+                        throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
                     }
 
                     if (shm_unlink((IntPtr)pMemName) != 0)
                     {
-                        throw new OutOfMemoryException();
+                        throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
                     }
                 }
             }
@@ -165,22 +165,22 @@ namespace Ryujinx.Memory
                     fd = mkstemp((IntPtr)pFileName);
                     if (fd == -1)
                     {
-                        throw new OutOfMemoryException();
+                        throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
                     }
 
                     if (unlink((IntPtr)pFileName) != 0)
                     {
-                        throw new OutOfMemoryException();
+                        throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
                     }
                 }
             }
 
             if (ftruncate(fd, (IntPtr)size) != 0)
             {
-                throw new OutOfMemoryException();
+                throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
             }
 
-            return (IntPtr)fd;
+            return fd;
         }
 
         public static void DestroySharedMemory(IntPtr handle)

--- a/src/Ryujinx.Memory/MemoryManagementWindows.cs
+++ b/src/Ryujinx.Memory/MemoryManagementWindows.cs
@@ -114,7 +114,7 @@ namespace Ryujinx.Memory
 
             if (handle == IntPtr.Zero)
             {
-                throw new OutOfMemoryException();
+                throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
             }
 
             return handle;
@@ -134,7 +134,7 @@ namespace Ryujinx.Memory
 
             if (ptr == IntPtr.Zero)
             {
-                throw new OutOfMemoryException();
+                throw new SystemException(Marshal.GetLastPInvokeErrorMessage());
             }
 
             return ptr;


### PR DESCRIPTION
Fix a regression with address space allocation while providing more information about the context of the exception.