### PR TITLE
Ava UI: Remove `IsActive` checks from dialog methods

### DIFF
--- a/src/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
+++ b/src/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
@@ -53,8 +53,6 @@ namespace Ryujinx.Ava.UI.Applet
 
                     bool opened = false;
 
-                    _parent.Activate();
-
                     UserResult response = await ContentDialogHelper.ShowDeferredContentDialog(_parent,
                        title,
                        message,

--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -371,7 +371,9 @@ namespace Ryujinx.Ava.UI.Helpers
                 }
                 else
                 {
-                    result = await contentDialog.ShowAsync();
+                    result = ContentDialogResult.None;
+
+                    Logger.Warning?.Print(LogClass.Ui, "Content dialog overlay failed to populate. Default value has been returned.");
                 }
 
                 return result;

--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -315,8 +315,10 @@ namespace Ryujinx.Ava.UI.Helpers
 
             Window parent = GetMainWindow();
 
-            if (parent is { IsActive: true } and MainWindow window && window.ViewModel.IsGameRunning)
+            if (parent is MainWindow window && window.ViewModel.IsGameRunning)
             {
+                parent.Activate();
+
                 contentDialogOverlayWindow = new()
                 {
                     Height = parent.Bounds.Height,
@@ -390,7 +392,7 @@ namespace Ryujinx.Ava.UI.Helpers
             {
                 foreach (Window item in al.Windows)
                 {
-                    if (item.IsActive && item is MainWindow window)
+                    if (item is MainWindow window)
                     {
                         return window;
                     }


### PR DESCRIPTION
There is no guarantee that the main window, or any window for that matter will be focused and this should not impact the ability to spawn content dialogs. Should resolve people getting "softlocked" on macOS and Linux when the window is not active and a software keyboard is triggered.

Fixes #5186

