### PR TITLE
Fix ShaderTools GpuAcessor default values

### DIFF
--- a/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -128,7 +128,26 @@ namespace Ryujinx.Graphics.Shader
         /// <returns>GPU graphics state</returns>
         GpuGraphicsState QueryGraphicsState()
         {
-            return default;
+            return new GpuGraphicsState(
+                false,
+                InputTopology.Points,
+                false,
+                TessPatchType.Triangles,
+                TessSpacing.EqualSpacing,
+                false,
+                false,
+                false,
+                false,
+                false,
+                1f,
+                AlphaTestOp.Always,
+                0f,
+                default,
+                true,
+                default,
+                false,
+                false,
+                false);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes a regression from #5509 that caused ShaderTools to assert in debug mode and produce "incorrect" code on release due to the default graphics state being invalid. No user visible effect, only affect ShaderTools not the emulator itself.

Closes #5644.