### PR TITLE
Ava UI: Allow DPI switching on Windows

### DIFF
--- a/src/Ryujinx.Ava/Program.cs
+++ b/src/Ryujinx.Ava/Program.cs
@@ -100,8 +100,6 @@ namespace Ryujinx.Ava
 
             ReloadConfig();
 
-            ForceDpiAware.Windows();
-
             WindowScaleFactor = ForceDpiAware.GetWindowScaleFactor();
 
             // Logging system information.


### PR DESCRIPTION
ForceDpiAware.Windows has a side effect of forcing the application DPI to be the same as the primary monitor. This isn't good if you have multiple monitors with different DPI.

On Avalonia, I don't think there are any downsides to disabling this. When it's disabled, `ForceDpiAware.GetWindowScaleFactor` always returns 1.

## Ryujinx (Debug) at 150% when primary monitor is 100%

### Before
![image](https://github.com/Ryujinx/Ryujinx/assets/6294155/fee87298-d90f-421b-876d-396fd642bb31)

### After
![image-1](https://github.com/Ryujinx/Ryujinx/assets/6294155/85043d67-446f-48f6-93f6-b64883d1c6eb)
