### PR TITLE
Fix invalid audio renderer buffer size when end offset < start offset

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Dsp/PcmHelper.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/PcmHelper.cs
@@ -20,6 +20,11 @@ namespace Ryujinx.Audio.Renderer.Dsp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetBufferSize<T>(int startSampleOffset, int endSampleOffset, int offset, int count) where T : unmanaged
         {
+            if (endSampleOffset < startSampleOffset)
+            {
+                return 0;
+            }
+
             return GetCountToDecode(startSampleOffset, endSampleOffset, offset, count) * Unsafe.SizeOf<T>();
         }
 

--- a/src/Ryujinx.Audio/Renderer/Parameter/VoiceInParameter.cs
+++ b/src/Ryujinx.Audio/Renderer/Parameter/VoiceInParameter.cs
@@ -264,8 +264,8 @@ namespace Ryujinx.Audio.Renderer.Parameter
             {
                 uint dataTypeSize = (uint)Unsafe.SizeOf<T>();
 
-                return StartSampleOffset * dataTypeSize <= Size &&
-                       EndSampleOffset * dataTypeSize <= Size;
+                return (ulong)StartSampleOffset * dataTypeSize <= Size &&
+                       (ulong)EndSampleOffset * dataTypeSize <= Size;
             }
 
             /// <summary>


### PR DESCRIPTION
This prevents audren from trying to get an span with an invalid length, due to the buffer size being negative. This is caused by the end offset being less than the start offset of the data, so when calculating the size, the result is negative.

There was already a check on `PcmHelper.Decode` and friends to protect against that:
```cs
            if (input.IsEmpty || endSampleOffset < startSampleOffset)
            {
                return 0;
            }
```
But it becomes useless if we don't also ensure we are not going to get a span with invalid length which would throw exceptions.
This behaviour matches what the Switch DSP code does. It exits without decoding anything when end offset < start offset.

Fixes
> the cutscene at the end of the mission "Dreaming Mushroom" in Episode 4 is unskippable and crashes, making it impossible to complete the game.

on https://github.com/Ryujinx/Ryujinx-Games-List/issues/4719