### PR TITLE
Fix debug assert on services without pointer buffer

### DIFF
--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/ServerManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/ServerManager.cs
@@ -31,7 +31,10 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
 
             if (allocator != null)
             {
-                _pointerBuffersBaseAddress = allocator.Allocate((ulong)maxSessions * (ulong)options.PointerBufferSize);
+                if (options.PointerBufferSize != 0)
+                {
+                    _pointerBuffersBaseAddress = allocator.Allocate((ulong)maxSessions * (ulong)options.PointerBufferSize);
+                }
 
                 if (options.CanDeferInvokeRequest)
                 {


### PR DESCRIPTION
Fixes an assert that started happening after #5580. This service does not have pointer buffer, but it was still trying to allocate a pointer buffer with size 0, which caused the assert.

This assert only happens in debug builds, so it should have no user visible effect.