### PR TITLE
Ava UI: Remove all remaining uses of `ReflectionBinding`

### DIFF
--- a/src/Ryujinx.Ava/Common/Locale/LocaleExtension.cs
+++ b/src/Ryujinx.Ava/Common/Locale/LocaleExtension.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia.Data;
 using Avalonia.Markup.Xaml;
-using Avalonia.Markup.Xaml.MarkupExtensions;
 using System;
 
 namespace Ryujinx.Ava.Common.Locale
@@ -18,13 +17,13 @@ namespace Ryujinx.Ava.Common.Locale
         {
             LocaleKeys keyToUse = Key;
 
-            ReflectionBindingExtension binding = new($"[{keyToUse}]")
+            Binding binding = new($"[{keyToUse}]")
             {
                 Mode = BindingMode.OneWay,
                 Source = LocaleManager.Instance,
             };
 
-            return binding.ProvideValue(serviceProvider);
+            return binding;
         }
     }
 }


### PR DESCRIPTION
Depends on #4362

**TODO:**
- [ ] `ErrorAppletWindow`, `SwkbdAppletDialog`
- [ ] `CheatWindow`
- [ ] `RumbleSettingsWindow`, `MotionSettingsWindow`, `ControllerSettingsWindow` (see #4998)
- [ ] `ApplicationGridView`, `ApplicationListView`
- [ ] `LocaleExtension`