### PR TITLE
sdl: set `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` to 0

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/ControllerInputViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ControllerInputViewModel.cs
@@ -597,8 +597,6 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
             else if (activeDevice.Type == DeviceType.Controller)
             {
-                bool isNintendoStyle = Devices.ToList().Find(x => x.Id == activeDevice.Id).Name.Contains("Nintendo");
-
                 string id = activeDevice.Id.Split(" ")[0];
 
                 config = new StandardControllerInputConfig
@@ -633,10 +631,10 @@ namespace Ryujinx.Ava.UI.ViewModels
                     },
                     RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                     {
-                        ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
-                        ButtonB = isNintendoStyle ? ConfigGamepadInputId.B : ConfigGamepadInputId.A,
-                        ButtonX = isNintendoStyle ? ConfigGamepadInputId.X : ConfigGamepadInputId.Y,
-                        ButtonY = isNintendoStyle ? ConfigGamepadInputId.Y : ConfigGamepadInputId.X,
+                        ButtonA = ConfigGamepadInputId.B,
+                        ButtonB = ConfigGamepadInputId.A,
+                        ButtonX = ConfigGamepadInputId.Y,
+                        ButtonY = ConfigGamepadInputId.X,
                         ButtonPlus = ConfigGamepadInputId.Plus,
                         ButtonR = ConfigGamepadInputId.RightShoulder,
                         ButtonZr = ConfigGamepadInputId.RightTrigger,

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -192,8 +192,6 @@ namespace Ryujinx.Headless.SDL2
                 }
                 else
                 {
-                    bool isNintendoStyle = gamepadName.Contains("Nintendo");
-
                     config = new StandardControllerInputConfig
                     {
                         Version = InputConfig.CurrentVersion,
@@ -229,10 +227,10 @@ namespace Ryujinx.Headless.SDL2
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                         {
-                            ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
-                            ButtonB = isNintendoStyle ? ConfigGamepadInputId.B : ConfigGamepadInputId.A,
-                            ButtonX = isNintendoStyle ? ConfigGamepadInputId.X : ConfigGamepadInputId.Y,
-                            ButtonY = isNintendoStyle ? ConfigGamepadInputId.Y : ConfigGamepadInputId.X,
+                            ButtonA = ConfigGamepadInputId.B,
+                            ButtonB = ConfigGamepadInputId.A,
+                            ButtonX = ConfigGamepadInputId.Y,
+                            ButtonY = ConfigGamepadInputId.X,
                             ButtonPlus = ConfigGamepadInputId.Plus,
                             ButtonR = ConfigGamepadInputId.RightShoulder,
                             ButtonZr = ConfigGamepadInputId.RightTrigger,

--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -60,6 +60,7 @@ namespace Ryujinx.SDL2.Common
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED, "0");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
+                SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
                 SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
 
 

--- a/src/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/src/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -1035,8 +1035,6 @@ namespace Ryujinx.Ui.Windows
                 }
                 else if (_inputDevice.ActiveId.StartsWith("controller"))
                 {
-                    bool isNintendoStyle = _inputDevice.ActiveText.Contains("Nintendo");
-
                     config = new StandardControllerInputConfig
                     {
                         Version = InputConfig.CurrentVersion,
@@ -1072,10 +1070,10 @@ namespace Ryujinx.Ui.Windows
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                         {
-                            ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
-                            ButtonB = isNintendoStyle ? ConfigGamepadInputId.B : ConfigGamepadInputId.A,
-                            ButtonX = isNintendoStyle ? ConfigGamepadInputId.X : ConfigGamepadInputId.Y,
-                            ButtonY = isNintendoStyle ? ConfigGamepadInputId.Y : ConfigGamepadInputId.X,
+                            ButtonA = ConfigGamepadInputId.B,
+                            ButtonB = ConfigGamepadInputId.A,
+                            ButtonX = ConfigGamepadInputId.Y,
+                            ButtonY = ConfigGamepadInputId.X,
                             ButtonPlus = ConfigGamepadInputId.Plus,
                             ButtonR = ConfigGamepadInputId.RightShoulder,
                             ButtonZr = ConfigGamepadInputId.RightTrigger,


### PR DESCRIPTION
Nintendo controllers notoriously have the A/B and X/Y buttons swapped, compared to the standard.
In order to combat this, when setting the default controller layout, Ryujinx checks whether the controller name contains "Nintendo", and swaps the mapping accordingly.
However, the reason the mapping is inverted in the first place is because SDL has `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` set to 1 by default. By setting it to 0, the mapping will be based on the buttons' position instead.
So, by doing it (and removing the `isNintendoStyle` variable), we get the following advantages:
- The mapping will be the same on all controllers, removing the need to adjust custom mappings depending on what controller is used
- Users who already set `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` to 0 globally for other games/applications (like me) won't have a wrong default mapping
- Checking whether the controller name contains "Nintendo" is ugly

Disadvantages:
- Breaks the controller configuration for existing users who are using a Nintendo controller