### PR TITLE
Add slightly better workaround for current workflow issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,11 @@ jobs:
         run: dotnet build -c "${{ matrix.configuration }}" -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER
 
       - name: Test
-        run: dotnet test --no-build -c "${{ matrix.configuration }}"
+        uses: TSRBerry/unstable-commands@v1
+        with:
+          commands: dotnet test --no-build -c "${{ matrix.configuration }}"
+          timeout-minutes: 10
+          retry-codes: 139
 
       - name: Publish Ryujinx
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx --self-contained true

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,30 +43,20 @@ jobs:
       # For some unknown reason this step sometimes fails with exit code 139 (segfault?),
       # so in that case we'll try again (3 tries max).
       - name: Run dotnet format style
-        run: |
-          attempt=0
-          exit_code=139
-          until [ $attempt -ge 3 ] || [ $exit_code -ne 139 ]; do
-            ((attempt+=1))
-            exit_code=0
-            echo "Attempt: ${attempt}/3"
-           dotnet format style --severity info --verify-no-changes --report ./style-report.json -v d || exit_code=$?
-          done
-          exit $exit_code
+        uses: TSRBerry/unstable-commands@v1
+        with:
+          commands: dotnet format style --severity info --verify-no-changes --report ./style-report.json -v d
+          timeout-minutes: 5
+          retry-codes: 139
 
       # For some unknown reason this step sometimes fails with exit code 139 (segfault?),
       # so in that case we'll try again (3 tries max).
       - name: Run dotnet format analyzers
-        run: |
-          attempt=0
-          exit_code=139
-          until [ $attempt -ge 3 ] || [ $exit_code -ne 139 ]; do
-            ((attempt+=1))
-            exit_code=0
-            echo "Attempt: ${attempt}/3"
-            dotnet format analyzers --severity info --verify-no-changes --report ./analyzers-report.json -v d || exit_code=$?
-          done
-          exit $exit_code
+        uses: TSRBerry/unstable-commands@v1
+        with:
+          commands: dotnet format analyzers --severity info --verify-no-changes --report ./analyzers-report.json -v d
+          timeout-minutes: 5
+          retry-codes: 139
 
       - name: Upload report
         if: failure()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,12 +40,22 @@ jobs:
         run: |
           dotnet format whitespace --verify-no-changes --report ./whitespace-report.json -v d
 
+      # For some unknown reason this step sometimes fails with exit code 139 (segfault?),
+      # so in that case we'll try again (3 tries max).
       - name: Run dotnet format style
         run: |
-          dotnet format style --severity info --verify-no-changes --report ./style-report.json -v d
+          attempt=0
+          exit_code=139
+          until [ $attempt -ge 3 ] || [ $exit_code -ne 139 ]; do
+            ((attempt+=1))
+            exit_code=0
+            echo "Attempt: ${attempt}/3"
+           dotnet format style --severity info --verify-no-changes --report ./style-report.json -v d || exit_code=$?
+          done
+          exit $exit_code
 
-      # For some reason this step sometimes fails with exit code 139 (segfault?),
-      # so should that be the case we'll try again (3 tries max).
+      # For some unknown reason this step sometimes fails with exit code 139 (segfault?),
+      # so in that case we'll try again (3 tries max).
       - name: Run dotnet format analyzers
         run: |
           attempt=0


### PR DESCRIPTION
This PR attempts to improve our current workflow issues by adding a slightly better workaround using my [unstable-commands](https://github.com/marketplace/actions/unstable-commands) action which I published yesterday.

I made this action primarily because we keep having issues with workflows that are either timing out or crashing for unknown reasons. Since we have trouble even replicating these issues on our own runners or local machines, the best thing we can do right now is to improve how we deal with them inside the workflows.

My action will retry the specified command if it runs into the timeout or one of the specified retry-codes was encountered. By default this action will only retry the command(s) up to 3 times before it gives up, we can of course adjust that if we think that could help.

In PR #4673 @gdkchan noticed that `dotnet format style` also segfaults sometimes, so I added my action to that command as well. I didn't add it to the whitespace step, since I don't think it could ever segfault.