### PR TITLE
Revert "sdl: set `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` to 0"

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/ControllerInputViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ControllerInputViewModel.cs
@@ -597,6 +597,8 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
             else if (activeDevice.Type == DeviceType.Controller)
             {
+                bool isNintendoStyle = Devices.ToList().Find(x => x.Id == activeDevice.Id).Name.Contains("Nintendo");
+
                 string id = activeDevice.Id.Split(" ")[0];
 
                 config = new StandardControllerInputConfig
@@ -631,10 +633,10 @@ namespace Ryujinx.Ava.UI.ViewModels
                     },
                     RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                     {
-                        ButtonA = ConfigGamepadInputId.B,
-                        ButtonB = ConfigGamepadInputId.A,
-                        ButtonX = ConfigGamepadInputId.Y,
-                        ButtonY = ConfigGamepadInputId.X,
+                        ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
+                        ButtonB = isNintendoStyle ? ConfigGamepadInputId.B : ConfigGamepadInputId.A,
+                        ButtonX = isNintendoStyle ? ConfigGamepadInputId.X : ConfigGamepadInputId.Y,
+                        ButtonY = isNintendoStyle ? ConfigGamepadInputId.Y : ConfigGamepadInputId.X,
                         ButtonPlus = ConfigGamepadInputId.Plus,
                         ButtonR = ConfigGamepadInputId.RightShoulder,
                         ButtonZr = ConfigGamepadInputId.RightTrigger,

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -195,6 +195,8 @@ namespace Ryujinx.Headless.SDL2
                 }
                 else
                 {
+                    bool isNintendoStyle = gamepadName.Contains("Nintendo");
+
                     config = new StandardControllerInputConfig
                     {
                         Version = InputConfig.CurrentVersion,
@@ -230,10 +232,10 @@ namespace Ryujinx.Headless.SDL2
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                         {
-                            ButtonA = ConfigGamepadInputId.B,
-                            ButtonB = ConfigGamepadInputId.A,
-                            ButtonX = ConfigGamepadInputId.Y,
-                            ButtonY = ConfigGamepadInputId.X,
+                            ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
+                            ButtonB = isNintendoStyle ? ConfigGamepadInputId.B : ConfigGamepadInputId.A,
+                            ButtonX = isNintendoStyle ? ConfigGamepadInputId.X : ConfigGamepadInputId.Y,
+                            ButtonY = isNintendoStyle ? ConfigGamepadInputId.Y : ConfigGamepadInputId.X,
                             ButtonPlus = ConfigGamepadInputId.Plus,
                             ButtonR = ConfigGamepadInputId.RightShoulder,
                             ButtonZr = ConfigGamepadInputId.RightTrigger,

--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -60,7 +60,6 @@ namespace Ryujinx.SDL2.Common
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED, "0");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
-                SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
                 SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
 
 

--- a/src/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/src/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -1035,6 +1035,8 @@ namespace Ryujinx.Ui.Windows
                 }
                 else if (_inputDevice.ActiveId.StartsWith("controller"))
                 {
+                    bool isNintendoStyle = _inputDevice.ActiveText.Contains("Nintendo");
+
                     config = new StandardControllerInputConfig
                     {
                         Version = InputConfig.CurrentVersion,
@@ -1070,10 +1072,10 @@ namespace Ryujinx.Ui.Windows
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                         {
-                            ButtonA = ConfigGamepadInputId.B,
-                            ButtonB = ConfigGamepadInputId.A,
-                            ButtonX = ConfigGamepadInputId.Y,
-                            ButtonY = ConfigGamepadInputId.X,
+                            ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
+                            ButtonB = isNintendoStyle ? ConfigGamepadInputId.B : ConfigGamepadInputId.A,
+                            ButtonX = isNintendoStyle ? ConfigGamepadInputId.X : ConfigGamepadInputId.Y,
+                            ButtonY = isNintendoStyle ? ConfigGamepadInputId.Y : ConfigGamepadInputId.X,
                             ButtonPlus = ConfigGamepadInputId.Plus,
                             ButtonR = ConfigGamepadInputId.RightShoulder,
                             ButtonZr = ConfigGamepadInputId.RightTrigger,


### PR DESCRIPTION
Reverts Ryujinx/Ryujinx#5433

`SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` seems to not have any effects on the official HID driver.