### PR TITLE
Fix some Vulkan validation errors (mostly related to barriers)

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -257,14 +257,22 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (realIndex != -1)
                 {
-                    _colors[realIndex].Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
+                    _colors[realIndex].Storage?.InsertReadToWriteBarrier(
+                        cbs,
+                        AccessFlags.ColorAttachmentWriteBit,
+                        PipelineStageFlags.ColorAttachmentOutputBit,
+                        insideRenderPass: true);
                 }
             }
         }
 
         public void InsertClearBarrierDS(CommandBufferScoped cbs)
         {
-            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.DepthStencilAttachmentWriteBit, PipelineStageFlags.LateFragmentTestsBit);
+            _depthStencil?.Storage?.InsertReadToWriteBarrier(
+                cbs,
+                AccessFlags.DepthStencilAttachmentWriteBit,
+                PipelineStageFlags.LateFragmentTestsBit,
+                insideRenderPass: true);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -41,6 +41,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly bool SupportsPreciseOcclusionQueries;
         public readonly bool SupportsPipelineStatisticsQuery;
         public readonly bool SupportsGeometryShader;
+        public readonly bool SupportsTessellationShader;
         public readonly bool SupportsViewportArray2;
         public readonly bool SupportsHostImportedMemory;
         public readonly bool SupportsDepthClipControl;
@@ -77,6 +78,7 @@ namespace Ryujinx.Graphics.Vulkan
             bool supportsPreciseOcclusionQueries,
             bool supportsPipelineStatisticsQuery,
             bool supportsGeometryShader,
+            bool supportsTessellationShader,
             bool supportsViewportArray2,
             bool supportsHostImportedMemory,
             bool supportsDepthClipControl,
@@ -112,6 +114,7 @@ namespace Ryujinx.Graphics.Vulkan
             SupportsPreciseOcclusionQueries = supportsPreciseOcclusionQueries;
             SupportsPipelineStatisticsQuery = supportsPipelineStatisticsQuery;
             SupportsGeometryShader = supportsGeometryShader;
+            SupportsTessellationShader = supportsTessellationShader;
             SupportsViewportArray2 = supportsViewportArray2;
             SupportsHostImportedMemory = supportsHostImportedMemory;
             SupportsDepthClipControl = supportsDepthClipControl;

--- a/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -5,7 +5,6 @@ using Ryujinx.Graphics.Shader.Translation;
 using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Numerics;
 using CompareOp = Ryujinx.Graphics.GAL.CompareOp;
 using Format = Ryujinx.Graphics.GAL.Format;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -18,6 +18,13 @@ namespace Ryujinx.Graphics.Vulkan
 {
     class PipelineBase : IDisposable
     {
+        private const PipelineStageFlags BarrierStageFlags =
+            PipelineStageFlags.VertexShaderBit |
+            PipelineStageFlags.TessellationControlShaderBit |
+            PipelineStageFlags.TessellationEvaluationShaderBit |
+            PipelineStageFlags.GeometryShaderBit |
+            PipelineStageFlags.FragmentShaderBit;
+
         public const int DescriptorSetLayouts = 4;
 
         public const int UniformSetIndex = 0;
@@ -151,8 +158,8 @@ namespace Ryujinx.Graphics.Vulkan
 
             Gd.Api.CmdPipelineBarrier(
                 CommandBuffer,
-                PipelineStageFlags.FragmentShaderBit,
-                PipelineStageFlags.FragmentShaderBit,
+                BarrierStageFlags,
+                BarrierStageFlags,
                 0,
                 1,
                 memoryBarrier,

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -18,13 +18,6 @@ namespace Ryujinx.Graphics.Vulkan
 {
     class PipelineBase : IDisposable
     {
-        private const PipelineStageFlags BarrierStageFlags =
-            PipelineStageFlags.VertexShaderBit |
-            PipelineStageFlags.TessellationControlShaderBit |
-            PipelineStageFlags.TessellationEvaluationShaderBit |
-            PipelineStageFlags.GeometryShaderBit |
-            PipelineStageFlags.FragmentShaderBit;
-
         public const int DescriptorSetLayouts = 4;
 
         public const int UniformSetIndex = 0;
@@ -156,10 +149,22 @@ namespace Ryujinx.Graphics.Vulkan
                 DstAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit,
             };
 
+            PipelineStageFlags pipelineStageFlags = PipelineStageFlags.VertexShaderBit | PipelineStageFlags.FragmentShaderBit;
+
+            if (Gd.Capabilities.SupportsGeometryShader)
+            {
+                pipelineStageFlags |= PipelineStageFlags.GeometryShaderBit;
+            }
+
+            if (Gd.Capabilities.SupportsTessellationShader)
+            {
+                pipelineStageFlags |= PipelineStageFlags.TessellationControlShaderBit | PipelineStageFlags.TessellationEvaluationShaderBit;
+            }
+
             Gd.Api.CmdPipelineBarrier(
                 CommandBuffer,
-                BarrierStageFlags,
-                BarrierStageFlags,
+                pipelineStageFlags,
+                pipelineStageFlags,
                 0,
                 1,
                 memoryBarrier,

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -9,8 +9,12 @@ namespace Ryujinx.Graphics.Vulkan
 {
     static class PipelineConverter
     {
-        private const AccessFlags SubpassSrcAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit | AccessFlags.ColorAttachmentWriteBit;
-        private const AccessFlags SubpassDstAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit | AccessFlags.ShaderReadBit;
+        private const AccessFlags SubpassAccessMask =
+            AccessFlags.MemoryReadBit |
+            AccessFlags.MemoryWriteBit |
+            AccessFlags.ShaderReadBit |
+            AccessFlags.ColorAttachmentWriteBit |
+            AccessFlags.DepthStencilAttachmentWriteBit;
 
         public static unsafe DisposableRenderPass ToRenderPass(this ProgramPipelineState state, VulkanRenderer gd, Device device)
         {
@@ -132,8 +136,8 @@ namespace Ryujinx.Graphics.Vulkan
                 0,
                 PipelineStageFlags.AllGraphicsBit,
                 PipelineStageFlags.AllGraphicsBit,
-                SubpassSrcAccessMask,
-                SubpassDstAccessMask,
+                SubpassAccessMask,
+                SubpassAccessMask,
                 0);
         }
 
@@ -146,8 +150,8 @@ namespace Ryujinx.Graphics.Vulkan
                 0,
                 PipelineStageFlags.AllGraphicsBit,
                 PipelineStageFlags.AllGraphicsBit,
-                SubpassSrcAccessMask,
-                SubpassDstAccessMask,
+                SubpassAccessMask,
+                SubpassAccessMask,
                 0);
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
@@ -146,7 +146,10 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void RecordScissor(Vk api, CommandBuffer commandBuffer)
         {
-            api.CmdSetScissor(commandBuffer, 0, (uint)ScissorsCount, _scissors.AsSpan());
+            if (ScissorsCount != 0)
+            {
+                api.CmdSetScissor(commandBuffer, 0, (uint)ScissorsCount, _scissors.AsSpan());
+            }
         }
 
         private readonly void RecordStencilMasks(Vk api, CommandBuffer commandBuffer)

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -444,21 +444,13 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_lastReadAccess != AccessFlags.None)
             {
-                ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
-
                 TextureView.InsertImageBarrier(
                     _gd.Api,
                     cbs.CommandBuffer,
-                    _imageAuto.Get(cbs).Value,
                     _lastReadAccess,
                     dstAccessFlags,
                     _lastReadStage,
-                    dstStageFlags,
-                    aspectFlags,
-                    0,
-                    0,
-                    _info.GetLayers(),
-                    _info.Levels);
+                    dstStageFlags);
 
                 _lastReadAccess = AccessFlags.None;
                 _lastReadStage = PipelineStageFlags.None;
@@ -472,21 +464,13 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.None)
             {
-                ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
-
                 TextureView.InsertImageBarrier(
                     _gd.Api,
                     cbs.CommandBuffer,
-                    _imageAuto.Get(cbs).Value,
                     _lastModificationAccess,
                     dstAccessFlags,
                     _lastModificationStage,
-                    dstStageFlags,
-                    aspectFlags,
-                    0,
-                    0,
-                    _info.GetLayers(),
-                    _info.Levels);
+                    dstStageFlags);
 
                 _lastModificationAccess = AccessFlags.None;
             }

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -444,7 +444,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_lastReadAccess != AccessFlags.None)
             {
-                TextureView.InsertImageBarrier(
+                TextureView.InsertMemoryBarrier(
                     _gd.Api,
                     cbs.CommandBuffer,
                     _lastReadAccess,
@@ -464,7 +464,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.None)
             {
-                TextureView.InsertImageBarrier(
+                TextureView.InsertMemoryBarrier(
                     _gd.Api,
                     cbs.CommandBuffer,
                     _lastModificationAccess,

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sampleCountFlags = ConvertToSampleCountFlags(gd.Capabilities.SupportedSampleCounts, (uint)info.Samples);
 
-            var usage = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample, forceStorage: true);
+            var usage = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
 
             var flags = ImageCreateFlags.CreateMutableFormatBit;
 
@@ -291,7 +291,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public static ImageUsageFlags GetImageUsage(Format format, Target target, bool supportsMsStorage, bool forceStorage = false)
+        public static ImageUsageFlags GetImageUsage(Format format, Target target, bool supportsMsStorage)
         {
             var usage = DefaultUsageFlags;
 
@@ -304,7 +304,7 @@ namespace Ryujinx.Graphics.Vulkan
                 usage |= ImageUsageFlags.ColorAttachmentBit;
             }
 
-            if (((forceStorage && !format.IsDepthOrStencil()) || format.IsImageCompatible()) && (supportsMsStorage || !target.IsMultisample()))
+            if (format.IsImageCompatible() && (supportsMsStorage || !target.IsMultisample()))
             {
                 usage |= ImageUsageFlags.StorageBit;
             }

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -438,6 +438,34 @@ namespace Ryujinx.Graphics.Vulkan
         public static unsafe void InsertImageBarrier(
             Vk api,
             CommandBuffer commandBuffer,
+            AccessFlags srcAccessMask,
+            AccessFlags dstAccessMask,
+            PipelineStageFlags srcStageMask,
+            PipelineStageFlags dstStageMask)
+        {
+            MemoryBarrier memoryBarrier = new()
+            {
+                SType = StructureType.MemoryBarrier,
+                SrcAccessMask = srcAccessMask,
+                DstAccessMask = dstAccessMask,
+            };
+
+            api.CmdPipelineBarrier(
+                commandBuffer,
+                srcStageMask,
+                dstStageMask,
+                DependencyFlags.None,
+                1,
+                memoryBarrier,
+                0,
+                null,
+                0,
+                null);
+        }
+
+        public static unsafe void InsertImageBarrier(
+            Vk api,
+            CommandBuffer commandBuffer,
             Image image,
             AccessFlags srcAccessMask,
             AccessFlags dstAccessMask,

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -435,7 +435,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ImageAspectFlags.ColorBit);
         }
 
-        public static unsafe void InsertImageBarrier(
+        public static unsafe void InsertMemoryBarrier(
             Vk api,
             CommandBuffer commandBuffer,
             AccessFlags srcAccessMask,

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -327,6 +327,7 @@ namespace Ryujinx.Graphics.Vulkan
                 features2.Features.OcclusionQueryPrecise,
                 _physicalDevice.PhysicalDeviceFeatures.PipelineStatisticsQuery,
                 _physicalDevice.PhysicalDeviceFeatures.GeometryShader,
+                _physicalDevice.PhysicalDeviceFeatures.TessellationShader,
                 _physicalDevice.IsDeviceExtensionPresent("VK_NV_viewport_array2"),
                 _physicalDevice.IsDeviceExtensionPresent(ExtExternalMemoryHost.ExtensionName),
                 supportsDepthClipControl && featuresDepthClipControl.DepthClipControl,


### PR DESCRIPTION
Overview
---

This change aims to reduce the validation error spam that happens when using the Vulkan backend with validation and error logging enabled right now, to make debugging easier, and potentially fix issues on some platforms.

Each commit fixes a different error, so I will explain what each of them fixes individually, in commit order:

- 1st change fixes the following barrier error:
> vkCmdPipelineBarrier(): pImageMemoryBarriers[0].image Barrier for VkImage 0xee74570000000a8a[] does not match an image from the current VkFramebuffer 0x7803750000000ae7[]. The Vulkan spec states: If fname:vkCmdPipelineBarrier is called within a render pass instance using a VkRenderPass object, the image member of any image memory barrier included in this command must be an attachment used in the current subpass both as an input attachment, and as either a color or depth/stencil attachment

When image barrier are used with an active render pass, the image must be one of the render pass input and output attachments. We can't really ensure that since the image might have been rendered on a previous render pass. This change fixes the issue by replacing the image barrier usage with a more generic memory barrier, that does not trigger the error, but *could possibly have performance implications*. So that will need testing on different games/GPUs.

- 2nd change fixes a image creation error:
> vkCreateImage(): Format VK_FORMAT_BC3_UNORM_BLOCK is not supported for this combination of parameters and VkGetPhysicalDeviceImageFormatProperties returned back VK_ERROR_FORMAT_NOT_SUPPORTED. The Vulkan spec states: Each of the following values (as described in Image Creation Limits) must not be undefined : imageCreateMaxMipLevels, imageCreateMaxArrayLayers, imageCreateMaxExtent, and imageCreateSampleCounts

Actually I think I added this one to fix another validation error. But setting the storage image bit for compressed textures is not valid, so I made it only set that flag for images that are considered "image compatible".

- 3rd change fixes another barrier related error:
> vkCmdPipelineBarrier(): pMemoryBarriers[0].dstAccessMask (0x100) is not a subset of VkSubpassDependency dstAccessMask of subpass 0 of VkRenderPass 0xac95f0000000249a[]. Candidate VkSubpassDependency are pDependencies entries [0]. The Vulkan spec states: If fname:vkCmdPipelineBarrier is called within a render pass instance using a VkRenderPass object, the render pass must have been created with at least one subpass dependency that expresses a dependency from the current subpass to itself, does not include VK_DEPENDENCY_BY_REGION_BIT if this command does not, and has synchronization scopes and access scopes that are all supersets of the scopes defined in this command

- 4th one stops calls to `vkCmdSetScissors` with a scissor count of zeor:
> vkCmdSetScissor: parameter scissorCount must be greater than 0. The Vulkan spec states: scissorCount must be greater than 0

Should be pretty self explanatory. The same thing was already being done for viewports.

- 5th one fixes a semaphore validation error:
> vkAcquireNextImageKHR: Semaphore must not be currently signaled. The Vulkan spec states: If semaphore is not VK_NULL_HANDLE it must be unsignaled

I think that was wrong in general since each swapchain image should have a separate semaphore, otherwise it could present the image before it is ready.

Read to write barriers (for clears) might specify color attachment in the destination access mask, but that flag was missing on the subpass dependency. So I updated the subpass dependency to use the same flag as both source and destination access, since the barriers work both ways now (read to write and write to read).

- 6th one fixes yet another barrier related error:
> vkCmdPipelineBarrier(): .srcStageMask (0x880) is not a subset of VkSubpassDependency srcAccessMask for any self-dependency of subpass 0 of VkRenderPass 0xd35cce0000006742[] for which dstAccessMask is also a subset. Candidate VkSubpassDependency are pDependencies entries [0].

It was possible it would try to insert a read to write barrier where one of the source stages is a compute shader. This is not valid because the subpass dependency does not include compute, and it is not possible to include compute as the subpass dependency can only have graphics stages. It was fixed by removing the compute bit, but that is not really ideal, so suggestions are welcome too.

- Last one does not actually fix a validation error, but that barrier was generally wrong for a long time.

`Pipeline.Barrier ` is supposed to be a generic barrier, but the only stage specified was the fragment shader. I changed it to include all shader stages except compute (which is not part of the subpass dependency). Maybe it should include compute too when not inside a render pass?

---

With this change, some simple 2D games can now run with no validation errors on Vulkan. After this, I plan to fix other validation errors that show on more complex games.

What to test
---

This makes changes to barriers, so it needs to be tested for performance or visual regressions on different games and GPU vendors. Xenoblade might be a good game to check for performance regression since from what I recall, it makes heavy use of barriers.
