### PR TITLE
[Ava]: Fix Cursor States On Windows 

### DIFF
--- a/src/Ryujinx.Ava/Input/AvaloniaMouse.cs
+++ b/src/Ryujinx.Ava/Input/AvaloniaMouse.cs
@@ -16,6 +16,12 @@ namespace Ryujinx.Ava.Input
         public bool IsConnected => true;
         public GamepadFeaturesFlag Features => throw new NotImplementedException();
         public bool[] Buttons => _driver.PressedButtons;
+        public enum CursorStates
+        {
+            CursorIsHidden,
+            CursorIsVisible,
+            ForceChangeCursor
+        }
 
         public AvaloniaMouse(AvaloniaMouseDriver driver)
         {

--- a/src/Ryujinx.Ava/UI/Helpers/Win32NativeInterop.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/Win32NativeInterop.cs
@@ -29,6 +29,7 @@ namespace Ryujinx.Ava.UI.Helpers
         [SuppressMessage("Design", "CA1069: Enums values should not be duplicated")]
         public enum WindowsMessages : uint
         {
+            Setcursor = 0x0020,
             Mousemove = 0x0200,
             Lbuttondown = 0x0201,
             Lbuttonup = 0x0202,

--- a/src/Ryujinx.Ava/UI/Helpers/Win32NativeInterop.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/Win32NativeInterop.cs
@@ -29,6 +29,7 @@ namespace Ryujinx.Ava.UI.Helpers
         [SuppressMessage("Design", "CA1069: Enums values should not be duplicated")]
         public enum WindowsMessages : uint
         {
+            Cursorleave = 0x00000002,
             Setcursor = 0x0020,
             Mousemove = 0x0200,
             Lbuttondown = 0x0201,
@@ -46,10 +47,21 @@ namespace Ryujinx.Ava.UI.Helpers
             Xbuttondblclk = 0x020D,
             Mousehwheel = 0x020E,
             Mouselast = 0x020E,
+            Mouseleave = 0x02A3,
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         internal delegate IntPtr WindowProc(IntPtr hWnd, WindowsMessages msg, IntPtr wParam, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TRACKMOUSEEVENT
+        {
+            public uint cbSize;
+            public WindowsMessages dwFlags;
+            public IntPtr hwndTrack;
+            public uint dwHoverTime;
+            public static readonly TRACKMOUSEEVENT Empty;
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         public struct WndClassEx
@@ -82,6 +94,12 @@ namespace Ryujinx.Ava.UI.Helpers
         {
             return LoadCursor(IntPtr.Zero, (IntPtr)Cursors.IdcArrow);
         }
+
+        [LibraryImport("user32.dll")]
+        internal static partial IntPtr GetActiveWindow();
+
+        [LibraryImport("user32.dll")]
+        internal static partial int TrackMouseEvent(ref TRACKMOUSEEVENT lpEventTrack);
 
         [LibraryImport("user32.dll")]
         public static partial IntPtr SetCursor(IntPtr handle);

--- a/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -36,6 +36,13 @@ namespace Ryujinx.Ava.UI.Renderer
         public event EventHandler<IntPtr> WindowCreated;
         public event EventHandler<Size> SizeChanged;
 
+        [SupportedOSPlatform("windows")]
+        private readonly IntPtr InvisibleCursorWin = CreateEmptyCursor();
+        [SupportedOSPlatform("windows")]
+        private readonly IntPtr DefaultCursorWin = CreateArrowCursor();
+        [SupportedOSPlatform("windows")]
+        private bool _isCursorVisible = !ConfigurationState.Instance.Hid.EnableMouse.Value;
+
         public EmbeddedWindow()
         {
             this.GetObservable(BoundsProperty).Subscribe(StateChanged);
@@ -147,9 +154,12 @@ namespace Ryujinx.Ava.UI.Renderer
                         msg == WindowsMessages.Rbuttondown ||
                         msg == WindowsMessages.Lbuttonup ||
                         msg == WindowsMessages.Rbuttonup ||
-                        msg == WindowsMessages.Mousemove)
+                        msg == WindowsMessages.Mousemove ||
+                        msg == WindowsMessages.Setcursor)
                     {
-                        Point rootVisualPosition = this.TranslatePoint(new Point((long)lParam & 0xFFFF, (long)lParam >> 16 & 0xFFFF), VisualRoot).Value;
+                        var _x = ((long)lParam & 0xFFFF) / Program.WindowScaleFactor;
+                        var _y = ((long)lParam >> 16 & 0xFFFF) / Program.WindowScaleFactor;
+                        Point rootVisualPosition = this.TranslatePoint(new Point(_x, _y), VisualRoot).Value;
                         Pointer pointer = new(0, PointerType.Mouse, true);
 
                         switch (msg)
@@ -211,6 +221,42 @@ namespace Ryujinx.Ava.UI.Renderer
 
                                     break;
                                 }
+                            case WindowsMessages.Setcursor:
+                                {
+                                    if (ConfigurationState.Instance.Hid.EnableMouse.Value)
+                                    {
+                                        if (ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Never)
+                                        {
+                                            if (!_isCursorVisible)
+                                            {
+                                                SetCursor(DefaultCursorWin);
+                                                _isCursorVisible = true;
+                                            }
+                                        }
+                                        else if (_isCursorVisible)
+                                        {
+                                            SetCursor(InvisibleCursorWin);
+                                            _isCursorVisible = false;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Always)
+                                        {
+                                            if (_isCursorVisible)
+                                            {
+                                                SetCursor(InvisibleCursorWin);
+                                                _isCursorVisible = false;
+                                            }
+                                        }
+                                        else if (!_isCursorVisible)
+                                        {
+                                            SetCursor(DefaultCursorWin);
+                                            _isCursorVisible = true;
+                                        }
+                                    }
+                                        return 1;
+                                    }
                         }
                     }
                 }
@@ -225,7 +271,7 @@ namespace Ryujinx.Ava.UI.Renderer
                 lpfnWndProc = Marshal.GetFunctionPointerForDelegate(_wndProcDelegate),
                 style = ClassStyles.CsOwndc,
                 lpszClassName = Marshal.StringToHGlobalUni(_className),
-                hCursor = CreateArrowCursor(),
+                hCursor = DefaultCursorWin
             };
 
             RegisterClassEx(ref wndClassEx);

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -55,6 +55,8 @@ namespace Ryujinx.Ava.UI.Windows
         public static bool ShowKeyErrorOnLoad { get; set; }
         public ApplicationLibrary ApplicationLibrary { get; set; }
 
+        public readonly double StatusBarHeight;
+
         public MainWindow()
         {
             ViewModel = new MainWindowViewModel();
@@ -73,7 +75,8 @@ namespace Ryujinx.Ava.UI.Windows
             ViewModel.Title = $"Ryujinx {Program.Version}";
 
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.
-            double barHeight = MenuBar.MinHeight + StatusBarView.StatusBar.MinHeight;
+            StatusBarHeight = StatusBarView.StatusBar.MinHeight;
+            double barHeight = MenuBar.MinHeight + StatusBarHeight;
             Height = ((Height - barHeight) / Program.WindowScaleFactor) + barHeight;
             Width /= Program.WindowScaleFactor;
 


### PR DESCRIPTION
With this PR, cursor states on windows should be finally fixed for good. The main reason for the issue persisting across commits was the fact that the cursor's position updates while the game was being rendered wasn't being updated with regards to the scaling factor of the system, which led to an empty area, where the cursor's position wasn't considered within the rendering area. Also, previously the cursor, was rendered on every draw of the frame, which when we hide the cursor leads to the cursor flickering. Which has been fixed as of this PR. Also, now the cursor states take precedence when direct mouse mode is enabled, while the cursor is in "Never" hide mode and direct mouse is enabled, the cursor is not hidden and the cursor now hides in both "Always" and "On-Idle" Cursor hiding states while direct mouse mode is turned on. I felt like this was the way it was meant to be implemented, however this can be changed depending on what the reviewers feel the cursor's state should be.

Testing needs to be done to ensure that this PR, fixes the issue on systems with different configurations ( Scaling Factor ) and on ( MacOS & Linux ) to ensure their functionality hasn't been broken.

Fixes Issue: [#5136](https://github.com/Ryujinx/Ryujinx/issues/5136)
P.S This PR Supersedes [#5288](https://github.com/Ryujinx/Ryujinx/pull/5288)

My Configuration: 
* Ryzen 7 5800H
* 16GB 
* RTX 3060
* Win 11 22H2