### PR TITLE
[CPU] Hotfix missing ToNearest rounding mode cases

### DIFF
--- a/src/ARMeilleure/Instructions/SoftFloat.cs
+++ b/src/ARMeilleure/Instructions/SoftFloat.cs
@@ -1448,6 +1448,7 @@ namespace ARMeilleure.Instructions
             {
                 var overflowToInf = fpcr.GetRoundingMode() switch
                 {
+                    FPRoundingMode.ToNearest => true,
                     FPRoundingMode.TowardsPlusInfinity => !sign,
                     FPRoundingMode.TowardsMinusInfinity => sign,
                     FPRoundingMode.TowardsZero => false,
@@ -2879,6 +2880,7 @@ namespace ARMeilleure.Instructions
             {
                 var overflowToInf = fpcr.GetRoundingMode() switch
                 {
+                    FPRoundingMode.ToNearest => true,
                     FPRoundingMode.TowardsPlusInfinity => !sign,
                     FPRoundingMode.TowardsMinusInfinity => sign,
                     FPRoundingMode.TowardsZero => false,


### PR DESCRIPTION
This PR fixes a regression from #5357 which led to some failing tests.