### PR TITLE
Prefer jagged arrays over multidimensional

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -233,10 +233,6 @@ dotnet_naming_style.IPascalCase.required_suffix =
 dotnet_naming_style.IPascalCase.word_separator =
 dotnet_naming_style.IPascalCase.capitalization = pascal_case
 
-# Diagnostics
-
-dotnet_diagnostic.CA1814.severity = error
-
 [src/Ryujinx.HLE/HOS/Services/**.cs]
 # Disable "mark members as static" rule for services
 dotnet_diagnostic.CA1822.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -233,6 +233,10 @@ dotnet_naming_style.IPascalCase.required_suffix =
 dotnet_naming_style.IPascalCase.word_separator =
 dotnet_naming_style.IPascalCase.capitalization = pascal_case
 
+# Diagnostics
+
+dotnet_diagnostic.CA1814.severity = error
+
 [src/Ryujinx.HLE/HOS/Services/**.cs]
 # Disable "mark members as static" rule for services
 dotnet_diagnostic.CA1822.severity = none

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -10,10 +10,10 @@ namespace Ryujinx.Graphics.Shader.Instructions
 {
     static partial class InstEmit
     {
-        private static readonly int[,] _maskLut = new int[,]
+        private static readonly int[][] _maskLut = new int[][]
         {
-            { 0b0001, 0b0010, 0b0100, 0b1000, 0b0011, 0b1001, 0b1010, 0b1100 },
-            { 0b0111, 0b1011, 0b1101, 0b1110, 0b1111, 0b0000, 0b0000, 0b0000 },
+            new int[] { 0b0001, 0b0010, 0b0100, 0b1000, 0b0011, 0b1001, 0b1010, 0b1100 },
+            new int[] { 0b0111, 0b1011, 0b1101, 0b1110, 0b1111, 0b0000, 0b0000, 0b0000 },
         };
 
         public const bool Sample1DAs2D = true;
@@ -605,7 +605,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             Operand[] rd1 = new Operand[2] { ConstF(0), ConstF(0) };
 
             int handle = imm;
-            int componentMask = _maskLut[dest2 == RegisterConsts.RegisterZeroIndex ? 0 : 1, writeMask];
+            int componentMask = _maskLut[dest2 == RegisterConsts.RegisterZeroIndex ? 0 : 1][writeMask];
 
             int componentsCount = BitOperations.PopCount((uint)componentMask);
 


### PR DESCRIPTION
In a [multidimensional array](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/multidimensional-arrays), each element in each dimension has the same, fixed size as the other elements in that dimension. In a [jagged array](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/jagged-arrays), which is an array of arrays, each inner array can be of a different size. By only using the space that's needed for a given array, no space is wasted. This rule, CA1814, recommends switching to a jagged array to conserve memory.

Benchmark:
```cs
[SimpleJob]
[MemoryDiagnoser]
[Orderer(SummaryOrderPolicy.FastestToSlowest)]
[RankColumn]
public class Test
{
    private static readonly int[,] multiDimensionalArray = new int[,]
    {
        { 0b0001, 0b0010, 0b0100, 0b1000, 0b0011, 0b1001, 0b1010, 0b1100 },
        { 0b0111, 0b1011, 0b1101, 0b1110, 0b1111, 0b0000, 0b0000, 0b0000 },
    };

    private static readonly int[][] jaggedArray = new int[][]
    {
        new int[] { 0b0001, 0b0010, 0b0100, 0b1000, 0b0011, 0b1001, 0b1010, 0b1100 },
        new int[] { 0b0111, 0b1011, 0b1101, 0b1110, 0b1111, 0b0000, 0b0000, 0b0000 },
    };

    [Benchmark(Baseline = true)]
    public int MultiDimensionalArray()
    {
        int sum = 0;
        for (int i = 0; i < multiDimensionalArray.GetLength(0); i++)
        {
            for (int j = 0; j < multiDimensionalArray.GetLength(1); j++)
            {
                sum += multiDimensionalArray[i, j];
            }
        }
        return sum;
    }

    [Benchmark]
    public int JaggedArray()
    {
        int sum = 0;
        for (int i = 0; i < jaggedArray.Length; i++)
        {
            for (int j = 0; j < jaggedArray[i].Length; j++)
            {
                sum += jaggedArray[i][j];
            }
        }
        return sum;
    }
}
```

Results:
```sh
|                Method |     Mean |    Error |   StdDev | Ratio | Rank | Allocated | Alloc Ratio |
|---------------------- |---------:|---------:|---------:|------:|-----:|----------:|------------:|
|           JaggedArray | 19.61 ns | 0.160 ns | 0.134 ns |  0.48 |    1 |         - |          NA |
| MultiDimensionalArray | 40.51 ns | 0.265 ns | 0.221 ns |  1.00 |    2 |         - |          NA |
```