### PR TITLE
Declare and use gl_PerVertex block for VTG per-vertex built-ins

### DIFF
--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/IoMap.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/IoMap.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
 using Ryujinx.Graphics.Shader.Translation;
+using System;
 using static Spv.Specification;
 
 namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
@@ -79,6 +80,44 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             }
 
             return false;
+        }
+
+        public static bool IsPerVertexBuiltIn(IoVariable ioVariable)
+        {
+            switch (ioVariable)
+            {
+                case IoVariable.Position:
+                case IoVariable.PointSize:
+                case IoVariable.ClipDistance:
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsPerVertexArrayBuiltIn(StorageKind storageKind, ShaderStage stage)
+        {
+            if (storageKind == StorageKind.Output)
+            {
+                return stage == ShaderStage.TessellationControl;
+            }
+            else
+            {
+                return stage == ShaderStage.TessellationControl ||
+                       stage == ShaderStage.TessellationEvaluation ||
+                       stage == ShaderStage.Geometry;
+            }
+        }
+
+        public static int GetPerVertexStructFieldIndex(IoVariable ioVariable)
+        {
+            return ioVariable switch
+            {
+                IoVariable.Position => 0,
+                IoVariable.PointSize => 1,
+                IoVariable.ClipDistance => 2,
+                _ => throw new ArgumentException($"Invalid built-in variable {ioVariable}.")
+            };
         }
     }
 }

--- a/src/Ryujinx.Graphics.Shader/ShaderStage.cs
+++ b/src/Ryujinx.Graphics.Shader/ShaderStage.cs
@@ -23,5 +23,18 @@ namespace Ryujinx.Graphics.Shader
         {
             return stage == ShaderStage.Vertex || stage == ShaderStage.Fragment || stage == ShaderStage.Compute;
         }
+
+        /// <summary>
+        /// Checks if the shader stage is vertex, tessellation or geometry.
+        /// </summary>
+        /// <param name="stage">Shader stage</param>
+        /// <returns>True if the shader stage is vertex, tessellation or geometry, false otherwise</returns>
+        public static bool IsVtg(this ShaderStage stage)
+        {
+            return stage == ShaderStage.Vertex ||
+                   stage == ShaderStage.TessellationControl ||
+                   stage == ShaderStage.TessellationEvaluation ||
+                   stage == ShaderStage.Geometry;
+        }
     }
 }

--- a/src/Spv.Generator/Module.cs
+++ b/src/Spv.Generator/Module.cs
@@ -28,6 +28,7 @@ namespace Spv.Generator
 
         // In the declaration block.
         private readonly Dictionary<TypeDeclarationKey, Instruction> _typeDeclarations;
+        private readonly List<Instruction> _typeDeclarationsList;
         // In the declaration block.
         private readonly List<Instruction> _globals;
         // In the declaration block.
@@ -54,6 +55,7 @@ namespace Spv.Generator
             _debug = new List<Instruction>();
             _annotations = new List<Instruction>();
             _typeDeclarations = new Dictionary<TypeDeclarationKey, Instruction>();
+            _typeDeclarationsList = new List<Instruction>();
             _constants = new Dictionary<ConstantKey, Instruction>();
             _globals = new List<Instruction>();
             _functionsDeclarations = new List<Instruction>();
@@ -126,7 +128,8 @@ namespace Spv.Generator
 
             instruction.SetId(GetNewId());
 
-            _typeDeclarations.Add(key, instruction);
+            _typeDeclarations[key] = instruction;
+            _typeDeclarationsList.Add(instruction);
         }
 
         public void AddEntryPoint(ExecutionModel executionModel, Instruction function, string name, params Instruction[] interfaces)
@@ -330,7 +333,7 @@ namespace Spv.Generator
 
             // Ensure that everything is in the right order in the declarations section.
             List<Instruction> declarations = new();
-            declarations.AddRange(_typeDeclarations.Values);
+            declarations.AddRange(_typeDeclarationsList);
             declarations.AddRange(_globals);
             declarations.AddRange(_constants.Values);
             declarations.Sort((Instruction x, Instruction y) => x.Id.CompareTo(y.Id));


### PR DESCRIPTION
This is changing how the SPIR-V generator handles per-vertex inputs and outputs on the vertex, tessellation and geometry shader stages. With this change, the produced code is closer to what glslang compiler produces. The benefit of doing that is that the code should work in all drivers. Generally compilers are only tested with the official compiler output, so deviating from it can cause issues, even if nothing in the spec says that the previous code was invalid.

There are to known issues with the old code currently, so this change is mostly to be on the safe side.