### PR TITLE
chore: Update Ryujinx.SDL2-CS to 2.28.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="5.0.1-build13" />
     <PackageVersion Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Version="1.2.0" />
     <PackageVersion Include="Ryujinx.GtkSharp" Version="3.24.24.59-ryujinx" />
-    <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.26.3-build25" />
+    <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.28.1-build28" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />


### PR DESCRIPTION
Not based on stable 2.28.1 but https://github.com/Ryujinx/SDL/commit/cb4b41ddf79a8886f1dabf56fce1da2fde97cd40.

Supersead #5450.