### PR TITLE
Classes implementing "IEquatable<T>" should be sealed

### DIFF
--- a/src/Spv.Generator/LiteralInteger.cs
+++ b/src/Spv.Generator/LiteralInteger.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Spv.Generator
 {
-    public class LiteralInteger : IOperand, IEquatable<LiteralInteger>
+    public sealed class LiteralInteger : IOperand, IEquatable<LiteralInteger>
     {
         [ThreadStatic]
         private static GeneratorPool<LiteralInteger> _pool;

--- a/src/Spv.Generator/LiteralString.cs
+++ b/src/Spv.Generator/LiteralString.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Spv.Generator
 {
-    public class LiteralString : IOperand, IEquatable<LiteralString>
+    public sealed class LiteralString : IOperand, IEquatable<LiteralString>
     {
         public OperandType Type => OperandType.String;
 


### PR DESCRIPTION
When a class implements the `IEquatable<T>` interface, it enters a contract that, in effect, states "I know how to compare two instances of type T or any type derived from T for equality.". However if that class is derived, it is very unlikely that the base class will know how to make a meaningful comparison. Therefore that implicit contract is now broken.