### PR TITLE
Fix PR build concurrency and stop auto assigning reviewers for draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,6 @@ name: Build job
 on:
   workflow_call:
 
-concurrency:
-  group: pr-builds-${{ github.event.number }}
-  cancel-in-progress: true
-
 env:
   POWERSHELL_TELEMETRY_OPTOUT: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -28,6 +28,7 @@ jobs:
           dot: true
 
       - name: Assign reviewers
+        if: ! github.event.pull_request.draft
         run: |
           pip3 install PyGithub
           python3 .github/update_reviewers.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.event.pull_request.number }} .github/reviewers.yml


### PR DESCRIPTION
@IsaacMarovitz noticed that some jobs for his PRs were cancelled even though he didn't push new commits.
This PR fixes this by removing the concurrency properties from the build workflow, since we only need them in the checks workflow anyway.

As far as I understood the [docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview) about reusing workflows, I was sure the `github` context would be passed to the called workflow as well. Sadly this doesn't seem to be the case, which means instead of playing it safe (like I thought I did) I essentially only allowed one PR at a time to run the build workflow.

Aside from that I quickly added a condition to the pr_triage workflow, so it doesn't assign reviewers to PRs that are marked as draft anymore.