### PR TITLE
"static readonly" constants should be "const" instead

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -32,7 +32,7 @@ namespace ARMeilleure.Instructions
             15L << 56 | 14L << 48 | 13L << 40 | 12L << 32 | 07L << 24 | 06L << 16 | 05L << 8 | 04L << 0, // S
         };
 
-        public static readonly long ZeroMask = 128L << 56 | 128L << 48 | 128L << 40 | 128L << 32 | 128L << 24 | 128L << 16 | 128L << 8 | 128L << 0;
+        public const long ZeroMask = 128L << 56 | 128L << 48 | 128L << 40 | 128L << 32 | 128L << 24 | 128L << 16 | 128L << 8 | 128L << 0;
 
         public static ulong X86GetGf2p8LogicalShiftLeft(int shift)
         {

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Modules
         private static readonly string _homeDir = AppDomain.CurrentDomain.BaseDirectory;
         private static readonly string _updateDir = Path.Combine(Path.GetTempPath(), "Ryujinx", "update");
         private static readonly string _updatePublishDir = Path.Combine(_updateDir, "publish");
-        private const int _connectionCount = 4;
+        private const int ConnectionCount = 4;
 
         private static string _buildVer;
         private static string _platformExt;
@@ -344,22 +344,22 @@ namespace Ryujinx.Modules
         private static void DoUpdateWithMultipleThreads(TaskDialog taskDialog, string downloadUrl, string updateFile)
         {
             // Multi-Threaded Updater
-            long chunkSize = _buildSize / _connectionCount;
-            long remainderChunk = _buildSize % _connectionCount;
+            long chunkSize = _buildSize / ConnectionCount;
+            long remainderChunk = _buildSize % ConnectionCount;
 
             int completedRequests = 0;
             int totalProgressPercentage = 0;
-            int[] progressPercentage = new int[_connectionCount];
+            int[] progressPercentage = new int[ConnectionCount];
 
-            List<byte[]> list = new(_connectionCount);
-            List<WebClient> webClients = new(_connectionCount);
+            List<byte[]> list = new(ConnectionCount);
+            List<WebClient> webClients = new(ConnectionCount);
 
-            for (int i = 0; i < _connectionCount; i++)
+            for (int i = 0; i < ConnectionCount; i++)
             {
                 list.Add(Array.Empty<byte>());
             }
 
-            for (int i = 0; i < _connectionCount; i++)
+            for (int i = 0; i < ConnectionCount; i++)
             {
 #pragma warning disable SYSLIB0014
                 // TODO: WebClient is obsolete and need to be replaced with a more complex logic using HttpClient.
@@ -368,7 +368,7 @@ namespace Ryujinx.Modules
 
                 webClients.Add(client);
 
-                if (i == _connectionCount - 1)
+                if (i == ConnectionCount - 1)
                 {
                     client.Headers.Add("Range", $"bytes={chunkSize * i}-{(chunkSize * (i + 1) - 1) + remainderChunk}");
                 }
@@ -385,7 +385,7 @@ namespace Ryujinx.Modules
                     Interlocked.Exchange(ref progressPercentage[index], args.ProgressPercentage);
                     Interlocked.Add(ref totalProgressPercentage, args.ProgressPercentage);
 
-                    taskDialog.SetProgressBarState(totalProgressPercentage / _connectionCount, TaskDialogProgressState.Normal);
+                    taskDialog.SetProgressBarState(totalProgressPercentage / ConnectionCount, TaskDialogProgressState.Normal);
                 };
 
                 client.DownloadDataCompleted += (_, args) =>
@@ -404,10 +404,10 @@ namespace Ryujinx.Modules
                     list[index] = args.Result;
                     Interlocked.Increment(ref completedRequests);
 
-                    if (Equals(completedRequests, _connectionCount))
+                    if (Equals(completedRequests, ConnectionCount))
                     {
                         byte[] mergedFileBytes = new byte[_buildSize];
-                        for (int connectionIndex = 0, destinationOffset = 0; connectionIndex < _connectionCount; connectionIndex++)
+                        for (int connectionIndex = 0, destinationOffset = 0; connectionIndex < ConnectionCount; connectionIndex++)
                         {
                             Array.Copy(list[connectionIndex], 0, mergedFileBytes, destinationOffset, list[connectionIndex].Length);
                             destinationOffset += list[connectionIndex].Length;

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Modules
         private static readonly string _homeDir = AppDomain.CurrentDomain.BaseDirectory;
         private static readonly string _updateDir = Path.Combine(Path.GetTempPath(), "Ryujinx", "update");
         private static readonly string _updatePublishDir = Path.Combine(_updateDir, "publish");
-        private static readonly int _connectionCount = 4;
+        private const int _connectionCount = 4;
 
         private static string _buildVer;
         private static string _platformExt;

--- a/src/Ryujinx.Common/SystemInterop/ForceDpiAware.cs
+++ b/src/Ryujinx.Common/SystemInterop/ForceDpiAware.cs
@@ -28,8 +28,8 @@ namespace Ryujinx.Common.SystemInterop
         [LibraryImport(X11LibraryName)]
         private static partial int XCloseDisplay(IntPtr display);
 
-        private const double _standardDpiScale = 96.0;
-        private const double _maxScaleFactor = 1.25;
+        private const double StandardDpiScale = 96.0;
+        private const double MaxScaleFactor = 1.25;
 
         /// <summary>
         /// Marks the application as DPI-Aware when running on the Windows operating system.
@@ -90,7 +90,7 @@ namespace Ryujinx.Common.SystemInterop
         {
             double userDpiScale = GetActualScaleFactor();
 
-            return Math.Min(userDpiScale / _standardDpiScale, _maxScaleFactor);
+            return Math.Min(userDpiScale / StandardDpiScale, MaxScaleFactor);
         }
     }
 }

--- a/src/Ryujinx.Common/SystemInterop/ForceDpiAware.cs
+++ b/src/Ryujinx.Common/SystemInterop/ForceDpiAware.cs
@@ -28,8 +28,8 @@ namespace Ryujinx.Common.SystemInterop
         [LibraryImport(X11LibraryName)]
         private static partial int XCloseDisplay(IntPtr display);
 
-        private static readonly double _standardDpiScale = 96.0;
-        private static readonly double _maxScaleFactor = 1.25;
+        private const double _standardDpiScale = 96.0;
+        private const double _maxScaleFactor = 1.25;
 
         /// <summary>
         /// Marks the application as DPI-Aware when running on the Windows operating system.

--- a/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Graphics.Vulkan
     /// </summary>
     class MultiFenceHolder
     {
-        private const int _bufferUsageTrackingGranularity = 4096;
+        private const int BufferUsageTrackingGranularity = 4096;
 
         private readonly FenceHolder[] _fences;
         private readonly BufferUsageBitmap _bufferUsageBitmap;
@@ -28,7 +28,7 @@ namespace Ryujinx.Graphics.Vulkan
         public MultiFenceHolder(int size)
         {
             _fences = new FenceHolder[CommandBufferPool.MaxCommandBuffers];
-            _bufferUsageBitmap = new BufferUsageBitmap(size, _bufferUsageTrackingGranularity);
+            _bufferUsageBitmap = new BufferUsageBitmap(size, BufferUsageTrackingGranularity);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Graphics.Vulkan
     /// </summary>
     class MultiFenceHolder
     {
-        private static readonly int _bufferUsageTrackingGranularity = 4096;
+        private const int _bufferUsageTrackingGranularity = 4096;
 
         private readonly FenceHolder[] _fences;
         private readonly BufferUsageBitmap _bufferUsageBitmap;

--- a/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Demangler.cs
+++ b/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Demangler.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Diagnostics.Demangler
 {
     class Demangler
     {
-        private static readonly string _base36 = "0123456789abcdefghijklmnopqrstuvwxyz";
+        private const string _base36 = "0123456789abcdefghijklmnopqrstuvwxyz";
         private readonly List<BaseNode> _substitutionList = new();
         private List<BaseNode> _templateParamList = new();
 

--- a/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Demangler.cs
+++ b/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Demangler.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Diagnostics.Demangler
 {
     class Demangler
     {
-        private const string _base36 = "0123456789abcdefghijklmnopqrstuvwxyz";
+        private const string Base36 = "0123456789abcdefghijklmnopqrstuvwxyz";
         private readonly List<BaseNode> _substitutionList = new();
         private List<BaseNode> _templateParamList = new();
 
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Diagnostics.Demangler
 
             for (int i = 0; i < reversedEncoded.Length; i++)
             {
-                int value = _base36.IndexOf(reversedEncoded[i]);
+                int value = Base36.IndexOf(reversedEncoded[i]);
                 if (value == -1)
                 {
                     return -1;

--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessConst.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessConst.cs
@@ -20,7 +20,7 @@
             "sdk",
         };
 
-        public static readonly string MainNpdmPath = "/main.npdm";
+        public const string MainNpdmPath = "/main.npdm";
 
         public const int NroAsetMagic = ('A' << 0) | ('S' << 8) | ('E' << 16) | ('T' << 24);
 


### PR DESCRIPTION
The value of a `static readonly` field is computed at runtime while the value of a `const` field is calculated at compile time, which improves performance.