### PR TITLE
opus: Implement GetWorkBufferSizeExEx and GetWorkBufferSizeForMultiStreamExEx

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
@@ -154,6 +154,28 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
+        [CommandCmif(8)] // 16.0.0+
+        // GetWorkBufferSizeExEx(OpusParametersEx) -> u32
+        public ResultCode GetWorkBufferSizeExEx(ServiceCtx context)
+        {
+            // NOTE: GetWorkBufferSizeEx use hardcoded values to compute the returned size.
+            //       GetWorkBufferSizeExEx fixes that by using dynamic values.
+            //       Since we already doing that, it's fine the call it directly.
+
+            return GetWorkBufferSizeEx(context);
+        }
+
+        [CommandCmif(9)] // 16.0.0+
+        // GetWorkBufferSizeForMultiStreamExEx(buffer<unknown<0x118>, 0x19>) -> u32
+        public ResultCode GetWorkBufferSizeForMultiStreamExEx(ServiceCtx context)
+        {
+            // NOTE: GetWorkBufferSizeForMultiStreamEx use hardcoded values to compute the returned size.
+            //       GetWorkBufferSizeForMultiStreamExEx fixes that by using dynamic values.
+            //       Since we already doing that, it's fine the call it directly.
+
+            return GetWorkBufferSizeForMultiStreamEx(context);
+        }
+
         private static int GetOpusMultistreamDecoderSize(int streams, int coupledStreams)
         {
             if (streams < 1 || coupledStreams > streams || coupledStreams < 0)

--- a/src/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             // NOTE: GetWorkBufferSizeEx use hardcoded values to compute the returned size.
             //       GetWorkBufferSizeExEx fixes that by using dynamic values.
-            //       Since we already doing that, it's fine the call it directly.
+            //       Since we're already doing that, it's fine to call it directly.
 
             return GetWorkBufferSizeEx(context);
         }
@@ -171,7 +171,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             // NOTE: GetWorkBufferSizeForMultiStreamEx use hardcoded values to compute the returned size.
             //       GetWorkBufferSizeForMultiStreamExEx fixes that by using dynamic values.
-            //       Since we already doing that, it's fine the call it directly.
+            //       Since we're already doing that, it's fine to call it directly.
 
             return GetWorkBufferSizeForMultiStreamEx(context);
         }


### PR DESCRIPTION
This implement `GetWorkBufferSizeExEx` and `GetWorkBufferSizeForMultiStreamExEx` for `IHardwareOpusDecoderManager`.
A proper fix would be to reimplement the whole service based on the RE, but it should be fine as-is.
Everything is checked by RE.

Fixes Sea of Stars which is playable now:
![image](https://github.com/Ryujinx/Ryujinx/assets/4905390/8bd53172-2b48-48b0-b07f-c34f5d5f9f29)
