### PR TITLE
Allow access to code memory for exefs mods

### DIFF
--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 5502; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 5518; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/src/ARMeilleure/Translation/PTC/PtcFormatter.cs
+++ b/src/ARMeilleure/Translation/PTC/PtcFormatter.cs
@@ -28,6 +28,26 @@ namespace ARMeilleure.Translation.PTC
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Dictionary<TKey, TValue> DeserializeAndUpdateDictionary<TKey, TValue>(Stream stream, Func<Stream, TValue> valueFunc, Func<TKey, TValue, (TKey, TValue)> updateFunc) where TKey : struct
+        {
+            Dictionary<TKey, TValue> dictionary = new();
+
+            int count = DeserializeStructure<int>(stream);
+
+            for (int i = 0; i < count; i++)
+            {
+                TKey key = DeserializeStructure<TKey>(stream);
+                TValue value = valueFunc(stream);
+
+                (key, value) = updateFunc(key, value);
+
+                dictionary.Add(key, value);
+            }
+
+            return dictionary;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static List<T> DeserializeList<T>(Stream stream) where T : struct
         {
             List<T> list = new();

--- a/src/Ryujinx.HLE/Loaders/Processes/Extensions/FileSystemExtensions.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/Extensions/FileSystemExtensions.cs
@@ -89,10 +89,6 @@ namespace Ryujinx.HLE.Loaders.Processes.Extensions
                 Logger.Warning?.Print(LogClass.Ptc, "Detected unsupported ExeFs modifications. PTC disabled.");
             }
 
-            // We allow it for nx-hbloader because it can be used to launch homebrew.
-            // We also allow it for exefs mods, since they might want to make use of that as well.
-            bool allowCodeMemoryForJit = programId == 0x010000000000100DUL || isHomebrew || modLoadResult.Modified;
-
             string programName = "";
 
             if (!isHomebrew && programId > 0x010000000000FFFF)
@@ -120,7 +116,7 @@ namespace Ryujinx.HLE.Loaders.Processes.Extensions
                 metaLoader,
                 nacpData,
                 enablePtc,
-                allowCodeMemoryForJit,
+                true,
                 programName,
                 metaLoader.GetProgramId(),
                 null,

--- a/src/Ryujinx.HLE/Loaders/Processes/Extensions/FileSystemExtensions.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/Extensions/FileSystemExtensions.cs
@@ -90,7 +90,8 @@ namespace Ryujinx.HLE.Loaders.Processes.Extensions
             }
 
             // We allow it for nx-hbloader because it can be used to launch homebrew.
-            bool allowCodeMemoryForJit = programId == 0x010000000000100DUL || isHomebrew;
+            // We also allow it for exefs mods, since they might want to make use of that as well.
+            bool allowCodeMemoryForJit = programId == 0x010000000000100DUL || isHomebrew || modLoadResult.Modified;
 
             string programName = "";
 

--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
@@ -28,6 +28,11 @@ namespace Ryujinx.HLE.Loaders.Processes
 {
     static class ProcessLoaderHelper
     {
+        // NOTE: If you want to change this value make sure to increment the InternalVersion of Ptc and PtcProfiler.
+        //       You also need to add a new migration path and adjust the existing ones.
+        // TODO: Remove this workaround when ASLR is implemented.
+        private const ulong CodeStartOffset = 0x500000UL;
+
         public static LibHac.Result RegisterProgramMapInfo(Switch device, PartitionFileSystem partitionFileSystem)
         {
             ulong applicationId = 0;
@@ -242,7 +247,7 @@ namespace Ryujinx.HLE.Loaders.Processes
 
             ulong argsStart = 0;
             uint argsSize = 0;
-            ulong codeStart = (meta.Flags & 1) != 0 ? 0x8000000UL : 0x200000UL;
+            ulong codeStart = ((meta.Flags & 1) != 0 ? 0x8000000UL : 0x200000UL) + CodeStartOffset;
             uint codeSize = 0;
 
             var buildIds = executables.Select(e => (e switch


### PR DESCRIPTION
This PR fixes an issue where games would crash if mods utilizing JIT (most notably [exlaunch](https://github.com/shadowninja108/exlaunch)) were used.

More context can be found at the linked issue.

---

Fixes #5466 