### PR TITLE
Ava UI: Remove animations on listbox items.

### DIFF
--- a/src/Ryujinx.Ava/Assets/Styles/Styles.xaml
+++ b/src/Ryujinx.Ava/Assets/Styles/Styles.xaml
@@ -335,28 +335,6 @@
                 Value="{DynamicResource AppListBackgroundColor}" />
         <Setter Property="BorderThickness"
                 Value="2"/>
-        <Style.Animations>
-            <Animation Duration="0:0:0.7">
-                <KeyFrame Cue="0%">
-                    <Setter Property="MaxHeight"
-                            Value="0" />
-                    <Setter Property="Opacity"
-                            Value="0.0" />
-                </KeyFrame>
-                <KeyFrame Cue="50%">
-                    <Setter Property="MaxHeight"
-                            Value="1000" />
-                    <Setter Property="Opacity"
-                            Value="0.3" />
-                </KeyFrame>
-                <KeyFrame Cue="100%">
-                    <Setter Property="MaxHeight"
-                            Value="1000" />
-                    <Setter Property="Opacity"
-                            Value="1.0" />
-                </KeyFrame>
-            </Animation>
-        </Style.Animations>
     </Style>
     <Style Selector="ListBox ListBoxItem:selected /template/ ContentPresenter">
         <Setter Property="Background"


### PR DESCRIPTION
Inconsistent usage around the UI and all uses of listbox look a little odd with an animation. 
Most windows themselves have some form of pop-up animation, the content itself does not need one too.

Would like thoughts on full removal vs making a selector for _just_ the game list load. Personally I don't have a huge list and prefer no animation, but the game list is maybe the one listbox it is designed for.

Before:

https://github.com/Ryujinx/Ryujinx/assets/44103205/5ca4048b-f7b6-42b5-a50f-9e32a6ec1a27

After:

https://github.com/Ryujinx/Ryujinx/assets/44103205/927ecd8c-8823-4d81-ab70-46c25b262438

