### PR TITLE
[Vulkan / Avalonia] Implement Color Space Passthrough option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,13 @@ tab_width = 4
 end_of_line = lf
 insert_final_newline = true
 
+# JSON files
+[*.json]
+
+# Indentation and spacing
+indent_size = 2
+tab_width = 2
+
 # C# files
 [*.cs]
 

--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -186,6 +186,7 @@ namespace Ryujinx.Ava
             ConfigurationState.Instance.Graphics.AntiAliasing.Event += UpdateAntiAliasing;
             ConfigurationState.Instance.Graphics.ScalingFilter.Event += UpdateScalingFilter;
             ConfigurationState.Instance.Graphics.ScalingFilterLevel.Event += UpdateScalingFilterLevel;
+            ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough.Event += UpdateColorSpacePassthrough;
 
             ConfigurationState.Instance.Multiplayer.LanInterfaceId.Event += UpdateLanInterfaceIdState;
 
@@ -227,6 +228,11 @@ namespace Ryujinx.Ava
         {
             _renderer.Window?.SetScalingFilter((Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
             _renderer.Window?.SetScalingFilterLevel(ConfigurationState.Instance.Graphics.ScalingFilterLevel.Value);
+        }
+
+        private void UpdateColorSpacePassthrough(object sender, ReactiveEventArgs<bool> e)
+        {
+            _renderer.Window?.SetColorSpacePassthrough((bool)ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough.Value);
         }
 
         private void ShowCursor()
@@ -461,6 +467,7 @@ namespace Ryujinx.Ava
             ConfigurationState.Instance.Graphics.ScalingFilter.Event -= UpdateScalingFilter;
             ConfigurationState.Instance.Graphics.ScalingFilterLevel.Event -= UpdateScalingFilterLevel;
             ConfigurationState.Instance.Graphics.AntiAliasing.Event -= UpdateAntiAliasing;
+            ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough.Event -= UpdateColorSpacePassthrough;
 
             _topLevel.PointerMoved -= TopLevel_PointerEnterOrMoved;
             _topLevel.PointerEnter -= TopLevel_PointerEnterOrMoved;
@@ -887,6 +894,7 @@ namespace Ryujinx.Ava
             _renderer?.Window?.SetAntiAliasing((Graphics.GAL.AntiAliasing)ConfigurationState.Instance.Graphics.AntiAliasing.Value);
             _renderer?.Window?.SetScalingFilter((Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
             _renderer?.Window?.SetScalingFilterLevel(ConfigurationState.Instance.Graphics.ScalingFilterLevel.Value);
+            _renderer?.Window?.SetColorSpacePassthrough(ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough.Value);
 
             Width = (int)RendererHost.Bounds.Width;
             Height = (int)RendererHost.Bounds.Height;

--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -620,6 +620,8 @@
   "SettingsTabHotkeysVolumeDownHotkey": "Decrease Volume:",
   "SettingsEnableMacroHLE": "Enable Macro HLE",
   "SettingsEnableMacroHLETooltip": "High-level emulation of GPU Macro code.\n\nImproves performance, but may cause graphical glitches in some games.\n\nLeave ON if unsure.",
+  "SettingsEnableColorSpacePassthrough": "Color Space Passthrough",
+  "SettingsEnableColorSpacePassthroughTooltip": "Directs the Vulkan backend to pass through color information without specifying a color space. For users with wide gamut displays, this may result in more vibrant colors, at the cost of color correctness.",
   "VolumeShort": "Vol",
   "UserProfilesManageSaves": "Manage Saves",
   "DeleteUserSave": "Do you want to delete user save for this game?",

--- a/src/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
@@ -145,6 +145,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool EnableShaderCache { get; set; }
         public bool EnableTextureRecompression { get; set; }
         public bool EnableMacroHLE { get; set; }
+        public bool EnableColorSpacePassthrough { get; set; }
         public bool EnableFileLog { get; set; }
         public bool EnableStub { get; set; }
         public bool EnableInfo { get; set; }
@@ -419,6 +420,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             EnableShaderCache = config.Graphics.EnableShaderCache;
             EnableTextureRecompression = config.Graphics.EnableTextureRecompression;
             EnableMacroHLE = config.Graphics.EnableMacroHLE;
+            EnableColorSpacePassthrough = config.Graphics.EnableColorSpacePassthrough;
             ResolutionScale = config.Graphics.ResScale == -1 ? 4 : config.Graphics.ResScale - 1;
             CustomResolutionScale = config.Graphics.ResScaleCustom;
             MaxAnisotropy = config.Graphics.MaxAnisotropy == -1 ? 0 : (int)(MathF.Log2(config.Graphics.MaxAnisotropy));
@@ -506,6 +508,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             config.Graphics.EnableShaderCache.Value = EnableShaderCache;
             config.Graphics.EnableTextureRecompression.Value = EnableTextureRecompression;
             config.Graphics.EnableMacroHLE.Value = EnableMacroHLE;
+            config.Graphics.EnableColorSpacePassthrough.Value = EnableColorSpacePassthrough;
             config.Graphics.ResScale.Value = ResolutionScale == 4 ? -1 : ResolutionScale + 1;
             config.Graphics.ResScaleCustom.Value = CustomResolutionScale;
             config.Graphics.MaxAnisotropy.Value = MaxAnisotropy == 0 ? -1 : MathF.Pow(2, MaxAnisotropy);

--- a/src/Ryujinx.Ava/UI/Views/Settings/SettingsGraphicsView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Settings/SettingsGraphicsView.axaml
@@ -73,6 +73,10 @@
                             ToolTip.Tip="{locale:Locale SettingsEnableMacroHLETooltip}">
                             <TextBlock Text="{locale:Locale SettingsEnableMacroHLE}" />
                         </CheckBox>
+                        <CheckBox IsChecked="{Binding EnableColorSpacePassthrough}"
+                            ToolTip.Tip="{locale:Locale SettingsEnableColorSpacePassthroughTooltip}">
+                            <TextBlock Text="{locale:Locale SettingsEnableColorSpacePassthrough}" />
+                        </CheckBox>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock VerticalAlignment="Center"

--- a/src/Ryujinx.Graphics.GAL/IWindow.cs
+++ b/src/Ryujinx.Graphics.GAL/IWindow.cs
@@ -13,5 +13,6 @@ namespace Ryujinx.Graphics.GAL
         void SetAntiAliasing(AntiAliasing antialiasing);
         void SetScalingFilter(ScalingFilter type);
         void SetScalingFilterLevel(float level);
+        void SetColorSpacePassthrough(bool colorSpacePassThroughEnabled);
     }
 }

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedWindow.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedWindow.cs
@@ -38,5 +38,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         public void SetScalingFilter(ScalingFilter type) { }
 
         public void SetScalingFilterLevel(float level) { }
+
+        public void SetColorSpacePassthrough(bool colorSpacePassthroughEnabled) { }
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/src/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -67,6 +67,11 @@ namespace Ryujinx.Graphics.Gpu
         /// Enables or disables recompression of compressed textures that are not natively supported by the host.
         /// </summary>
         public static bool EnableTextureRecompression = false;
+
+        /// <summary>
+        /// Enables or disables color space passthrough, if available.
+        /// </summary>
+        public static bool EnableColorSpacePassthrough = false;
     }
 #pragma warning restore CA2211
 }

--- a/src/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Window.cs
@@ -307,6 +307,8 @@ namespace Ryujinx.Graphics.OpenGL
             _updateScalingFilter = true;
         }
 
+        public void SetColorSpacePassthrough(bool colorSpacePassthroughEnabled) { }
+
         private void UpdateEffect()
         {
             if (_updateEffect)

--- a/src/Ryujinx.Graphics.Vulkan/WindowBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/WindowBase.cs
@@ -14,5 +14,6 @@ namespace Ryujinx.Graphics.Vulkan
         public abstract void SetAntiAliasing(AntiAliasing effect);
         public abstract void SetScalingFilter(ScalingFilter scalerType);
         public abstract void SetScalingFilterLevel(float scale);
+        public abstract void SetColorSpacePassthrough(bool colorSpacePassthroughEnabled);
     }
 }

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Ui.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 47;
+        public const int CurrentVersion = 48;
 
         /// <summary>
         /// Version of the configuration file format
@@ -185,6 +185,11 @@ namespace Ryujinx.Ui.Common.Configuration
         /// Enables or disables Macro high-level emulation
         /// </summary>
         public bool EnableMacroHLE { get; set; }
+
+        /// <summary>
+        /// Enables or disables color space passthrough, if available.
+        /// </summary>
+        public bool EnableColorSpacePassthrough { get; set; }
 
         /// <summary>
         /// Enables or disables profiled translation cache persistency

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -486,6 +486,11 @@ namespace Ryujinx.Ui.Common.Configuration
             public ReactiveObject<bool> EnableMacroHLE { get; private set; }
 
             /// <summary>
+            /// Enables or disables color space passthrough, if available.
+            /// </summary>
+            public ReactiveObject<bool> EnableColorSpacePassthrough { get; private set; }
+
+            /// <summary>
             /// Graphics backend
             /// </summary>
             public ReactiveObject<GraphicsBackend> GraphicsBackend { get; private set; }
@@ -535,6 +540,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 PreferredGpu.Event += static (sender, e) => LogValueChange(e, nameof(PreferredGpu));
                 EnableMacroHLE = new ReactiveObject<bool>();
                 EnableMacroHLE.Event += static (sender, e) => LogValueChange(e, nameof(EnableMacroHLE));
+                EnableColorSpacePassthrough = new ReactiveObject<bool>();
+                EnableColorSpacePassthrough.Event += static (sender, e) => LogValueChange(e, nameof(EnableColorSpacePassthrough));
                 AntiAliasing = new ReactiveObject<AntiAliasing>();
                 AntiAliasing.Event += static (sender, e) => LogValueChange(e, nameof(AntiAliasing));
                 ScalingFilter = new ReactiveObject<ScalingFilter>();
@@ -667,6 +674,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 EnableShaderCache = Graphics.EnableShaderCache,
                 EnableTextureRecompression = Graphics.EnableTextureRecompression,
                 EnableMacroHLE = Graphics.EnableMacroHLE,
+                EnableColorSpacePassthrough = Graphics.EnableColorSpacePassthrough,
                 EnablePtc = System.EnablePtc,
                 EnableInternetAccess = System.EnableInternetAccess,
                 EnableFsIntegrityChecks = System.EnableFsIntegrityChecks,
@@ -772,6 +780,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Graphics.EnableShaderCache.Value = true;
             Graphics.EnableTextureRecompression.Value = false;
             Graphics.EnableMacroHLE.Value = true;
+            Graphics.EnableColorSpacePassthrough.Value = false;
             Graphics.AntiAliasing.Value = AntiAliasing.None;
             Graphics.ScalingFilter.Value = ScalingFilter.Bilinear;
             Graphics.ScalingFilterLevel.Value = 80;
@@ -1391,6 +1400,15 @@ namespace Ryujinx.Ui.Common.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 48)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 48.");
+
+                configurationFileFormat.EnableColorSpacePassthrough = false;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value = configurationFileFormat.ResScaleCustom;
@@ -1426,6 +1444,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Graphics.EnableShaderCache.Value = configurationFileFormat.EnableShaderCache;
             Graphics.EnableTextureRecompression.Value = configurationFileFormat.EnableTextureRecompression;
             Graphics.EnableMacroHLE.Value = configurationFileFormat.EnableMacroHLE;
+            Graphics.EnableColorSpacePassthrough.Value = configurationFileFormat.EnableColorSpacePassthrough;
             System.EnablePtc.Value = configurationFileFormat.EnablePtc;
             System.EnableInternetAccess.Value = configurationFileFormat.EnableInternetAccess;
             System.EnableFsIntegrityChecks.Value = configurationFileFormat.EnableFsIntegrityChecks;


### PR DESCRIPTION
### Context
Ryujinx outputs sRGB in conformance with the Switch hardware. This makes sense and is correct behavior, but people on wide gamut displays might want Ryujinx to be able to output wide gamut colors, in order to take advantage of their display's capabilities.

This PR implements the option for Ryujinx's Vulkan backend to attempt to not explicitly select a color space during output, and instead pass the color information through Vulkan to the rest of the display engine. This should result in Ryujinx displaying with RGB values stretched to the color space that the operating system and display are currently using.

<img width="400" alt="Screenshot 2023-08-03 at 12 00 59 PM" src="https://github.com/Ryujinx/Ryujinx/assets/6864788/0b40cdf4-a451-4f8b-89bb-49680137a3d3">
<img width="400" alt="Screenshot 2023-08-03 at 1 46 10 PM" src="https://github.com/Ryujinx/Ryujinx/assets/6864788/9e56a150-8582-470e-8944-c2cf370df32b">

### Description

Adds a "Enable Color Space Passthrough" checkbox option under the Graphics settings tab in Avalonia. In Vulkan's ``Window.cs``, inside the ``ChooseSwapSurfaceFormat`` function, a check for the new option status is implemented. If enabled, the function checks for ``ColorSpaceKHR.SpacePassThroughExt`` as an exposed color space and if it is available, returns it. 

``_vSyncEnabled`` is also renamed ``_swapchainIsDirty``, as it is now repurposed as a general flag indicating that the swapchain needs recreation when either vertical sync or the new color space option is toggled.

The relevant change to the configuration file and its version is implemented; as a first time contributor I'm not 100% sure I did this right but hopefully I did.

### Other Considerations

Currently, the option is only implemented in Avalonia and Vulkan. The reason for focusing on these two is that this PR primarily affects Mac users, who typically have wide gamut displays with this color space option exposed to Vulkan via MoltenVK. I do not have enough information to know how or if this option will work as expected on Windows or Linux.

Preliminary research suggests that this option will only function if the operating system and Vulkan driver together 'properly' allow surfaces to select their color space on an ad-hoc basis as macOS does. Unclear how Windows or Linux handles this in all cases.

I considered exposing this option *only* if the user is on macOS, but was not familiar enough with Avalonia's UI logic to do so. I also thought that it may not be harmful to leave it exposed for other systems where it will potentially work.