### PR TITLE
GPU: Don't sync/bind index buffer when it's not in use

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -331,7 +331,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 UpdateShaderState();
             }
 
-            _channel.BufferManager.CommitGraphicsBindings();
+            _channel.BufferManager.CommitGraphicsBindings(_drawState.DrawIndexed);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -538,6 +538,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     bufferCache.SynchronizeBufferRange(_indexBuffer.Address, _indexBuffer.Size);
                 }
             }
+            else if (_rebind)
+            {
+                _indexBufferDirty = true;
+            }
 
             uint vbEnableMask = _vertexBuffersEnableMask;
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -515,24 +515,28 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Ensures that the graphics engine bindings are visible to the host GPU.
         /// Note: this actually performs the binding using the host graphics API.
         /// </summary>
-        public void CommitGraphicsBindings()
+        /// <param name="indexed">True if the index buffer is in use</param>
+        public void CommitGraphicsBindings(bool indexed)
         {
             var bufferCache = _channel.MemoryManager.Physical.BufferCache;
 
-            if (_indexBufferDirty || _rebind)
+            if (indexed)
             {
-                _indexBufferDirty = false;
-
-                if (_indexBuffer.Address != 0)
+                if (_indexBufferDirty || _rebind)
                 {
-                    BufferRange buffer = bufferCache.GetBufferRange(_indexBuffer.Address, _indexBuffer.Size);
+                    _indexBufferDirty = false;
 
-                    _context.Renderer.Pipeline.SetIndexBuffer(buffer, _indexBuffer.Type);
+                    if (_indexBuffer.Address != 0)
+                    {
+                        BufferRange buffer = bufferCache.GetBufferRange(_indexBuffer.Address, _indexBuffer.Size);
+
+                        _context.Renderer.Pipeline.SetIndexBuffer(buffer, _indexBuffer.Type);
+                    }
                 }
-            }
-            else if (_indexBuffer.Address != 0)
-            {
-                bufferCache.SynchronizeBufferRange(_indexBuffer.Address, _indexBuffer.Size);
+                else if (_indexBuffer.Address != 0)
+                {
+                    bufferCache.SynchronizeBufferRange(_indexBuffer.Address, _indexBuffer.Size);
+                }
             }
 
             uint vbEnableMask = _vertexBuffersEnableMask;


### PR DESCRIPTION
Sometimes draws don't use an index buffer. It's not necessary to check or upload data for the current index buffer binding as it won't be used.

This fixes Pokemon: Legends Arceus updating a stale index buffer for every draw during its TFB pass, which was all non-indexed draws. Not sure if Scarlet/Violet also does this.

This probably didn't cost much on normal PCs, but it had a large impact on MacOS, which the macos1 release build avoided by mirroring index buffers (the PR currently does not). Needs buffer mirrors still for the rest of the performance.

There are additional cases where index buffers are bound or checked with non-indexed draws on the backend, but this one was straightforward to fix and has the largest impact. Testing is welcome to ensure nothing weird broke.