### PR TITLE
MacOS: Allow barriers inside a render pass for non-Apple GPUs and don't treat as TBDR

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -144,9 +144,9 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 _drawCountSinceBarrier = DrawCount;
 
-                // Barriers apparently have no effect inside a render pass on MoltenVK.
+                // Barriers are not supported inside a render pass on Apple GPUs.
                 // As a workaround, end the render pass.
-                if (Gd.IsMoltenVk)
+                if (Gd.Vendor == Vendor.Apple)
                 {
                     EndRenderPass();
                 }

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -680,7 +680,8 @@ namespace Ryujinx.Graphics.Vulkan
 
             IsAmdWindows = Vendor == Vendor.Amd && OperatingSystem.IsWindows();
             IsIntelWindows = Vendor == Vendor.Intel && OperatingSystem.IsWindows();
-            IsTBDR = IsMoltenVk ||
+            IsTBDR =
+                Vendor == Vendor.Apple ||
                 Vendor == Vendor.Qualcomm ||
                 Vendor == Vendor.ARM ||
                 Vendor == Vendor.Broadcom ||


### PR DESCRIPTION
Barriers inside a render pass should only be disabled for Apple GPUs (which don't support them). [MoltenVK itself ](https://github.com/KhronosGroup/MoltenVK/pull/1540)supports them for other GPUs.

Also changed `isTBDR` to be by vendor rather than setting all GPUs using MoltenVK to `true`.