### PR TITLE
Assertion arguments should be passed in the correct order

### DIFF
--- a/src/Ryujinx.Tests.Memory/MultiRegionTrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/MultiRegionTrackingTests.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.Tests.Memory
 
             int oddRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 1);
 
-            Assert.AreEqual(oddRegionCount, PageCount / 2); // Must have written to all odd pages.
+            Assert.AreEqual(PageCount / 2, oddRegionCount); // Must have written to all odd pages.
 
             // Write to all the even pages.
             RandomOrder(random, even, (i) =>
@@ -129,7 +129,7 @@ namespace Ryujinx.Tests.Memory
 
             int evenRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 0);
 
-            Assert.AreEqual(evenRegionCount, PageCount / 2);
+            Assert.AreEqual(PageCount / 2, evenRegionCount);
         }
 
         [Test]
@@ -172,7 +172,7 @@ namespace Ryujinx.Tests.Memory
                 }, 1);
             }
 
-            Assert.AreEqual(oddRegionCount, PageCount / 2); // Must have written to all odd pages.
+            Assert.AreEqual(PageCount / 2, oddRegionCount); // Must have written to all odd pages.
 
             // Write to all pages.
 
@@ -182,19 +182,19 @@ namespace Ryujinx.Tests.Memory
 
             int evenRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 0, 1);
 
-            Assert.AreEqual(evenRegionCount, PageCount / 2); // Must have written to all even pages.
+            Assert.AreEqual(PageCount / 2, evenRegionCount); // Must have written to all even pages.
 
             oddRegionCount = 0;
 
             handle.QueryModified(0, PageSize * PageCount, (address, range) => { oddRegionCount++; }, 1);
 
-            Assert.AreEqual(oddRegionCount, 0); // Sequence number has not changed, so found no dirty subregions.
+            Assert.AreEqual(0, oddRegionCount); // Sequence number has not changed, so found no dirty subregions.
 
             // With sequence number 2, all all pages should be reported as modified.
 
             oddRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 1, 2);
 
-            Assert.AreEqual(oddRegionCount, PageCount / 2); // Must have written to all odd pages.
+            Assert.AreEqual(PageCount / 2, oddRegionCount); // Must have written to all odd pages.
         }
 
         [Test]

--- a/src/Ryujinx.Tests.Memory/Tests.cs
+++ b/src/Ryujinx.Tests.Memory/Tests.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.Tests.Memory
         {
             Marshal.WriteInt32(_memoryBlock.Pointer, 0x2020, 0x1234abcd);
 
-            Assert.AreEqual(_memoryBlock.Read<int>(0x2020), 0x1234abcd);
+            Assert.AreEqual(0x1234abcd, _memoryBlock.Read<int>(0x2020));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace Ryujinx.Tests.Memory
         {
             _memoryBlock.Write(0x2040, 0xbadc0de);
 
-            Assert.AreEqual(Marshal.ReadInt32(_memoryBlock.Pointer, 0x2040), 0xbadc0de);
+            Assert.AreEqual(0xbadc0de, Marshal.ReadInt32(_memoryBlock.Pointer, 0x2040));
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace Ryujinx.Tests.Memory
             toAlias.UnmapView(backing, pageSize * 3, pageSize);
 
             toAlias.Write(0, 0xbadc0de);
-            Assert.AreEqual(Marshal.ReadInt32(backing.Pointer, (int)pageSize), 0xbadc0de);
+            Assert.AreEqual(0xbadc0de, Marshal.ReadInt32(backing.Pointer, (int)pageSize));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace Ryujinx.Tests.Memory
                     int offset = rng.Next(0, (int)pageSize - sizeof(int));
 
                     toAlias.Write((ulong)((dstPage << pageBits) + offset), 0xbadc0de);
-                    Assert.AreEqual(Marshal.ReadInt32(backing.Pointer, (srcPage << pageBits) + offset), 0xbadc0de);
+                    Assert.AreEqual(0xbadc0de, Marshal.ReadInt32(backing.Pointer, (srcPage << pageBits) + offset));
                 }
                 else
                 {

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/MemoryPoolStateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/MemoryPoolStateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(Unsafe.SizeOf<MemoryPoolState>(), 0x20);
+            Assert.AreEqual(0x20, Unsafe.SizeOf<MemoryPoolState>());
         }
 
         [Test]

--- a/src/Ryujinx.Tests/Cpu/EnvironmentTests.cs
+++ b/src/Ryujinx.Tests/Cpu/EnvironmentTests.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.Tests.Cpu
 
             // Subnormal results are not flushed to zero by default.
             // This operation should not be allowed to do constant propagation, hence the methods that explicitly disallow inlining.
-            Assert.AreNotEqual(GetDenormal() + GetZero(), 0f);
+            Assert.AreNotEqual(0f, GetDenormal() + GetZero());
 
             bool methodCalled = false;
             bool isFz = false;
@@ -83,7 +83,7 @@ namespace Ryujinx.Tests.Cpu
             int result = method(Marshal.GetFunctionPointerForDelegate(managedMethod));
 
             // Subnormal results are not flushed to zero by default, which we should have returned to exiting the method.
-            Assert.AreNotEqual(GetDenormal() + GetZero(), 0f);
+            Assert.AreNotEqual(0f, GetDenormal() + GetZero());
 
             Assert.True(result == 0);
             Assert.True(methodCalled);

--- a/src/Ryujinx.Tests/TreeDictionaryTests.cs
+++ b/src/Ryujinx.Tests/TreeDictionaryTests.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Tests.Collections
         {
             TreeDictionary<int, int> dictionary = new();
 
-            Assert.AreEqual(dictionary.Count, 0);
+            Assert.AreEqual(0, dictionary.Count);
 
             dictionary.Add(2, 7);
             dictionary.Add(1, 4);
@@ -22,28 +22,28 @@ namespace Ryujinx.Tests.Collections
             dictionary.Add(11, 2);
             dictionary.Add(5, 2);
 
-            Assert.AreEqual(dictionary.Count, 7);
+            Assert.AreEqual(7, dictionary.Count);
 
             List<KeyValuePair<int, int>> list = dictionary.AsLevelOrderList();
 
             /*
              *  Tree Should Look as Follows After Rotations
-             *  
+             *
              *        2
              *    1        4
              *           3    10
              *              5    11
-             *  
+             *
              */
 
             Assert.AreEqual(list.Count, dictionary.Count);
-            Assert.AreEqual(list[0].Key, 2);
-            Assert.AreEqual(list[1].Key, 1);
-            Assert.AreEqual(list[2].Key, 4);
-            Assert.AreEqual(list[3].Key, 3);
-            Assert.AreEqual(list[4].Key, 10);
-            Assert.AreEqual(list[5].Key, 5);
-            Assert.AreEqual(list[6].Key, 11);
+            Assert.AreEqual(2, list[0].Key);
+            Assert.AreEqual(1, list[1].Key);
+            Assert.AreEqual(4, list[2].Key);
+            Assert.AreEqual(3, list[3].Key);
+            Assert.AreEqual(10, list[4].Key);
+            Assert.AreEqual(5, list[5].Key);
+            Assert.AreEqual(11, list[6].Key);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace Ryujinx.Tests.Collections
         {
             TreeDictionary<int, int> dictionary = new();
 
-            Assert.AreEqual(dictionary.Count, 0);
+            Assert.AreEqual(0, dictionary.Count);
 
             dictionary.Add(2, 7);
             dictionary.Add(1, 4);
@@ -66,18 +66,18 @@ namespace Ryujinx.Tests.Collections
             dictionary.Add(13, 2);
             dictionary.Add(24, 2);
             dictionary.Add(6, 2);
-            Assert.AreEqual(dictionary.Count, 13);
+            Assert.AreEqual(13, dictionary.Count);
 
             List<KeyValuePair<int, int>> list = dictionary.AsLevelOrderList();
 
             /*
              *  Tree Should Look as Follows After Rotations
-             *  
+             *
              *              4
              *      2               10
              *  1      3       7         13
              *              5      9  11    24
-             *                6  8 
+             *                6  8
              */
 
             foreach (KeyValuePair<int, int> node in list)
@@ -85,19 +85,19 @@ namespace Ryujinx.Tests.Collections
                 Console.WriteLine($"{node.Key} -> {node.Value}");
             }
             Assert.AreEqual(list.Count, dictionary.Count);
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 7);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 6);
-            Assert.AreEqual(list[12].Key, 8);
+            Assert.AreEqual(4, list[0].Key);
+            Assert.AreEqual(2, list[1].Key);
+            Assert.AreEqual(10, list[2].Key);
+            Assert.AreEqual(1, list[3].Key);
+            Assert.AreEqual(3, list[4].Key);
+            Assert.AreEqual(7, list[5].Key);
+            Assert.AreEqual(13, list[6].Key);
+            Assert.AreEqual(5, list[7].Key);
+            Assert.AreEqual(9, list[8].Key);
+            Assert.AreEqual(11, list[9].Key);
+            Assert.AreEqual(24, list[10].Key);
+            Assert.AreEqual(6, list[11].Key);
+            Assert.AreEqual(8, list[12].Key);
 
             list.Clear();
 
@@ -105,12 +105,12 @@ namespace Ryujinx.Tests.Collections
 
             /*
              *  Tree Should Look as Follows After Removal
-             *  
+             *
              *              4
              *      2               10
              *  1      3       6         13
              *              5      9  11    24
-             *                  8 
+             *                  8
              */
 
             list = dictionary.AsLevelOrderList();
@@ -118,18 +118,18 @@ namespace Ryujinx.Tests.Collections
             {
                 Console.WriteLine($"{node.Key} -> {node.Value}");
             }
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 6);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 8);
+            Assert.AreEqual(4, list[0].Key);
+            Assert.AreEqual(2, list[1].Key);
+            Assert.AreEqual(10, list[2].Key);
+            Assert.AreEqual(1, list[3].Key);
+            Assert.AreEqual(3, list[4].Key);
+            Assert.AreEqual(6, list[5].Key);
+            Assert.AreEqual(13, list[6].Key);
+            Assert.AreEqual(5, list[7].Key);
+            Assert.AreEqual(9, list[8].Key);
+            Assert.AreEqual(11, list[9].Key);
+            Assert.AreEqual(24, list[10].Key);
+            Assert.AreEqual(8, list[11].Key);
 
             list.Clear();
 
@@ -138,28 +138,28 @@ namespace Ryujinx.Tests.Collections
             list = dictionary.AsLevelOrderList();
             /*
              *  Tree Should Look as Follows After Removal
-             *  
+             *
              *              4
              *      2               9
              *  1      3       6         13
              *              5      8  11    24
-             *                   
+             *
              */
             foreach (KeyValuePair<int, int> node in list)
             {
                 Console.WriteLine($"{node.Key} -> {node.Value}");
             }
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 9);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 6);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 8);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
+            Assert.AreEqual(4, list[0].Key);
+            Assert.AreEqual(2, list[1].Key);
+            Assert.AreEqual(9, list[2].Key);
+            Assert.AreEqual(1, list[3].Key);
+            Assert.AreEqual(3, list[4].Key);
+            Assert.AreEqual(6, list[5].Key);
+            Assert.AreEqual(13, list[6].Key);
+            Assert.AreEqual(5, list[7].Key);
+            Assert.AreEqual(8, list[8].Key);
+            Assert.AreEqual(11, list[9].Key);
+            Assert.AreEqual(24, list[10].Key);
         }
 
         [Test]
@@ -167,7 +167,7 @@ namespace Ryujinx.Tests.Collections
         {
             TreeDictionary<int, int> dictionary = new();
 
-            Assert.AreEqual(dictionary.Count, 0);
+            Assert.AreEqual(0, dictionary.Count);
 
             dictionary.Add(2, 7);
             dictionary.Add(1, 4);
@@ -182,7 +182,7 @@ namespace Ryujinx.Tests.Collections
             dictionary.Add(13, 2);
             dictionary.Add(24, 2);
             dictionary.Add(6, 2);
-            Assert.AreEqual(dictionary.Count, 13);
+            Assert.AreEqual(13, dictionary.Count);
 
             List<KeyValuePair<int, int>> list = dictionary.AsLevelOrderList();
 
@@ -193,52 +193,52 @@ namespace Ryujinx.Tests.Collections
 
             /*
              *  Tree Should Look as Follows After Rotations
-             *  
+             *
              *              4
              *      2               10
              *  1      3       7         13
              *              5      9  11    24
-             *                6  8 
+             *                6  8
              */
 
             Assert.AreEqual(list.Count, dictionary.Count);
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 7);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 6);
-            Assert.AreEqual(list[12].Key, 8);
+            Assert.AreEqual(4, list[0].Key);
+            Assert.AreEqual(2, list[1].Key);
+            Assert.AreEqual(10, list[2].Key);
+            Assert.AreEqual(1, list[3].Key);
+            Assert.AreEqual(3, list[4].Key);
+            Assert.AreEqual(7, list[5].Key);
+            Assert.AreEqual(13, list[6].Key);
+            Assert.AreEqual(5, list[7].Key);
+            Assert.AreEqual(9, list[8].Key);
+            Assert.AreEqual(11, list[9].Key);
+            Assert.AreEqual(24, list[10].Key);
+            Assert.AreEqual(6, list[11].Key);
+            Assert.AreEqual(8, list[12].Key);
 
-            Assert.AreEqual(list[4].Value, 2);
+            Assert.AreEqual(2, list[4].Value);
 
             dictionary.Add(3, 4);
 
             list = dictionary.AsLevelOrderList();
 
-            Assert.AreEqual(list[4].Value, 4);
+            Assert.AreEqual(4, list[4].Value);
 
 
             // Assure that none of the nodes locations have been modified.
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 7);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 6);
-            Assert.AreEqual(list[12].Key, 8);
+            Assert.AreEqual(4, list[0].Key);
+            Assert.AreEqual(2, list[1].Key);
+            Assert.AreEqual(10, list[2].Key);
+            Assert.AreEqual(1, list[3].Key);
+            Assert.AreEqual(3, list[4].Key);
+            Assert.AreEqual(7, list[5].Key);
+            Assert.AreEqual(13, list[6].Key);
+            Assert.AreEqual(5, list[7].Key);
+            Assert.AreEqual(9, list[8].Key);
+            Assert.AreEqual(11, list[9].Key);
+            Assert.AreEqual(24, list[10].Key);
+            Assert.AreEqual(6, list[11].Key);
+            Assert.AreEqual(8, list[12].Key);
         }
     }
 }


### PR DESCRIPTION
The standard assertions library methods expect the first argument to be the expected value (like a hard-coded value) and the second argument to be the actual value. Swap them and your test will still have the same outcome (succeed/fail when it should) but the error messages will be confusing.

I noticed that this pattern is already being applied in most of the tests, so this PR only aims to standardize what was out of standard.