### PR TITLE
[Hotfix] sockets: Resolve empty port requests to 0 again

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -586,7 +586,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
             if (hostEntry != null)
             {
-                if (int.TryParse(service, out int port))
+                if (int.TryParse(service, out int port) || string.IsNullOrEmpty(service))
                 {
                     errno = GaiError.Success;
                     serializedSize = SerializeAddrInfos(context, responseBufferPosition, responseBufferSize, hostEntry, port);


### PR DESCRIPTION
This PR fixes a regression from #5380 which was found by @demize.

`GetAddrInfoRequest()` can be called with an empty `service` parameter, which means that the requester doesn't care about the port. The logic introduced by #5380 didn't handle this case properly and would instead return `GaiError.Service`.

The fix here is to add another condition to the if-statement so empty strings aren't causing errors, because we still want to handle those properly.