### PR TITLE
Introduce Mako to fix pr_triage workflow

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -29,4 +29,4 @@ infra:
   - TSRBerry
 
 default:
-  - marysaka
+  - @developers

--- a/.github/update_reviewers.py
+++ b/.github/update_reviewers.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from typing import List, Set
-from github import Github
+from github import Auth, Github
 from github.Repository import Repository
 from github.GithubException import GithubException
 
+import os
 import sys
 import yaml
 
@@ -57,16 +58,19 @@ def update_reviewers(config, repo: Repository, pr_id: int) -> int:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 5:
-        sys.stderr.write("usage: <token> <repo_path> <pr_id> <config_path>\n")
+    if len(sys.argv) != 7:
+        sys.stderr.write("usage: <app_id> <private_key_env_name> <installation_id> <repo_path> <pr_id> <config_path>\n")
         sys.exit(1)
 
-    token = sys.argv[1]
-    repo_path = sys.argv[2]
-    pr_id = int(sys.argv[3])
-    config_path = Path(sys.argv[4])
+    app_id = sys.argv[1]
+    private_key = os.environ[sys.argv[2]]
+    installation_id = sys.argv[3]
+    repo_path = sys.argv[4]
+    pr_id = int(sys.argv[5])
+    config_path = Path(sys.argv[6])
 
-    g = Github(token)
+    auth = Auth.AppAuth(app_id, private_key).get_installation_auth(installation_id)
+    g = Github(auth=auth)
     repo = g.get_repo(repo_path)
 
     if not repo:

--- a/.github/update_reviewers.py
+++ b/.github/update_reviewers.py
@@ -25,6 +25,10 @@ def update_reviewers(config, repo: Repository, pr_id: int) -> int:
         sys.stderr.writable(f"Unknown PR #{pr_id}\n")
         return 1
 
+    if pull_request.draft:
+        print("Not assigning reviewers for draft PRs")
+        return 0
+
     pull_request_author = pull_request.user.login
     reviewers = set()
     team_reviewers = set()

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -27,8 +27,11 @@ jobs:
           sync-labels: true
           dot: true
 
+      - run: pip3 install PyGithub
+
       - name: Assign reviewers
         run: |
-          pip3 install PyGithub
-          python3 .github/update_reviewers.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.event.pull_request.number }} .github/reviewers.yml
+          python3 .github/update_reviewers.py ${{ secrets.MAKO_APP_ID }} "MAKO_PRIVATE_KEY" ${{ secrets.MAKO_INSTALLATION_ID }} ${{ github.repository }} ${{ github.event.pull_request.number }} .github/reviewers.yml
         shell: bash
+        env:
+            MAKO_PRIVATE_KEY: ${{ secrets.MAKO_PRIVATE_KEY }}

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -28,7 +28,6 @@ jobs:
           dot: true
 
       - name: Assign reviewers
-        if: ! github.event.pull_request.draft
         run: |
           pip3 install PyGithub
           python3 .github/update_reviewers.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.event.pull_request.number }} .github/reviewers.yml


### PR DESCRIPTION
This PR fixes a regression from #5519 where I broke the pr_triage workflow for non draft PRs.

In addition to that this PR also introduces Mako, a GitHub App for Ryujinx, which for now will only be used to assign reviewers to non-draft PRs.

In the future Mako might get a few more tasks to make project management (and maybe moderation) a little bit easier.