### PR TITLE
Add SmallChange properties to all sliders.

### DIFF
--- a/src/Ryujinx.Ava/UI/Views/Input/ControllerInputView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Input/ControllerInputView.axaml
@@ -465,6 +465,7 @@
                                         Maximum="1"
                                         TickFrequency="0.01"
                                         IsSnapToTickEnabled="True"
+                                        SmallChange="0.01"
                                         Minimum="0"
                                         Value="{ReflectionBinding Configuration.DeadzoneLeft, Mode=TwoWay}" />
                                     <TextBlock
@@ -484,6 +485,7 @@
                                         Maximum="2"
                                         TickFrequency="0.01"
                                         IsSnapToTickEnabled="True"
+                                        SmallChange="0.01"
                                         Minimum="0"
                                         Value="{ReflectionBinding Configuration.RangeLeft, Mode=TwoWay}" />
                                     <TextBlock
@@ -607,6 +609,7 @@
                                 Maximum="1"
                                 TickFrequency="0.01"
                                 IsSnapToTickEnabled="True"
+                                SmallChange="0.01"
                                 Minimum="0"
                                 Value="{ReflectionBinding Configuration.TriggerThreshold, Mode=TwoWay}" />
                             <TextBlock
@@ -1085,6 +1088,7 @@
                                         Maximum="1"
                                         TickFrequency="0.01"
                                         IsSnapToTickEnabled="True"
+                                        SmallChange="0.01"
                                         Padding="0"
                                         VerticalAlignment="Center"
                                         Minimum="0"
@@ -1106,6 +1110,7 @@
                                         Maximum="2"
                                         TickFrequency="0.01"
                                         IsSnapToTickEnabled="True"
+                                        SmallChange="0.01"
                                         Minimum="0"
                                         Value="{ReflectionBinding Configuration.RangeRight, Mode=TwoWay}" />
                                     <TextBlock

--- a/src/Ryujinx.Ava/UI/Views/Input/MotionInputView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Input/MotionInputView.axaml
@@ -29,6 +29,7 @@
                     MaxWidth="150"
                     TickFrequency="0.01"
                     IsSnapToTickEnabled="True"
+                    SmallChange="0.01"
                     Maximum="100"
                     Minimum="0"
                     Value="{Binding Sensitivity, Mode=TwoWay}" />
@@ -50,6 +51,7 @@
                     MaxWidth="150"
                     TickFrequency="0.01"
                     IsSnapToTickEnabled="True"
+                    SmallChange="0.01"
                     Maximum="100"
                     Minimum="0"
                     Value="{Binding GyroDeadzone, Mode=TwoWay}" />

--- a/src/Ryujinx.Ava/UI/Views/Input/RumbleInputView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Input/RumbleInputView.axaml
@@ -26,6 +26,7 @@
                     Width="200"
                     TickFrequency="0.01"
                     IsSnapToTickEnabled="True"
+                    SmallChange="0.01"
                     Maximum="10"
                     Minimum="0"
                     Value="{Binding StrongRumble, Mode=TwoWay}" />
@@ -47,6 +48,7 @@
                     Maximum="10"
                     TickFrequency="0.01"
                     IsSnapToTickEnabled="True"
+                    SmallChange="0.01"
                     Minimum="0"
                     Value="{Binding WeakRumble, Mode=TwoWay}" />
                 <TextBlock

--- a/src/Ryujinx.Ava/UI/Views/Main/MainViewControls.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Main/MainViewControls.axaml
@@ -56,6 +56,7 @@
             Margin="5,-10,5,0"
             VerticalAlignment="Center"
             IsSnapToTickEnabled="True"
+            SmallChange="1"
             Maximum="4"
             Minimum="1"
             TickFrequency="1"


### PR DESCRIPTION
Avalonia will use the `SmallChange` property by default when using a keyboard input. If this isn't present it will simply snap to the `Minimum` and `Maximum` values.