### PR TITLE
Fix numeric SWKB validation

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -544,7 +544,7 @@
   "SwkbdMinCharacters": "Must be at least {0} characters long",
   "SwkbdMinRangeCharacters": "Must be {0}-{1} characters long",
   "SoftwareKeyboard": "Software Keyboard",
-  "SoftwareKeyboardModeNumbersOnly": "Must be numbers only",
+  "SoftwareKeyboardModeNumeric": "Must be 0-9 or '.' only",
   "SoftwareKeyboardModeAlphabet": "Must be non CJK-characters only",
   "SoftwareKeyboardModeASCII": "Must be ASCII text only",
   "DialogControllerAppletMessagePlayerRange": "Application requests {0} player(s) with:\n\nTYPES: {1}\n\nPLAYERS: {2}\n\n{3}Please open Settings and reconfigure Input now or press Close.",

--- a/src/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
@@ -136,10 +136,10 @@ namespace Ryujinx.Ava.UI.Controls
             string localeText;
             switch (mode)
             {
-                case KeyboardMode.NumbersOnly:
-                    localeText = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.SoftwareKeyboardModeNumbersOnly);
+                case KeyboardMode.Numeric:
+                    localeText = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.SoftwareKeyboardModeNumeric);
                     validationInfoText = string.IsNullOrEmpty(validationInfoText) ? localeText : string.Join("\n", validationInfoText, localeText);
-                    _checkInput = text => text.All(char.IsDigit);
+                    _checkInput = text => text.All(NumericCharacterValidation.IsNumeric);
                     break;
                 case KeyboardMode.Alphabet:
                     localeText = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.SoftwareKeyboardModeAlphabet);

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/KeyboardMode.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/KeyboardMode.cs
@@ -11,9 +11,9 @@
         Default = 0,
 
         /// <summary>
-        /// Only numbers allowed.
+        /// Only 0-9 or '.' allowed.
         /// </summary>
-        NumbersOnly = 1,
+        Numeric = 1,
 
         /// <summary>
         /// Only ASCII characters allowed.

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/NumericCharacterValidation.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/NumericCharacterValidation.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    public static partial class NumericCharacterValidation
+    {
+        public static bool IsNumeric(char value)
+        {
+            Regex regex = NumericRegex();
+
+            return regex.IsMatch(value.ToString());
+        }
+
+        [GeneratedRegex("[0-9]|.")]
+        private static partial Regex NumericRegex();
+    }
+}

--- a/src/Ryujinx/Ui/Applet/SwkbdAppletDialog.cs
+++ b/src/Ryujinx/Ui/Applet/SwkbdAppletDialog.cs
@@ -91,8 +91,8 @@ namespace Ryujinx.Ui.Applet
             switch (mode)
             {
                 case KeyboardMode.Numeric:
-                    _validationInfoText += "<i>Must be numbers only.</i>";
-                    _checkInput = text => text.All(char.IsDigit);
+                    _validationInfoText += "<i>Must be 0-9 or '.' only.</i>";
+                    _checkInput = text => text.All(NumericCharacterValidation.IsNumeric);
                     break;
                 case KeyboardMode.Alphabet:
                     _validationInfoText += "<i>Must be non CJK-characters only.</i>";

--- a/src/Ryujinx/Ui/Applet/SwkbdAppletDialog.cs
+++ b/src/Ryujinx/Ui/Applet/SwkbdAppletDialog.cs
@@ -90,7 +90,7 @@ namespace Ryujinx.Ui.Applet
 
             switch (mode)
             {
-                case KeyboardMode.NumbersOnly:
+                case KeyboardMode.Numeric:
                     _validationInfoText += "<i>Must be numbers only.</i>";
                     _checkInput = text => text.All(char.IsDigit);
                     break;


### PR DESCRIPTION
Pip pointed out that this was too restrictive. Numeric is used for situations like manual IP address and DNS setting, in which case numbers `0-9` AND `.` must be valid characters.

- Fixes SMOO IP address selection