### PR TITLE
Implement scaled vertex format emulation

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/src/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -21,6 +21,7 @@ namespace Ryujinx.Graphics.GAL
         public readonly bool SupportsBgraFormat;
         public readonly bool SupportsR4G4Format;
         public readonly bool SupportsR4G4B4A4Format;
+        public readonly bool SupportsScaledVertexFormats;
         public readonly bool SupportsSnormBufferTextureFormat;
         public readonly bool Supports5BitComponentFormat;
         public readonly bool SupportsBlendEquationAdvanced;
@@ -71,6 +72,7 @@ namespace Ryujinx.Graphics.GAL
             bool supportsBgraFormat,
             bool supportsR4G4Format,
             bool supportsR4G4B4A4Format,
+            bool supportsScaledVertexFormats,
             bool supportsSnormBufferTextureFormat,
             bool supports5BitComponentFormat,
             bool supportsBlendEquationAdvanced,
@@ -117,6 +119,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsBgraFormat = supportsBgraFormat;
             SupportsR4G4Format = supportsR4G4Format;
             SupportsR4G4B4A4Format = supportsR4G4B4A4Format;
+            SupportsScaledVertexFormats = supportsScaledVertexFormats;
             SupportsSnormBufferTextureFormat = supportsSnormBufferTextureFormat;
             Supports5BitComponentFormat = supports5BitComponentFormat;
             SupportsBlendEquationAdvanced = supportsBlendEquationAdvanced;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
@@ -218,17 +218,34 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         {
             bool changed = false;
             ref Array32<AttributeType> attributeTypes = ref _graphics.AttributeTypes;
+            bool supportsScaledFormats = _context.Capabilities.SupportsScaledVertexFormats;
 
             for (int location = 0; location < state.Length; location++)
             {
                 VertexAttribType type = state[location].UnpackType();
 
-                AttributeType value = type switch
+                AttributeType value;
+
+                if (supportsScaledFormats)
                 {
-                    VertexAttribType.Sint => AttributeType.Sint,
-                    VertexAttribType.Uint => AttributeType.Uint,
-                    _ => AttributeType.Float,
-                };
+                    value = type switch
+                    {
+                        VertexAttribType.Sint => AttributeType.Sint,
+                        VertexAttribType.Uint => AttributeType.Uint,
+                        _ => AttributeType.Float,
+                    };
+                }
+                else
+                {
+                    value = type switch
+                    {
+                        VertexAttribType.Sint => AttributeType.Sint,
+                        VertexAttribType.Uint => AttributeType.Uint,
+                        VertexAttribType.Uscaled => AttributeType.Uscaled,
+                        VertexAttribType.Sscaled => AttributeType.Sscaled,
+                        _ => AttributeType.Float,
+                    };
+                }
 
                 if (attributeTypes[location] != value)
                 {

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
@@ -154,6 +154,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
         public bool QueryHostSupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
 
+        public bool QueryHostSupportsScaledVertexFormats() => _context.Capabilities.SupportsScaledVertexFormats;
+
         public bool QueryHostSupportsShaderBallot() => _context.Capabilities.SupportsShaderBallot;
 
         public bool QueryHostSupportsShaderBarrierDivergence() => _context.Capabilities.SupportsShaderBarrierDivergence;

--- a/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -159,6 +159,7 @@ namespace Ryujinx.Graphics.OpenGL
                 supportsMismatchingViewFormat: HwCapabilities.SupportsMismatchingViewFormat,
                 supportsCubemapView: true,
                 supportsNonConstantTextureOffset: HwCapabilities.SupportsNonConstantTextureOffset,
+                supportsScaledVertexFormats: true,
                 supportsShaderBallot: HwCapabilities.SupportsShaderBallot,
                 supportsShaderBarrierDivergence: !(intelWindows || intelUnix),
                 supportsShaderFloat64: true,

--- a/src/Ryujinx.Graphics.Shader/AttributeType.cs
+++ b/src/Ryujinx.Graphics.Shader/AttributeType.cs
@@ -9,6 +9,8 @@ namespace Ryujinx.Graphics.Shader
         Float,
         Sint,
         Uint,
+        Sscaled,
+        Uscaled,
     }
 
     static class AttributeTypeExtensions
@@ -31,6 +33,32 @@ namespace Ryujinx.Graphics.Shader
                 AttributeType.Float => AggregateType.FP32,
                 AttributeType.Sint => AggregateType.S32,
                 AttributeType.Uint => AggregateType.U32,
+                _ => throw new ArgumentException($"Invalid attribute type \"{type}\"."),
+            };
+        }
+
+        public static string ToVec4Type(this AttributeType type, bool supportsScaledFormats)
+        {
+            return type switch
+            {
+                AttributeType.Float => "vec4",
+                AttributeType.Sint => "ivec4",
+                AttributeType.Uint => "uvec4",
+                AttributeType.Sscaled => supportsScaledFormats ? "vec4" : "ivec4",
+                AttributeType.Uscaled => supportsScaledFormats ? "vec4" : "uvec4",
+                _ => throw new ArgumentException($"Invalid attribute type \"{type}\"."),
+            };
+        }
+
+        public static AggregateType ToAggregateType(this AttributeType type, bool supportsScaledFormats)
+        {
+            return type switch
+            {
+                AttributeType.Float=> AggregateType.FP32,
+                AttributeType.Sint => AggregateType.S32,
+                AttributeType.Uint => AggregateType.U32,
+                AttributeType.Sscaled => supportsScaledFormats ? AggregateType.FP32 : AggregateType.S32,
+                AttributeType.Uscaled => supportsScaledFormats ? AggregateType.FP32 : AggregateType.U32,
                 _ => throw new ArgumentException($"Invalid attribute type \"{type}\"."),
             };
         }

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -521,7 +521,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 if (context.Config.Stage == ShaderStage.Vertex)
                 {
-                    type = context.Config.GpuAccessor.QueryAttributeType(attr).ToVec4Type();
+                    bool supportsScaledFormats = context.Config.GpuAccessor.QueryHostSupportsScaledVertexFormats();
+                    type = context.Config.GpuAccessor.QueryAttributeType(attr).ToVec4Type(supportsScaledFormats);
                 }
                 else
                 {

--- a/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -332,6 +332,15 @@ namespace Ryujinx.Graphics.Shader
         }
 
         /// <summary>
+        /// Queries host support scaled vertex formats, where a integer value is converted to floating-point.
+        /// </summary>
+        /// <returns>True if the host support scaled vertex formats, false otherwise</returns>
+        bool QueryHostSupportsScaledVertexFormats()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Queries host GPU shader ballot support.
         /// </summary>
         /// <returns>True if the GPU and driver supports shader ballot, false otherwise</returns>

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
@@ -64,7 +64,31 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     }
                     else
                     {
-                        context.Copy(Register(rd), AttributeMap.GenerateAttributeLoad(context, primVertex, offset, isOutput, op.P));
+                        value = AttributeMap.GenerateAttributeLoad(context, primVertex, offset, isOutput, op.P);
+
+                        if (!context.Config.GpuAccessor.QueryHostSupportsScaledVertexFormats() &&
+                            context.Config.Stage == ShaderStage.Vertex &&
+                            !op.O &&
+                            offset >= 0x80 &&
+                            offset < 0x280)
+                        {
+                            // The host does not support scaled vertex formats,
+                            // the emulator should use a integer format, and
+                            // we compensate here inserting the conversion to float.
+
+                            AttributeType type = context.Config.GpuAccessor.QueryAttributeType((offset - 0x80) >> 4);
+
+                            if (type == AttributeType.Sscaled)
+                            {
+                                value = context.IConvertS32ToFP32(value);
+                            }
+                            else if (type == AttributeType.Uscaled)
+                            {
+                                value = context.IConvertU32ToFP32(value);
+                            }
+                        }
+
+                        context.Copy(Register(rd), value);
                     }
                 }
                 else

--- a/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -354,7 +354,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (Stage == ShaderStage.Vertex && !isOutput)
             {
-                type |= GpuAccessor.QueryAttributeType(location).ToAggregateType();
+                type |= GpuAccessor.QueryAttributeType(location).ToAggregateType(GpuAccessor.QueryHostSupportsScaledVertexFormats());
             }
             else
             {

--- a/src/Ryujinx.Graphics.Vulkan/FormatCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FormatCapabilities.cs
@@ -9,6 +9,48 @@ namespace Ryujinx.Graphics.Vulkan
 {
     class FormatCapabilities
     {
+        private static readonly GAL.Format[] _scaledFormats = {
+            GAL.Format.R8Uscaled,
+            GAL.Format.R8Sscaled,
+            GAL.Format.R16Uscaled,
+            GAL.Format.R16Sscaled,
+            GAL.Format.R8G8Uscaled,
+            GAL.Format.R8G8Sscaled,
+            GAL.Format.R16G16Uscaled,
+            GAL.Format.R16G16Sscaled,
+            GAL.Format.R8G8B8Uscaled,
+            GAL.Format.R8G8B8Sscaled,
+            GAL.Format.R16G16B16Uscaled,
+            GAL.Format.R16G16B16Sscaled,
+            GAL.Format.R8G8B8A8Uscaled,
+            GAL.Format.R8G8B8A8Sscaled,
+            GAL.Format.R16G16B16A16Uscaled,
+            GAL.Format.R16G16B16A16Sscaled,
+            GAL.Format.R10G10B10A2Uscaled,
+            GAL.Format.R10G10B10A2Sscaled,
+        };
+
+        private static readonly GAL.Format[] _intFormats = {
+            GAL.Format.R8Uint,
+            GAL.Format.R8Sint,
+            GAL.Format.R16Uint,
+            GAL.Format.R16Sint,
+            GAL.Format.R8G8Uint,
+            GAL.Format.R8G8Sint,
+            GAL.Format.R16G16Uint,
+            GAL.Format.R16G16Sint,
+            GAL.Format.R8G8B8Uint,
+            GAL.Format.R8G8B8Sint,
+            GAL.Format.R16G16B16Uint,
+            GAL.Format.R16G16B16Sint,
+            GAL.Format.R8G8B8A8Uint,
+            GAL.Format.R8G8B8A8Sint,
+            GAL.Format.R16G16B16A16Uint,
+            GAL.Format.R16G16B16A16Sint,
+            GAL.Format.R10G10B10A2Uint,
+            GAL.Format.R10G10B10A2Sint,
+        };
+
         private readonly FormatFeatureFlags[] _bufferTable;
         private readonly FormatFeatureFlags[] _optimalTable;
 
@@ -64,6 +106,25 @@ namespace Ryujinx.Graphics.Vulkan
             }
 
             return (formatFeatureFlags & flags) == flags;
+        }
+
+        public bool SupportsScaledVertexFormats()
+        {
+            // We want to check is all scaled formats are supported,
+            // but if the integer variant is not supported either,
+            // then the format is likely not supported at all,
+            // we ignore formats that are entirely unsupported here.
+
+            for (int i = 0; i < _scaledFormats.Length; i++)
+            {
+                if (!BufferFormatSupports(FormatFeatureFlags.VertexBufferBit, _scaledFormats[i]) &&
+                    BufferFormatSupports(FormatFeatureFlags.VertexBufferBit, _intFormats[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public bool BufferFormatSupports(FormatFeatureFlags flags, VkFormat format)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -596,6 +596,7 @@ namespace Ryujinx.Graphics.Vulkan
                 supportsMismatchingViewFormat: true,
                 supportsCubemapView: !IsAmdGcn,
                 supportsNonConstantTextureOffset: false,
+                supportsScaledVertexFormats: FormatCapabilities.SupportsScaledVertexFormats(),
                 supportsShaderBallot: false,
                 supportsShaderBarrierDivergence: Vendor != Vendor.Intel,
                 supportsShaderFloat64: Capabilities.SupportsShaderFloat64,


### PR DESCRIPTION
This will be required for #5551 since it accesses vertex buffers using buffer textures, and scaled formats are not supported for buffer textures. This change is also useful on its own however, for GPUs that do not support scaled vertex formats, but I think all the GPUs we support right now supports them. In any case, I have added the required checks, so it will emulate them (using integer formats and converting to float in the shader) if not natively supported.