### PR TITLE
Make Vulkan memory allocator actually thread safe

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/MemoryAllocator.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MemoryAllocator.cs
@@ -67,6 +67,7 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 var newBl = new MemoryAllocatorBlockList(_api, _device, memoryTypeIndex, _blockAlignment, isBuffer);
                 _blockLists.Add(newBl);
+
                 return newBl.Allocate(size, alignment, map);
             }
             finally

--- a/src/Ryujinx.Graphics.Vulkan/MemoryAllocator.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MemoryAllocator.cs
@@ -1,6 +1,7 @@
 ﻿using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -13,6 +14,7 @@ namespace Ryujinx.Graphics.Vulkan
         private readonly Device _device;
         private readonly List<MemoryAllocatorBlockList> _blockLists;
         private readonly int _blockAlignment;
+        private readonly ReaderWriterLockSlim _lock;
 
         public MemoryAllocator(Vk api, VulkanPhysicalDevice physicalDevice, Device device)
         {
@@ -21,6 +23,7 @@ namespace Ryujinx.Graphics.Vulkan
             _device = device;
             _blockLists = new List<MemoryAllocatorBlockList>();
             _blockAlignment = (int)Math.Min(int.MaxValue, MaxDeviceMemoryUsageEstimate / _physicalDevice.PhysicalDeviceProperties.Limits.MaxMemoryAllocationCount);
+            _lock = new(LockRecursionPolicy.NoRecursion);
         }
 
         public MemoryAllocation AllocateDeviceMemory(
@@ -40,21 +43,36 @@ namespace Ryujinx.Graphics.Vulkan
 
         private MemoryAllocation Allocate(int memoryTypeIndex, ulong size, ulong alignment, bool map, bool isBuffer)
         {
-            for (int i = 0; i < _blockLists.Count; i++)
+            _lock.EnterReadLock();
+
+            try
             {
-                var bl = _blockLists[i];
-                if (bl.MemoryTypeIndex == memoryTypeIndex && bl.ForBuffer == isBuffer)
+                for (int i = 0; i < _blockLists.Count; i++)
                 {
-                    lock (bl)
+                    var bl = _blockLists[i];
+                    if (bl.MemoryTypeIndex == memoryTypeIndex && bl.ForBuffer == isBuffer)
                     {
                         return bl.Allocate(size, alignment, map);
                     }
                 }
             }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
 
-            var newBl = new MemoryAllocatorBlockList(_api, _device, memoryTypeIndex, _blockAlignment, isBuffer);
-            _blockLists.Add(newBl);
-            return newBl.Allocate(size, alignment, map);
+            _lock.EnterWriteLock();
+
+            try
+            {
+                var newBl = new MemoryAllocatorBlockList(_api, _device, memoryTypeIndex, _blockAlignment, isBuffer);
+                _blockLists.Add(newBl);
+                return newBl.Allocate(size, alignment, map);
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
         }
 
         internal int FindSuitableMemoryTypeIndex(

--- a/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
@@ -257,13 +257,22 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (block.IsTotallyFree())
             {
-                for (int i = 0; i < _blocks.Count; i++)
+                _lock.EnterWriteLock();
+
+                try
                 {
-                    if (_blocks[i] == block)
+                    for (int i = 0; i < _blocks.Count; i++)
                     {
-                        _blocks.RemoveAt(i);
-                        break;
+                        if (_blocks[i] == block)
+                        {
+                            _blocks.RemoveAt(i);
+                            break;
+                        }
                     }
+                }
+                finally
+                {
+                    _lock.ExitWriteLock();
                 }
 
                 block.Destroy(_api, _device);

--- a/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
@@ -3,6 +3,7 @@ using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -166,6 +167,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         private readonly int _blockAlignment;
 
+        private readonly ReaderWriterLockSlim _lock;
+
         public MemoryAllocatorBlockList(Vk api, Device device, int memoryTypeIndex, int blockAlignment, bool forBuffer)
         {
             _blocks = new List<Block>();
@@ -174,6 +177,7 @@ namespace Ryujinx.Graphics.Vulkan
             MemoryTypeIndex = memoryTypeIndex;
             ForBuffer = forBuffer;
             _blockAlignment = blockAlignment;
+            _lock = new(LockRecursionPolicy.NoRecursion);
         }
 
         public unsafe MemoryAllocation Allocate(ulong size, ulong alignment, bool map)
@@ -184,18 +188,27 @@ namespace Ryujinx.Graphics.Vulkan
                 throw new ArgumentOutOfRangeException(nameof(alignment), $"Invalid alignment 0x{alignment:X}.");
             }
 
-            for (int i = 0; i < _blocks.Count; i++)
-            {
-                var block = _blocks[i];
+            _lock.EnterReadLock();
 
-                if (block.Mapped == map && block.Size >= size)
+            try
+            {
+                for (int i = 0; i < _blocks.Count; i++)
                 {
-                    ulong offset = block.Allocate(size, alignment);
-                    if (offset != InvalidOffset)
+                    var block = _blocks[i];
+
+                    if (block.Mapped == map && block.Size >= size)
                     {
-                        return new MemoryAllocation(this, block, block.Memory, GetHostPointer(block, offset), offset, size);
+                        ulong offset = block.Allocate(size, alignment);
+                        if (offset != InvalidOffset)
+                        {
+                            return new MemoryAllocation(this, block, block.Memory, GetHostPointer(block, offset), offset, size);
+                        }
                     }
                 }
+            }
+            finally
+            {
+                _lock.ExitReadLock();
             }
 
             ulong blockAlignedSize = BitUtils.AlignUp(size, (ulong)_blockAlignment);
@@ -259,13 +272,22 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void InsertBlock(Block block)
         {
-            int index = _blocks.BinarySearch(block);
-            if (index < 0)
-            {
-                index = ~index;
-            }
+            _lock.EnterWriteLock();
 
-            _blocks.Insert(index, block);
+            try
+            {
+                int index = _blocks.BinarySearch(block);
+                if (index < 0)
+                {
+                    index = ~index;
+                }
+
+                _blocks.Insert(index, block);
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
It seems there was some attempt to make `MemoryAllocator.Allocate` method thread safe, by locking the `MemoryAllocatorBlockList` object when it already exists, however this is not really enough to make it thread safe for several reasons:
- No suck locks exists when a new `MemoryAllocatorBlockList`. It is possible that another thread will access it right after it is added to the list, and then we have 2 threads calling the `Allocate` method which is what the first lock is supposed to prevent.
- Adding the new `MemoryAllocatorBlockList` to the `_blockLists` is also not thread safe.
- Block freeing is not thread safe, although I don't think this ever happens outside of the render thread, but even if it doesn't it will touch the internal `_blocks` list that can be accessed from other threads.

This change tries to address those issues by using a `ReaderWriterLock` to ensure any modification operation on the lists will be done on only one thread at once.

Following the advice from #5493 I used `ReadWriterLockSlim` instead of `ReadWriterLock`.

The motivation for this was the issue reported on https://github.com/Ryujinx/Ryujinx/pull/4899#issuecomment-1676082980, but if it's indeed a thread safety issue, it would be very hard to reproduce and confirm that the fix works.