### PR TITLE
MacOS: Fix rendering on AMD GPUs

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -291,6 +291,11 @@ namespace Ryujinx.Graphics.Vulkan
                                              featuresCustomBorderColor.CustomBorderColors &&
                                              featuresCustomBorderColor.CustomBorderColorWithoutFormat;
 
+            // AMD GPUs using MoltenVK don't render correctly with the MultiViewPort feature enabled.
+            // Using it without geometry shader support may also not conform to the Vulkan spec.
+            // May be possible to re-enable on MoltenVK once geometry shader support is added.
+            bool supportsMultiView = features2.Features.MultiViewport && !IsMoltenVk;
+
             ref var properties = ref properties2.Properties;
 
             SampleCountFlags supportedSampleCounts =
@@ -315,7 +320,7 @@ namespace Ryujinx.Graphics.Vulkan
                 features2.Features.ShaderStorageImageMultisample,
                 _physicalDevice.IsDeviceExtensionPresent(ExtConditionalRendering.ExtensionName),
                 _physicalDevice.IsDeviceExtensionPresent(ExtExtendedDynamicState.ExtensionName),
-                features2.Features.MultiViewport,
+                supportsMultiView,
                 featuresRobustness2.NullDescriptor || IsMoltenVk,
                 _physicalDevice.IsDeviceExtensionPresent(KhrPushDescriptor.ExtensionName),
                 featuresPrimitiveTopologyListRestart.PrimitiveTopologyListRestart,


### PR DESCRIPTION
Fixes #3964. Doesn't fix crashes (which may or may not be related)

Although the issue only seemed to affect AMD cards on MacOS, I disable the `MultiViewPort` feature for all GPUs using MoltenVK due to discussion [here](https://github.com/KhronosGroup/MoltenVK/issues/1356) and [here](https://github.com/KhronosGroup/Vulkan-Portability/issues/23).

Master:

https://github.com/Ryujinx/Ryujinx/assets/906346/29a8e720-cca8-4573-a5f2-359958d0e3ca

PR:

https://github.com/Ryujinx/Ryujinx/assets/906346/46279d43-aaeb-43f6-8942-b4310091d212
