### PR TITLE
Ava: Swallow keyUp and keyDown events as well

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -65,10 +65,7 @@ namespace Ryujinx.Ava
     internal class AppHost
     {
         private const int CursorHideIdleTime = 5; // Hide Cursor seconds.
-        private const float MaxResolutionScale = 4.0f; // Max resolution hotkeys can scale to before wrapping.
         private const int TargetFps = 60;
-        private const float VolumeDelta = 0.05f;
-
         private static readonly Cursor _invisibleCursor = new(StandardCursorType.None);
         private readonly IntPtr _invisibleCursorWin;
         private readonly IntPtr _defaultCursorWin;
@@ -87,8 +84,8 @@ namespace Ryujinx.Ava
         public RendererHost RendererHost;
 
         private readonly GraphicsDebugLevel _glLogLevel;
-        private float _newVolume;
-        private KeyboardHotkeyState _prevHotkeyState;
+        // private float _newVolume;
+        // private KeyboardHotkeyState _prevHotkeyState;
 
         private long _lastCursorMoveTime;
         private bool _isCursorInRenderer = true;
@@ -1042,70 +1039,70 @@ namespace Ryujinx.Ava
                     }
                 });
 
-                KeyboardHotkeyState currentHotkeyState = GetHotkeyState();
-
-                if (currentHotkeyState != _prevHotkeyState)
-                {
-                    switch (currentHotkeyState)
-                    {
-                        case KeyboardHotkeyState.ToggleVSync:
-                            Device.EnableDeviceVsync = !Device.EnableDeviceVsync;
-
-                            break;
-                        case KeyboardHotkeyState.Screenshot:
-                            ScreenshotRequested = true;
-                            break;
-                        case KeyboardHotkeyState.ShowUi:
-                            _viewModel.ShowMenuAndStatusBar = !_viewModel.ShowMenuAndStatusBar;
-                            break;
-                        case KeyboardHotkeyState.Pause:
-                            if (_viewModel.IsPaused)
-                            {
-                                Resume();
-                            }
-                            else
-                            {
-                                Pause();
-                            }
-                            break;
-                        case KeyboardHotkeyState.ToggleMute:
-                            if (Device.IsAudioMuted())
-                            {
-                                Device.SetVolume(ConfigurationState.Instance.System.AudioVolume);
-                            }
-                            else
-                            {
-                                Device.SetVolume(0);
-                            }
-
-                            _viewModel.Volume = Device.GetVolume();
-                            break;
-                        case KeyboardHotkeyState.ResScaleUp:
-                            GraphicsConfig.ResScale = GraphicsConfig.ResScale % MaxResolutionScale + 1;
-                            break;
-                        case KeyboardHotkeyState.ResScaleDown:
-                            GraphicsConfig.ResScale =
-                            (MaxResolutionScale + GraphicsConfig.ResScale - 2) % MaxResolutionScale + 1;
-                            break;
-                        case KeyboardHotkeyState.VolumeUp:
-                            _newVolume = MathF.Round((Device.GetVolume() + VolumeDelta), 2);
-                            Device.SetVolume(_newVolume);
-
-                            _viewModel.Volume = Device.GetVolume();
-                            break;
-                        case KeyboardHotkeyState.VolumeDown:
-                            _newVolume = MathF.Round((Device.GetVolume() - VolumeDelta), 2);
-                            Device.SetVolume(_newVolume);
-
-                            _viewModel.Volume = Device.GetVolume();
-                            break;
-                        case KeyboardHotkeyState.None:
-                            (_keyboardInterface as AvaloniaKeyboard).Clear();
-                            break;
-                    }
-                }
-
-                _prevHotkeyState = currentHotkeyState;
+                // KeyboardHotkeyState currentHotkeyState = GetHotkeyState();
+                //
+                // if (currentHotkeyState != _prevHotkeyState)
+                // {
+                //     switch (currentHotkeyState)
+                //     {
+                //         case KeyboardHotkeyState.ToggleVSync:
+                //             Device.EnableDeviceVsync = !Device.EnableDeviceVsync;
+                //
+                //             break;
+                //         case KeyboardHotkeyState.Screenshot:
+                //             ScreenshotRequested = true;
+                //             break;
+                //         case KeyboardHotkeyState.ShowUi:
+                //             _viewModel.ShowMenuAndStatusBar = !_viewModel.ShowMenuAndStatusBar;
+                //             break;
+                //         case KeyboardHotkeyState.Pause:
+                //             if (_viewModel.IsPaused)
+                //             {
+                //                 Resume();
+                //             }
+                //             else
+                //             {
+                //                 Pause();
+                //             }
+                //             break;
+                //         case KeyboardHotkeyState.ToggleMute:
+                //             if (Device.IsAudioMuted())
+                //             {
+                //                 Device.SetVolume(ConfigurationState.Instance.System.AudioVolume);
+                //             }
+                //             else
+                //             {
+                //                 Device.SetVolume(0);
+                //             }
+                //
+                //             _viewModel.Volume = Device.GetVolume();
+                //             break;
+                //         case KeyboardHotkeyState.ResScaleUp:
+                //             GraphicsConfig.ResScale = GraphicsConfig.ResScale % MaxResolutionScale + 1;
+                //             break;
+                //         case KeyboardHotkeyState.ResScaleDown:
+                //             GraphicsConfig.ResScale =
+                //             (MaxResolutionScale + GraphicsConfig.ResScale - 2) % MaxResolutionScale + 1;
+                //             break;
+                //         case KeyboardHotkeyState.VolumeUp:
+                //             _newVolume = MathF.Round((Device.GetVolume() + VolumeDelta), 2);
+                //             Device.SetVolume(_newVolume);
+                //
+                //             _viewModel.Volume = Device.GetVolume();
+                //             break;
+                //         case KeyboardHotkeyState.VolumeDown:
+                //             _newVolume = MathF.Round((Device.GetVolume() - VolumeDelta), 2);
+                //             Device.SetVolume(_newVolume);
+                //
+                //             _viewModel.Volume = Device.GetVolume();
+                //             break;
+                //         case KeyboardHotkeyState.None:
+                //             (_keyboardInterface as AvaloniaKeyboard).Clear();
+                //             break;
+                //     }
+                // }
+                //
+                // _prevHotkeyState = currentHotkeyState;
 
                 if (ScreenshotRequested)
                 {
@@ -1130,50 +1127,6 @@ namespace Ryujinx.Ava
             Device.Hid.DebugPad.Update();
 
             return true;
-        }
-
-        private KeyboardHotkeyState GetHotkeyState()
-        {
-            KeyboardHotkeyState state = KeyboardHotkeyState.None;
-
-            if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ToggleVsync))
-            {
-                state = KeyboardHotkeyState.ToggleVSync;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot))
-            {
-                state = KeyboardHotkeyState.Screenshot;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUi))
-            {
-                state = KeyboardHotkeyState.ShowUi;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Pause))
-            {
-                state = KeyboardHotkeyState.Pause;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ToggleMute))
-            {
-                state = KeyboardHotkeyState.ToggleMute;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ResScaleUp))
-            {
-                state = KeyboardHotkeyState.ResScaleUp;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ResScaleDown))
-            {
-                state = KeyboardHotkeyState.ResScaleDown;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.VolumeUp))
-            {
-                state = KeyboardHotkeyState.VolumeUp;
-            }
-            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.VolumeDown))
-            {
-                state = KeyboardHotkeyState.VolumeDown;
-            }
-
-            return state;
         }
     }
 }

--- a/src/Ryujinx.Ava/Input/AvaloniaKeyboardDriver.cs
+++ b/src/Ryujinx.Ava/Input/AvaloniaKeyboardDriver.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Ava.Input
 {
     internal class AvaloniaKeyboardDriver : IGamepadDriver
     {
-        private static readonly string[] _keyboardIdentifers = new string[1] { "0" };
+        private static readonly string[] _keyboardIdentifiers = { "0" };
         private readonly Control _control;
         private readonly HashSet<AvaKey> _pressedKeys;
 
@@ -21,7 +21,7 @@ namespace Ryujinx.Ava.Input
         public event EventHandler<string> TextInput;
 
         public string DriverName => "AvaloniaKeyboardDriver";
-        public ReadOnlySpan<string> GamepadsIds => _keyboardIdentifers;
+        public ReadOnlySpan<string> GamepadsIds => _keyboardIdentifiers;
 
         public AvaloniaKeyboardDriver(Control control)
         {
@@ -32,6 +32,8 @@ namespace Ryujinx.Ava.Input
             _control.KeyUp += OnKeyRelease;
             _control.TextInput += Control_TextInput;
             _control.AddHandler(InputElement.TextInputEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
+            _control.AddHandler(InputElement.KeyDownEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
+            _control.AddHandler(InputElement.KeyUpEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
         }
 
         private void Control_TextInput(object sender, TextInputEventArgs e)
@@ -39,7 +41,7 @@ namespace Ryujinx.Ava.Input
             TextInput?.Invoke(this, e.Text);
         }
 
-        private void Control_LastChanceTextInput(object sender, TextInputEventArgs e)
+        private void Control_LastChanceTextInput(object sender, RoutedEventArgs e)
         {
             // Swallow event
             e.Handled = true;
@@ -59,12 +61,12 @@ namespace Ryujinx.Ava.Input
 
         public IGamepad GetGamepad(string id)
         {
-            if (!_keyboardIdentifers[0].Equals(id))
+            if (!_keyboardIdentifiers[0].Equals(id))
             {
                 return null;
             }
 
-            return new AvaloniaKeyboard(this, _keyboardIdentifers[0], LocaleManager.Instance[LocaleKeys.AllKeyboards]);
+            return new AvaloniaKeyboard(this, _keyboardIdentifiers[0], LocaleManager.Instance[LocaleKeys.AllKeyboards]);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Ryujinx.Ava/Input/AvaloniaKeyboardDriver.cs
+++ b/src/Ryujinx.Ava/Input/AvaloniaKeyboardDriver.cs
@@ -31,9 +31,9 @@ namespace Ryujinx.Ava.Input
             _control.KeyDown += OnKeyPress;
             _control.KeyUp += OnKeyRelease;
             _control.TextInput += Control_TextInput;
-            _control.AddHandler(InputElement.TextInputEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
-            _control.AddHandler(InputElement.KeyDownEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
-            _control.AddHandler(InputElement.KeyUpEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
+            // _control.AddHandler(InputElement.TextInputEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
+            // _control.AddHandler(InputElement.KeyDownEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
+            // _control.AddHandler(InputElement.KeyUpEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
         }
 
         private void Control_TextInput(object sender, TextInputEventArgs e)

--- a/src/Ryujinx.Ava/UI/Applet/AvaloniaDynamicTextInputHandler.cs
+++ b/src/Ryujinx.Ava/UI/Applet/AvaloniaDynamicTextInputHandler.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.Ava.UI.Applet
             (_parent.InputManager.KeyboardDriver as AvaloniaKeyboardDriver).KeyRelease += AvaloniaDynamicTextInputHandler_KeyRelease;
             (_parent.InputManager.KeyboardDriver as AvaloniaKeyboardDriver).TextInput += AvaloniaDynamicTextInputHandler_TextInput;
 
-            _hiddenTextBox = _parent.HiddenTextBox;
+            // _hiddenTextBox = _parent.HiddenTextBox;
 
             Dispatcher.UIThread.Post(() =>
             {

--- a/src/Ryujinx.Ava/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Main/MainMenuBarView.axaml
@@ -59,6 +59,7 @@
                 <MenuItem
                     Command="{ReflectionBinding ToggleFullscreen}"
                     Header="{locale:Locale MenuBarOptionsToggleFullscreen}"
+                    HotKey="F11"
                     InputGesture="F11" />
                 <MenuItem>
                     <MenuItem.Icon>
@@ -98,18 +99,21 @@
                 <MenuItem
                     Click="PauseEmulation_Click"
                     Header="{locale:Locale MenuBarOptionsPauseEmulation}"
+                    HotKey="{Binding PauseKey}"
                     InputGesture="{Binding PauseKey}"
                     IsEnabled="{Binding !IsPaused}"
                     IsVisible="{Binding !IsPaused}" />
                 <MenuItem
                     Click="ResumeEmulation_Click"
                     Header="{locale:Locale MenuBarOptionsResumeEmulation}"
+                    HotKey="{Binding PauseKey}"
                     InputGesture="{Binding PauseKey}"
                     IsEnabled="{Binding IsPaused}"
                     IsVisible="{Binding IsPaused}" />
                 <MenuItem
-                    Click="StopEmulation_Click"
+                    Command="{ReflectionBinding ExitCurrentState}"
                     Header="{locale:Locale MenuBarOptionsStopEmulation}"
+                    HotKey="Escape"
                     InputGesture="Escape"
                     IsEnabled="{Binding IsGameRunning}"
                     ToolTip.Tip="{locale:Locale StopEmulationTooltip}" />
@@ -125,11 +129,13 @@
                     Command="{ReflectionBinding TakeScreenshot}"
                     Header="{locale:Locale MenuBarFileToolsTakeScreenshot}"
                     InputGesture="{Binding ScreenshotKey}"
+                    HotKey="{Binding ScreenshotKey}"
                     IsEnabled="{Binding IsGameRunning}" />
                 <MenuItem
                     Command="{ReflectionBinding HideUi}"
                     Header="{locale:Locale MenuBarFileToolsHideUi}"
                     InputGesture="{Binding ShowUiKey}"
+                    HotKey="{Binding ShowUiKey}"
                     IsEnabled="{Binding IsGameRunning}" />
                 <MenuItem
                     Click="OpenCheatManagerForCurrentApp"

--- a/src/Ryujinx.Ava/UI/Views/Main/MainStatusBarView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Main/MainStatusBarView.axaml
@@ -95,15 +95,14 @@
                 BorderBrush="Gray"
                 BorderThickness="1"
                 IsVisible="{Binding !ShowLoadProgress}" />
-            <TextBlock
+            <MenuItem
                 Name="DockedStatus"
                 Margin="5,0,5,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 IsVisible="{Binding !ShowLoadProgress}"
-                PointerReleased="DockedStatus_PointerReleased"
-                Text="{Binding DockedStatusText}"
-                TextAlignment="Left" />
+                Command="{ReflectionBinding ToggleDockMode}"
+                Header="{Binding DockedStatusText}" />
             <Border
                 Width="2"
                 Height="12"

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml
@@ -38,14 +38,14 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <helpers:OffscreenTextBox Name="HiddenTextBox" Grid.Row="0" />
-        <StackPanel Grid.Row="0" IsVisible="False">
-            <helpers:HotKeyControl Name="FullscreenHotKey" Command="{ReflectionBinding ToggleFullscreen}" />
-            <helpers:HotKeyControl Name="FullscreenHotKey2" Command="{ReflectionBinding ToggleFullscreen}" />
-            <helpers:HotKeyControl Name="FullscreenHotKeyMacOS" Command="{ReflectionBinding ToggleFullscreen}" />
-            <helpers:HotKeyControl Name="DockToggleHotKey" Command="{ReflectionBinding ToggleDockMode}" />
-            <helpers:HotKeyControl Name="ExitHotKey" Command="{ReflectionBinding ExitCurrentState}" />
-        </StackPanel>
+        <!-- <helpers:OffscreenTextBox Name="HiddenTextBox" Grid.Row="0" /> -->
+        <!-- <StackPanel Grid.Row="0" IsVisible="False"> -->
+        <!--     <helpers:HotKeyControl Name="FullscreenHotKey" Command="{ReflectionBinding ToggleFullscreen}" /> -->
+        <!--     <helpers:HotKeyControl Name="FullscreenHotKey2" Command="{ReflectionBinding ToggleFullscreen}" /> -->
+        <!--     <helpers:HotKeyControl Name="FullscreenHotKeyMacOS" Command="{ReflectionBinding ToggleFullscreen}" /> -->
+        <!--     ~1~ <helpers:HotKeyControl Name="DockToggleHotKey" Command="{ReflectionBinding ToggleDockMode}" /> @1@ -->
+        <!--     <helpers:HotKeyControl Name="ExitHotKey" Command="{ReflectionBinding ExitCurrentState}" /> -->
+        <!-- </StackPanel> -->
         <Grid
             Grid.Row="1"
             HorizontalAlignment="Stretch"

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Threading;
 using FluentAvalonia.UI.Controls;
 using Ryujinx.Ava.Common;
@@ -14,6 +13,7 @@ using Ryujinx.Graphics.Gpu;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS;
 using Ryujinx.HLE.HOS.Services.Account.Acc;
+using Ryujinx.Input.HLE;
 using Ryujinx.Input.SDL2;
 using Ryujinx.Modules;
 using Ryujinx.Ui.App.Common;
@@ -25,7 +25,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using InputManager = Ryujinx.Input.HLE.InputManager;
 
 namespace Ryujinx.Ava.UI.Windows
 {
@@ -368,7 +367,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             ApplicationList.DataContext = ViewModel;
 
-            LoadHotKeys();
+            // LoadHotKeys();
         }
 
         private void SetWindowSizePosition()
@@ -447,16 +446,16 @@ namespace Ryujinx.Ava.UI.Windows
 #pragma warning restore IDE0055
         }
 
-        public void LoadHotKeys()
-        {
-#pragma warning disable IDE0055 // Disable formatting
-            HotKeyManager.SetHotKey(FullscreenHotKey,      new KeyGesture(Key.Enter, KeyModifiers.Alt));
-            HotKeyManager.SetHotKey(FullscreenHotKey2,     new KeyGesture(Key.F11));
-            HotKeyManager.SetHotKey(FullscreenHotKeyMacOS, new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta));
-            HotKeyManager.SetHotKey(DockToggleHotKey,      new KeyGesture(Key.F9));
-            HotKeyManager.SetHotKey(ExitHotKey,            new KeyGesture(Key.Escape));
-#pragma warning restore IDE0055
-        }
+        //         public void LoadHotKeys()
+        //         {
+        // #pragma warning disable IDE0055 // Disable formatting
+        //             // HotKeyManager.SetHotKey(FullscreenHotKey,      new KeyGesture(Key.Enter, KeyModifiers.Alt));
+        //             // HotKeyManager.SetHotKey(FullscreenHotKey2,     new KeyGesture(Key.F11));
+        //             // HotKeyManager.SetHotKey(FullscreenHotKeyMacOS, new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta));
+        //             // HotKeyManager.SetHotKey(DockToggleHotKey,      new KeyGesture(Key.F9));
+        //             // HotKeyManager.SetHotKey(ExitHotKey,            new KeyGesture(Key.Escape));
+        // #pragma warning restore IDE0055
+        //         }
 
         private void VolumeStatus_CheckedChanged(object sender, SplitButtonClickEventArgs e)
         {


### PR DESCRIPTION
Today I saw someone talking about the system bell annoying them while playing with keyboard input.
#4320 fixed this before, but it seems the issue came back.

Now we swallow all keyboard related events, so the system bell can't be triggered anymore.
This shouldn't break anything else, but I couldn't verify this, since I couldn't get keyboard input to work even before I added this fix. However keyboard input still works fine on Linux after adding that fix and I can confirm the bell won't play anymore on macOS.