### PR TITLE
GPU: Enable VK_EXT_4444_formats

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -42,6 +42,7 @@ namespace Ryujinx.Graphics.Vulkan
             "VK_NV_viewport_array2",
             "VK_EXT_depth_clip_control",
             "VK_KHR_portability_subset", // As per spec, we should enable this if present.
+            "VK_EXT_4444_formats",
         };
 
         private static readonly string[] _requiredExtensions = {


### PR DESCRIPTION
Enables VK_EXT_4444_formats if GPU supports them resolves a validation error

`GUI.RenderLoop Gpu UserCallback: Validation Error: [ VUID-vkGetPhysicalDeviceFormatProperties-format-parameter ] Object 0: VK_NULL_HANDLE, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x4addcb92 | vkGetPhysicalDeviceFormatProperties: value of format (1000340001) does not fall within the begin..end range of the core VkFormat enumeration tokens and is not an extension added token. The Vulkan spec states: format must be a valid VkFormat value (https://vulkan.lunarg.com/doc/view/1.3.250.1/windows/1.3-extensions/vkspec.html#VUID-vkGetPhysicalDeviceFormatProperties-format-parameter)`