### PR TITLE
[Hotfix] hid: Prevent out of bounds array access

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -70,6 +70,11 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
         internal void SetSupportedPlayer(PlayerIndex player, bool supported = true)
         {
+            if ((int)player >= _supportedPlayers.Length)
+            {
+                return;
+            }
+
             _supportedPlayers[(int)player] = supported;
         }
 

--- a/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
         internal void SetSupportedPlayer(PlayerIndex player, bool supported = true)
         {
-            if ((int)player >= _supportedPlayers.Length)
+            if ((uint)player >= _supportedPlayers.Length)
             {
                 return;
             }

--- a/src/Ryujinx.Tests/Cpu/EnvironmentTests.cs
+++ b/src/Ryujinx.Tests/Cpu/EnvironmentTests.cs
@@ -48,7 +48,22 @@ namespace Ryujinx.Tests.Cpu
             bool methodCalled = false;
             bool isFz = false;
 
-            var managedMethod = () =>
+            var method = TranslatorTestMethods.GenerateFpFlagsPInvokeTest();
+
+            // This method sets flush-to-zero and then calls the managed method.
+            // Before and after setting the flags, it ensures subnormal addition works as expected.
+            // It returns a positive result if any tests fail, and 0 on success (or if the platform cannot change FP flags)
+            int result = method(Marshal.GetFunctionPointerForDelegate(ManagedMethod));
+
+            // Subnormal results are not flushed to zero by default, which we should have returned to exiting the method.
+            Assert.AreNotEqual(GetDenormal() + GetZero(), 0f);
+
+            Assert.True(result == 0);
+            Assert.True(methodCalled);
+            Assert.True(isFz);
+            return;
+
+            void ManagedMethod()
             {
                 // Floating point math should not modify fp flags.
                 float test = 2f * 3.5f;
@@ -73,21 +88,7 @@ namespace Ryujinx.Tests.Cpu
 
                     methodCalled = true;
                 }
-            };
-
-            var method = TranslatorTestMethods.GenerateFpFlagsPInvokeTest();
-
-            // This method sets flush-to-zero and then calls the managed method.
-            // Before and after setting the flags, it ensures subnormal addition works as expected.
-            // It returns a positive result if any tests fail, and 0 on success (or if the platform cannot change FP flags)
-            int result = method(Marshal.GetFunctionPointerForDelegate(managedMethod));
-
-            // Subnormal results are not flushed to zero by default, which we should have returned to exiting the method.
-            Assert.AreNotEqual(GetDenormal() + GetZero(), 0f);
-
-            Assert.True(result == 0);
-            Assert.True(methodCalled);
-            Assert.True(isFz);
+            }
         }
     }
 }


### PR DESCRIPTION
After #5518 was merged, people reported a lot of crashes indicating an out of bounds access within hid.

This PR fixes this issue by returning from `SetSupportedPlayer()` before the array gets accessed should the index be too large.

With this change ARCropolis works properly again.

---

It seems none of my PRs can be merged without requiring a hotfix shortly after that. :upside_down_face: 