### PR TITLE
Delete ResourceAccess

### DIFF
--- a/src/Ryujinx.Graphics.GAL/ResourceLayout.cs
+++ b/src/Ryujinx.Graphics.GAL/ResourceLayout.cs
@@ -15,14 +15,6 @@ namespace Ryujinx.Graphics.GAL
         BufferImage,
     }
 
-    public enum ResourceAccess : byte
-    {
-        None = 0,
-        Read = 1,
-        Write = 2,
-        ReadWrite = Read | Write,
-    }
-
     [Flags]
     public enum ResourceStages : byte
     {
@@ -81,19 +73,17 @@ namespace Ryujinx.Graphics.GAL
         public int Binding { get; }
         public ResourceType Type { get; }
         public ResourceStages Stages { get; }
-        public ResourceAccess Access { get; }
 
-        public ResourceUsage(int binding, ResourceType type, ResourceStages stages, ResourceAccess access)
+        public ResourceUsage(int binding, ResourceType type, ResourceStages stages)
         {
             Binding = binding;
             Type = type;
             Stages = stages;
-            Access = access;
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Binding, Type, Stages, Access);
+            return HashCode.Combine(Binding, Type, Stages);
         }
 
         public override bool Equals(object obj)
@@ -103,7 +93,7 @@ namespace Ryujinx.Graphics.GAL
 
         public bool Equals(ResourceUsage other)
         {
-            return Binding == other.Binding && Type == other.Type && Stages == other.Stages && Access == other.Access;
+            return Binding == other.Binding && Type == other.Type && Stages == other.Stages;
         }
 
         public static bool operator ==(ResourceUsage left, ResourceUsage right)

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeContext.cs
@@ -490,10 +490,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         /// </summary>
         /// <param name="offset">Offset of the range</param>
         /// <param name="size">Size of the range in bytes</param>
+        /// <param name="write">Indicates if the buffer contents will be modified</param>
         /// <returns>Range</returns>
-        public BufferRange GetVertexDataBufferRange(int offset, int size)
+        public BufferRange GetVertexDataBufferRange(int offset, int size, bool write)
         {
-            return new BufferRange(_vertexDataBuffer.Handle, offset, size);
+            return new BufferRange(_vertexDataBuffer.Handle, offset, size, write);
         }
 
         /// <summary>
@@ -501,10 +502,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         /// </summary>
         /// <param name="offset">Offset of the range</param>
         /// <param name="size">Size of the range in bytes</param>
+        /// <param name="write">Indicates if the buffer contents will be modified</param>
         /// <returns>Range</returns>
-        public BufferRange GetGeometryVertexDataBufferRange(int offset, int size)
+        public BufferRange GetGeometryVertexDataBufferRange(int offset, int size, bool write)
         {
-            return new BufferRange(_geometryVertexDataBuffer.Handle, offset, size);
+            return new BufferRange(_geometryVertexDataBuffer.Handle, offset, size, write);
         }
 
         /// <summary>
@@ -512,10 +514,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         /// </summary>
         /// <param name="offset">Offset of the range</param>
         /// <param name="size">Size of the range in bytes</param>
+        /// <param name="write">Indicates if the buffer contents will be modified</param>
         /// <returns>Range</returns>
-        public BufferRange GetGeometryIndexDataBufferRange(int offset, int size)
+        public BufferRange GetGeometryIndexDataBufferRange(int offset, int size, bool write)
         {
-            return new BufferRange(_geometryIndexDataBuffer.Handle, offset, size);
+            return new BufferRange(_geometryIndexDataBuffer.Handle, offset, size, write);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeState.cs
@@ -202,7 +202,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             _context.Renderer.Pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(vertexInfoBinding, vertexInfoRange) });
 
             int vertexDataBinding = _vertexAsCompute.Reservations.VertexOutputStorageBufferBinding;
-            BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize);
+            BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize, write: true);
             _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[] { new BufferAssignment(vertexDataBinding, vertexDataRange) });
 
             _vacContext.VertexInfoBufferUpdater.Commit();
@@ -245,9 +245,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             int geometryVbBinding = _geometryAsCompute.Reservations.GeometryVertexOutputStorageBufferBinding;
             int geometryIbBinding = _geometryAsCompute.Reservations.GeometryIndexOutputStorageBufferBinding;
 
-            BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize);
-            BufferRange vertexBuffer = _vacContext.GetGeometryVertexDataBufferRange(_geometryVertexDataOffset, _geometryVertexDataSize);
-            BufferRange indexBuffer = _vacContext.GetGeometryIndexDataBufferRange(_geometryIndexDataOffset, _geometryIndexDataSize);
+            BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize, write: false);
+            BufferRange vertexBuffer = _vacContext.GetGeometryVertexDataBufferRange(_geometryVertexDataOffset, _geometryVertexDataSize, write: true);
+            BufferRange indexBuffer = _vacContext.GetGeometryIndexDataBufferRange(_geometryIndexDataOffset, _geometryIndexDataSize, write: true);
 
             _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[]
             {
@@ -293,8 +293,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
 
             if (_geometryAsCompute != null)
             {
-                BufferRange vertexBuffer = _vacContext.GetGeometryVertexDataBufferRange(_geometryVertexDataOffset, _geometryVertexDataSize);
-                BufferRange indexBuffer = _vacContext.GetGeometryIndexDataBufferRange(_geometryIndexDataOffset, _geometryIndexDataSize);
+                BufferRange vertexBuffer = _vacContext.GetGeometryVertexDataBufferRange(_geometryVertexDataOffset, _geometryVertexDataSize, write: false);
+                BufferRange indexBuffer = _vacContext.GetGeometryIndexDataBufferRange(_geometryIndexDataOffset, _geometryIndexDataSize, write: false);
 
                 _context.Renderer.Pipeline.SetProgram(_vertexPassthroughProgram);
                 _context.Renderer.Pipeline.SetIndexBuffer(indexBuffer, IndexType.UInt);
@@ -310,7 +310,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             }
             else
             {
-                BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize);
+                BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize, write: false);
 
                 _context.Renderer.Pipeline.SetProgram(_vertexPassthroughProgram);
                 _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[] { new BufferAssignment(vertexDataBinding, vertexDataRange) });

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderInfoBuilder.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderInfoBuilder.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             }
 
             AddDescriptor(SupportBufferStages, ResourceType.UniformBuffer, UniformSetIndex, 0, 1);
-            AddUsage(SupportBufferStages, ResourceType.UniformBuffer, ResourceAccess.Read, UniformSetIndex, 0, 1);
+            AddUsage(SupportBufferStages, ResourceType.UniformBuffer, UniformSetIndex, 0, 1);
 
             ResourceReservationCounts rrc = new(!context.Capabilities.SupportsTransformFeedback && tfEnabled, vertexAsCompute);
 
@@ -73,16 +73,16 @@ namespace Ryujinx.Graphics.Gpu.Shader
             // TODO: Handle that better? Maybe we should only set the binding that are really needed on each shader.
             ResourceStages stages = vertexAsCompute ? ResourceStages.Compute | ResourceStages.Vertex : VtgStages;
 
-            PopulateDescriptorAndUsages(stages, ResourceType.UniformBuffer, ResourceAccess.Read, UniformSetIndex, 1, rrc.ReservedConstantBuffers - 1);
-            PopulateDescriptorAndUsages(stages, ResourceType.StorageBuffer, ResourceAccess.ReadWrite, StorageSetIndex, 0, rrc.ReservedStorageBuffers);
-            PopulateDescriptorAndUsages(stages, ResourceType.BufferTexture, ResourceAccess.Read, TextureSetIndex, 0, rrc.ReservedTextures);
-            PopulateDescriptorAndUsages(stages, ResourceType.BufferImage, ResourceAccess.ReadWrite, ImageSetIndex, 0, rrc.ReservedImages);
+            PopulateDescriptorAndUsages(stages, ResourceType.UniformBuffer, UniformSetIndex, 1, rrc.ReservedConstantBuffers - 1);
+            PopulateDescriptorAndUsages(stages, ResourceType.StorageBuffer, StorageSetIndex, 0, rrc.ReservedStorageBuffers);
+            PopulateDescriptorAndUsages(stages, ResourceType.BufferTexture, TextureSetIndex, 0, rrc.ReservedTextures);
+            PopulateDescriptorAndUsages(stages, ResourceType.BufferImage, ImageSetIndex, 0, rrc.ReservedImages);
         }
 
-        private void PopulateDescriptorAndUsages(ResourceStages stages, ResourceType type, ResourceAccess access, int setIndex, int start, int count)
+        private void PopulateDescriptorAndUsages(ResourceStages stages, ResourceType type, int setIndex, int start, int count)
         {
             AddDescriptor(stages, type, setIndex, start, count);
-            AddUsage(stages, type, access, setIndex, start, count);
+            AddUsage(stages, type, setIndex, start, count);
         }
 
         /// <summary>
@@ -174,15 +174,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// </summary>
         /// <param name="stages">Shader stages where the resource is used</param>
         /// <param name="type">Type of the resource</param>
-        /// <param name="access">How the resource is accessed by the shader stages where it is used</param>
         /// <param name="setIndex">Descriptor set number where the resource will be bound</param>
         /// <param name="binding">Binding number where the resource will be bound</param>
         /// <param name="count">Number of resources bound at the binding location</param>
-        private void AddUsage(ResourceStages stages, ResourceType type, ResourceAccess access, int setIndex, int binding, int count)
+        private void AddUsage(ResourceStages stages, ResourceType type, int setIndex, int binding, int count)
         {
             for (int index = 0; index < count; index++)
             {
-                _resourceUsages[setIndex].Add(new ResourceUsage(binding + index, type, stages, access));
+                _resourceUsages[setIndex].Add(new ResourceUsage(binding + index, type, stages));
             }
         }
 
@@ -200,8 +199,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 _resourceUsages[setIndex].Add(new ResourceUsage(
                     buffer.Binding,
                     isStorage ? ResourceType.StorageBuffer : ResourceType.UniformBuffer,
-                    stages,
-                    buffer.Flags.HasFlag(BufferUsageFlags.Write) ? ResourceAccess.ReadWrite : ResourceAccess.Read));
+                    stages));
             }
         }
 
@@ -225,8 +223,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 _resourceUsages[setIndex].Add(new ResourceUsage(
                     texture.Binding,
                     type,
-                    stages,
-                    texture.Flags.HasFlag(TextureUsageFlags.ImageStore) ? ResourceAccess.ReadWrite : ResourceAccess.Read));
+                    stages));
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/ResourceBindingSegment.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ResourceBindingSegment.cs
@@ -8,15 +8,13 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly int Count;
         public readonly ResourceType Type;
         public readonly ResourceStages Stages;
-        public readonly ResourceAccess Access;
 
-        public ResourceBindingSegment(int binding, int count, ResourceType type, ResourceStages stages, ResourceAccess access)
+        public ResourceBindingSegment(int binding, int count, ResourceType type, ResourceStages stages)
         {
             Binding = binding;
             Count = count;
             Type = type;
             Stages = stages;
-            Access = access;
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/ResourceLayoutBuilder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ResourceLayoutBuilder.cs
@@ -34,20 +34,10 @@ namespace Ryujinx.Graphics.Vulkan
                 _ => throw new ArgumentException($"Invalid resource type \"{type}\"."),
             };
 
-            ResourceAccess access = IsReadOnlyType(type) ? ResourceAccess.Read : ResourceAccess.ReadWrite;
-
             _resourceDescriptors[setIndex].Add(new ResourceDescriptor(binding, 1, type, stages));
-            _resourceUsages[setIndex].Add(new ResourceUsage(binding, type, stages, access));
+            _resourceUsages[setIndex].Add(new ResourceUsage(binding, type, stages));
 
             return this;
-        }
-
-        private static bool IsReadOnlyType(ResourceType type)
-        {
-            return type == ResourceType.UniformBuffer ||
-                   type == ResourceType.Sampler ||
-                   type == ResourceType.TextureAndSampler ||
-                   type == ResourceType.BufferTexture;
         }
 
         public ResourceLayout Build()

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -162,8 +162,7 @@ namespace Ryujinx.Graphics.Vulkan
                                 currentDescriptor.Binding,
                                 currentCount,
                                 currentDescriptor.Type,
-                                currentDescriptor.Stages,
-                                ResourceAccess.ReadWrite));
+                                currentDescriptor.Stages));
                         }
 
                         currentDescriptor = descriptor;
@@ -181,8 +180,7 @@ namespace Ryujinx.Graphics.Vulkan
                         currentDescriptor.Binding,
                         currentCount,
                         currentDescriptor.Type,
-                        currentDescriptor.Stages,
-                        ResourceAccess.ReadWrite));
+                        currentDescriptor.Stages));
                 }
 
                 segments[setIndex] = currentSegments.ToArray();
@@ -206,16 +204,9 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     ResourceUsage usage = setUsages[setIndex].Usages[index];
 
-                    // If the resource is not accessed, we don't need to update it.
-                    if (usage.Access == ResourceAccess.None)
-                    {
-                        continue;
-                    }
-
                     if (currentUsage.Binding + currentCount != usage.Binding ||
                         currentUsage.Type != usage.Type ||
-                        currentUsage.Stages != usage.Stages ||
-                        currentUsage.Access != usage.Access)
+                        currentUsage.Stages != usage.Stages)
                     {
                         if (currentCount != 0)
                         {
@@ -223,8 +214,7 @@ namespace Ryujinx.Graphics.Vulkan
                                 currentUsage.Binding,
                                 currentCount,
                                 currentUsage.Type,
-                                currentUsage.Stages,
-                                currentUsage.Access));
+                                currentUsage.Stages));
                         }
 
                         currentUsage = usage;
@@ -242,8 +232,7 @@ namespace Ryujinx.Graphics.Vulkan
                         currentUsage.Binding,
                         currentCount,
                         currentUsage.Type,
-                        currentUsage.Stages,
-                        currentUsage.Access));
+                        currentUsage.Stages));
                 }
 
                 segments[setIndex] = currentSegments.ToArray();


### PR DESCRIPTION
I added it to allow us to know if a resource is written from the shader on the backend, however #4899 added a bool on `BufferRange` that serves the same purpose, making it redundant, so this PR removes the `ResourceAccess` enum and all of its uses.

I also set the `write` bool to true now on the `BufferRange`s passed from vertex/geometry as compute where the buffers are modified from the shader. I don't think this makes any difference since those buffers are never modified from CPU, but it's technically the right thing to do.