### PR TITLE
[Ryujinx.HLE] Log when `IFileSystem.Commit()` fails due to `PathAlreadyInUse`

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
@@ -2,6 +2,7 @@ using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
 using Path = LibHac.FsSrv.Sf.Path;
+using Ryujinx.Common.Logging;
 
 namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 {
@@ -148,7 +149,15 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Commit()
         public ResultCode Commit(ServiceCtx context)
         {
-            return (ResultCode)_fileSystem.Get.Commit().Value;
+            Result result = _fileSystem.Get.Commit();
+            ResultCode resultCode = (ResultCode)result.Value;
+
+            if (result.IsFailure() && resultCode == ResultCode.PathAlreadyInUse)
+            {
+                Logger.Warning?.Print(LogClass.ServiceFs, "The filesystem resource is already in use by another process.");
+            }
+
+            return resultCode;
         }
 
         [CommandCmif(11)]


### PR DESCRIPTION
When the filesystem resource is already in use by another process, the call to `IFileSystem.Commit()` might fail with a result code of `PathAlreadyInUse`. This commit adds a warning log when this occurs to inform the user. This is because the resource might not have been released by other processes on the user's machine. The actual issue resolution will be left to the user since the root cause might wildly vary depending on what processes are running.

Related Issue: #5024

Note that this commit technically does not actually resolve the issue above. It simply helps the user with debugging purposes.

Signed-off-by: James Raphael Tiovalen <jamestiotio@gmail.com>
