### PR TITLE
Do not add more code after alpha test discard on fragment shader

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4675;
+        private const uint CodeGenVersion = 5529;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
@@ -162,8 +162,10 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             if (op.Ccc == Ccc.T)
             {
-                context.PrepareForReturn();
-                context.Return();
+                if (context.PrepareForReturn())
+                {
+                    context.Return();
+                }
             }
             else
             {
@@ -174,8 +176,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 {
                     Operand lblSkip = Label();
                     context.BranchIfFalse(lblSkip, cond);
-                    context.PrepareForReturn();
-                    context.Return();
+
+                    if (context.PrepareForReturn())
+                    {
+                        context.Return();
+                    }
+
                     context.MarkLabel(lblSkip);
                 }
             }


### PR DESCRIPTION
Adding code after a terminal instruction on a basic block is invalid on SPIR-V. `OpKill` (`discard` in GLSL) is considered a terminal instruction. There was one case where we could generate more code after that: Alpha test with the condition set to "never", which would always discard the fragment.

This change fixes the issue by making sure we don't generate any code after a 'discard' when alpha test is set to "Never".

Should fix #4965.
Thanks for @jcm93 for looking into this issue and providing a save.
Testing is welcome.