### PR TITLE
Add VTimer as alternative interrupt method on Apple Hypervisor

### DIFF
--- a/src/Ryujinx.Cpu/AppleHv/HvAddressSpace.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvAddressSpace.cs
@@ -1,9 +1,11 @@
 using Ryujinx.Cpu.AppleHv.Arm;
 using Ryujinx.Memory;
 using System;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvAddressSpace : IDisposable
     {
         private const ulong KernelRegionBase = unchecked((ulong)-(1L << 39));

--- a/src/Ryujinx.Cpu/AppleHv/HvAddressSpaceRange.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvAddressSpaceRange.cs
@@ -2,10 +2,12 @@ using Ryujinx.Cpu.AppleHv.Arm;
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvAddressSpaceRange : IDisposable
     {
         private const ulong AllocationGranule = 1UL << 14;

--- a/src/Ryujinx.Cpu/AppleHv/HvApi.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvApi.cs
@@ -12,10 +12,18 @@ namespace Ryujinx.Cpu.AppleHv
 #pragma warning restore CS0649
     }
 
+    enum HvExitReason : uint
+    {
+        Canceled,
+        Exception,
+        VTimerActivated,
+        Unknown,
+    }
+
     struct HvVcpuExit
     {
 #pragma warning disable CS0649 // Field is never assigned to
-        public uint Reason;
+        public HvExitReason Reason;
         public HvVcpuExitException Exception;
 #pragma warning restore CS0649
     }

--- a/src/Ryujinx.Cpu/AppleHv/HvApi.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
@@ -263,6 +264,7 @@ namespace Ryujinx.Cpu.AppleHv
         }
     }
 
+    [SupportedOSPlatform("macos")]
     static partial class HvApi
     {
         public const string LibraryName = "/System/Library/Frameworks/Hypervisor.framework/Hypervisor";

--- a/src/Ryujinx.Cpu/AppleHv/HvCpuContext.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvCpuContext.cs
@@ -1,7 +1,9 @@
 using ARMeilleure.Memory;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvCpuContext : ICpuContext
     {
         private readonly ITickSource _tickSource;

--- a/src/Ryujinx.Cpu/AppleHv/HvEngine.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvEngine.cs
@@ -1,7 +1,9 @@
 using ARMeilleure.Memory;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     public class HvEngine : ICpuEngine
     {
         private readonly ITickSource _tickSource;

--- a/src/Ryujinx.Cpu/AppleHv/HvExecutionContext.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvExecutionContext.cs
@@ -2,6 +2,7 @@ using ARMeilleure.State;
 using Ryujinx.Cpu.AppleHv.Arm;
 using Ryujinx.Memory.Tracking;
 using System;
+using System.Threading;
 
 namespace Ryujinx.Cpu.AppleHv
 {
@@ -67,6 +68,8 @@ namespace Ryujinx.Cpu.AppleHv
 
         private readonly ExceptionCallbacks _exceptionCallbacks;
 
+        private int _interruptRequested;
+
         public HvExecutionContext(ICounter counter, ExceptionCallbacks exceptionCallbacks)
         {
             _counter = counter;
@@ -111,7 +114,15 @@ namespace Ryujinx.Cpu.AppleHv
         /// <inheritdoc/>
         public void RequestInterrupt()
         {
-            _impl.RequestInterrupt();
+            if (Interlocked.Exchange(ref _interruptRequested, 1) == 0 && _impl is HvExecutionContextVcpu impl)
+            {
+                impl.RequestInterrupt();
+            }
+        }
+
+        private bool GetAndClearInterruptRequested()
+        {
+            return Interlocked.Exchange(ref _interruptRequested, 0) != 0;
         }
 
         /// <inheritdoc/>
@@ -131,9 +142,9 @@ namespace Ryujinx.Cpu.AppleHv
             {
                 HvApi.hv_vcpu_run(vcpu.Handle).ThrowOnError();
 
-                uint reason = vcpu.ExitInfo->Reason;
+                HvExitReason reason = vcpu.ExitInfo->Reason;
 
-                if (reason == 1)
+                if (reason == HvExitReason.Exception)
                 {
                     uint hvEsr = (uint)vcpu.ExitInfo->Exception.Syndrome;
                     ExceptionClass hvEc = (ExceptionClass)(hvEsr >> 26);
@@ -146,13 +157,21 @@ namespace Ryujinx.Cpu.AppleHv
                     address = SynchronousException(memoryManager, ref vcpu);
                     HvApi.hv_vcpu_set_reg(vcpu.Handle, HvReg.PC, address).ThrowOnError();
                 }
-                else if (reason == 0)
+                else if (reason == HvExitReason.Canceled || reason == HvExitReason.VTimerActivated)
                 {
-                    if (_impl.GetAndClearInterruptRequested())
+                    if (GetAndClearInterruptRequested())
                     {
                         ReturnToPool(vcpu);
                         InterruptHandler();
                         vcpu = RentFromPool(memoryManager.AddressSpace, vcpu);
+                    }
+
+                    if (reason == HvExitReason.VTimerActivated)
+                    {
+                        vcpu.EnableAndUpdateVTimer();
+
+                        // Unmask VTimer interrupts.
+                        HvApi.hv_vcpu_set_vtimer_mask(vcpu.Handle, false);
                     }
                 }
                 else

--- a/src/Ryujinx.Cpu/AppleHv/HvExecutionContext.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvExecutionContext.cs
@@ -171,7 +171,7 @@ namespace Ryujinx.Cpu.AppleHv
                         vcpu.EnableAndUpdateVTimer();
 
                         // Unmask VTimer interrupts.
-                        HvApi.hv_vcpu_set_vtimer_mask(vcpu.Handle, false);
+                        HvApi.hv_vcpu_set_vtimer_mask(vcpu.Handle, false).ThrowOnError();
                     }
                 }
                 else

--- a/src/Ryujinx.Cpu/AppleHv/HvExecutionContext.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvExecutionContext.cs
@@ -2,10 +2,12 @@ using ARMeilleure.State;
 using Ryujinx.Cpu.AppleHv.Arm;
 using Ryujinx.Memory.Tracking;
 using System;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvExecutionContext : IExecutionContext
     {
         /// <inheritdoc/>

--- a/src/Ryujinx.Cpu/AppleHv/HvExecutionContextShadow.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvExecutionContextShadow.cs
@@ -46,14 +46,5 @@ namespace Ryujinx.Cpu.AppleHv
         {
             _v[index] = value;
         }
-
-        public void RequestInterrupt()
-        {
-        }
-
-        public bool GetAndClearInterruptRequested()
-        {
-            return false;
-        }
     }
 }

--- a/src/Ryujinx.Cpu/AppleHv/HvExecutionContextVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvExecutionContextVcpu.cs
@@ -2,7 +2,6 @@ using ARMeilleure.State;
 using Ryujinx.Memory;
 using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Ryujinx.Cpu.AppleHv
 {
@@ -135,7 +134,6 @@ namespace Ryujinx.Cpu.AppleHv
         }
 
         private readonly ulong _vcpu;
-        private int _interruptRequested;
 
         public HvExecutionContextVcpu(ulong vcpu)
         {
@@ -181,16 +179,8 @@ namespace Ryujinx.Cpu.AppleHv
 
         public void RequestInterrupt()
         {
-            if (Interlocked.Exchange(ref _interruptRequested, 1) == 0)
-            {
-                ulong vcpu = _vcpu;
-                HvApi.hv_vcpus_exit(ref vcpu, 1);
-            }
-        }
-
-        public bool GetAndClearInterruptRequested()
-        {
-            return Interlocked.Exchange(ref _interruptRequested, 0) != 0;
+            ulong vcpu = _vcpu;
+            HvApi.hv_vcpus_exit(ref vcpu, 1);
         }
     }
 }

--- a/src/Ryujinx.Cpu/AppleHv/HvExecutionContextVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvExecutionContextVcpu.cs
@@ -2,9 +2,11 @@ using ARMeilleure.State;
 using Ryujinx.Memory;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvExecutionContextVcpu : IHvExecutionContext
     {
         private static readonly MemoryBlock _setSimdFpRegFuncMem;

--- a/src/Ryujinx.Cpu/AppleHv/HvMemoryBlockAllocation.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvMemoryBlockAllocation.cs
@@ -1,8 +1,10 @@
 using Ryujinx.Memory;
 using System;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     readonly struct HvMemoryBlockAllocation : IDisposable
     {
         private readonly HvMemoryBlockAllocator _owner;

--- a/src/Ryujinx.Cpu/AppleHv/HvMemoryBlockAllocator.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvMemoryBlockAllocator.cs
@@ -1,7 +1,9 @@
 using Ryujinx.Memory;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvMemoryBlockAllocator : PrivateMemoryAllocatorImpl<HvMemoryBlockAllocator.Block>
     {
         public class Block : PrivateMemoryAllocator.Block

--- a/src/Ryujinx.Cpu/AppleHv/HvMemoryManager.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvMemoryManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace Ryujinx.Cpu.AppleHv
@@ -14,6 +15,7 @@ namespace Ryujinx.Cpu.AppleHv
     /// <summary>
     /// Represents a CPU memory manager which maps guest virtual memory directly onto the Hypervisor page table.
     /// </summary>
+    [SupportedOSPlatform("macos")]
     public class HvMemoryManager : MemoryManagerBase, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
     {
         public const int PageBits = 12;

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
@@ -1,7 +1,13 @@
+using System.Diagnostics;
+
 namespace Ryujinx.Cpu.AppleHv
 {
     unsafe class HvVcpu
     {
+        private const ulong InterruptIntervalNs = 16 * 1000; // 16 ms
+
+        private static ulong _interruptTimeDeltaTicks = 0;
+
         public readonly ulong Handle;
         public readonly HvVcpuExit* ExitInfo;
         public readonly IHvExecutionContext ShadowContext;
@@ -20,6 +26,29 @@ namespace Ryujinx.Cpu.AppleHv
             ShadowContext = shadowContext;
             NativeContext = nativeContext;
             IsEphemeral = isEphemeral;
+        }
+
+        public void EnableAndUpdateVTimer()
+        {
+            // We need to ensure interrupts will be serviced,
+            // and for that we set up the VTime to trigger an interrupt at fixed intervals.
+
+            ulong deltaTicks = _interruptTimeDeltaTicks;
+
+            if (deltaTicks == 0)
+            {
+                // Calculate our time delta in ticks based on the current clock frequency.
+
+                int result = TimeApi.mach_timebase_info(out var timeBaseInfo);
+
+                Debug.Assert(result == 0);
+
+                deltaTicks = ((InterruptIntervalNs * timeBaseInfo.numer) + (timeBaseInfo.denom - 1)) / timeBaseInfo.denom;
+                _interruptTimeDeltaTicks = deltaTicks;
+            }
+
+            HvApi.hv_vcpu_set_sys_reg(Handle, HvSysReg.CNTV_CTL_EL0, 1).ThrowOnError();
+            HvApi.hv_vcpu_set_sys_reg(Handle, HvSysReg.CNTV_CVAL_EL0, TimeApi.mach_absolute_time() + deltaTicks).ThrowOnError();
         }
     }
 }

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     unsafe class HvVcpu
     {
         private const ulong InterruptIntervalNs = 16 * 1000000; // 16 ms

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.Cpu.AppleHv
 
                 Debug.Assert(result == 0);
 
-                deltaTicks = ((InterruptIntervalNs * timeBaseInfo.numer) + (timeBaseInfo.denom - 1)) / timeBaseInfo.denom;
+                deltaTicks = ((InterruptIntervalNs * timeBaseInfo.Numer) + (timeBaseInfo.Denom - 1)) / timeBaseInfo.Denom;
                 _interruptTimeDeltaTicks = deltaTicks;
             }
 

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.Cpu.AppleHv
 
                 Debug.Assert(result == 0);
 
-                deltaTicks = ((InterruptIntervalNs * timeBaseInfo.Numer) + (timeBaseInfo.Denom - 1)) / timeBaseInfo.Denom;
+                deltaTicks = ((InterruptIntervalNs * timeBaseInfo.Denom) + (timeBaseInfo.Numer - 1)) / timeBaseInfo.Numer;
                 _interruptTimeDeltaTicks = deltaTicks;
             }
 

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpu.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.Cpu.AppleHv
 {
     unsafe class HvVcpu
     {
-        private const ulong InterruptIntervalNs = 16 * 1000; // 16 ms
+        private const ulong InterruptIntervalNs = 16 * 1000000; // 16 ms
 
         private static ulong _interruptTimeDeltaTicks = 0;
 

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpuPool.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpuPool.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     class HvVcpuPool
     {
         // Since there's a limit on the number of VCPUs we can create,

--- a/src/Ryujinx.Cpu/AppleHv/HvVcpuPool.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVcpuPool.cs
@@ -81,6 +81,8 @@ namespace Ryujinx.Cpu.AppleHv
 
             HvVcpu vcpu = new(vcpuHandle, exitInfo, shadowContext, nativeContext, isEphemeral);
 
+            vcpu.EnableAndUpdateVTimer();
+
             return vcpu;
         }
 

--- a/src/Ryujinx.Cpu/AppleHv/HvVm.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvVm.cs
@@ -1,8 +1,10 @@
 using Ryujinx.Memory;
 using System;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
+    [SupportedOSPlatform("macos")]
     static class HvVm
     {
         // This alignment allows us to use larger blocks on the page table.

--- a/src/Ryujinx.Cpu/AppleHv/IHvExecutionContext.cs
+++ b/src/Ryujinx.Cpu/AppleHv/IHvExecutionContext.cs
@@ -2,7 +2,7 @@ using ARMeilleure.State;
 
 namespace Ryujinx.Cpu.AppleHv
 {
-    public interface IHvExecutionContext
+    interface IHvExecutionContext
     {
         ulong Pc { get; set; }
         ulong ElrEl1 { get; set; }

--- a/src/Ryujinx.Cpu/AppleHv/IHvExecutionContext.cs
+++ b/src/Ryujinx.Cpu/AppleHv/IHvExecutionContext.cs
@@ -39,8 +39,5 @@ namespace Ryujinx.Cpu.AppleHv
                 SetV(i, context.GetV(i));
             }
         }
-
-        void RequestInterrupt();
-        bool GetAndClearInterruptRequested();
     }
 }

--- a/src/Ryujinx.Cpu/AppleHv/TimeApi.cs
+++ b/src/Ryujinx.Cpu/AppleHv/TimeApi.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Cpu.AppleHv
 {
@@ -8,6 +9,7 @@ namespace Ryujinx.Cpu.AppleHv
         public uint Denom;
     }
 
+    [SupportedOSPlatform("macos")]
     static partial class TimeApi
     {
         [LibraryImport("libc", SetLastError = true)]

--- a/src/Ryujinx.Cpu/AppleHv/TimeApi.cs
+++ b/src/Ryujinx.Cpu/AppleHv/TimeApi.cs
@@ -2,10 +2,10 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.Cpu.AppleHv
 {
-    struct mach_timebase_info_t
+    struct MachTimebaseInfo
     {
-        public uint numer;
-        public uint denom;
+        public uint Numer;
+        public uint Denom;
     }
 
     static partial class TimeApi
@@ -14,6 +14,6 @@ namespace Ryujinx.Cpu.AppleHv
         public static partial ulong mach_absolute_time();
 
         [LibraryImport("libc", SetLastError = true)]
-        public static partial int mach_timebase_info(out mach_timebase_info_t info);
+        public static partial int mach_timebase_info(out MachTimebaseInfo info);
     }
 }

--- a/src/Ryujinx.Cpu/AppleHv/TimeApi.cs
+++ b/src/Ryujinx.Cpu/AppleHv/TimeApi.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Cpu.AppleHv
+{
+    struct mach_timebase_info_t
+    {
+        public uint numer;
+        public uint denom;
+    }
+
+    static partial class TimeApi
+    {
+        [LibraryImport("libc", SetLastError = true)]
+        public static partial ulong mach_absolute_time();
+
+        [LibraryImport("libc", SetLastError = true)]
+        public static partial int mach_timebase_info(out mach_timebase_info_t info);
+    }
+}


### PR DESCRIPTION
There are two ways (that I'm aware of, at least) to interrupt a VCPU on Apple Hypervisor. The most obvious one is the one that the emulator currently uses, calling `hv_vcpus_exit`. The second and slightly less efficient one is setting up a timer to interrupt the VCPU periodically.

The method that the emulator currently uses can miss interrupts in some cases. The most obvious case is when the thread is interrupted before it starts executing guest code again. Because it uses a VCPU pool, and it returns the VCPU to the pool when hadling guest interrupts (calling HLE kernel), there is no way to interrupt a VCPU at that time, so it just ignores the interrupt request. On top of that, I'm not sure how `hv_vcpus_exit` behaves if you call it before the guest code is running. For the emulator, it needs to interrupt even if `hv_vcpu_run` was not called yet, but it probably does nothing in this case.

So in order to address the case where the VCPU might not be interrupted, this implements the second approach mentioned before, setting up a virtual timer that will interrupt the VCPU periodically, which then gives it a chance to check if interrupts have been requested and service them. The `hv_vcpus_exit` approach is also still used, to allow the thread to be interrupted quickly if we can (and if we can't, the timer will interrupt it eventually, but right now it can take up to 16 ms, which is the timer interval currently being used).

This fixes softlocks and infinite loading screens on several games running on Hypervisor on macOS.

Here are a few examples.

**Persona 5 Scramble/Strikers:**
<img width="1392" alt="Captura de Tela 2023-09-07 às 11 38 57" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/c3ce69bc-df95-4a24-a80b-cfcdf6779471">
Before that change, it would freeze before reaching the title screen, even after several attempts.

**Bravely Default II:**
<img width="1392" alt="Captura de Tela 2023-09-07 às 11 51 22" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/b6ef628b-610f-4b6a-9397-442104e1cb0d">
<img width="1392" alt="Captura de Tela 2023-09-07 às 11 52 07" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/e92a43f3-07fc-4fde-a552-cfc23af973ee">
<img width="1392" alt="Captura de Tela 2023-09-07 às 11 52 24" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/5f5801bd-4e03-4e70-8465-052183d5de2c">
This one would usually freeze either before title screen or the introduction, I was never able to make it that far before this change.

**Life is Strange True Colors:**
<img width="1392" alt="Captura de Tela 2023-09-07 às 12 10 51" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/177c36c9-a688-4de1-97d3-bff5afa3579d">
<img width="1392" alt="Captura de Tela 2023-09-07 às 12 12 15" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/b714b4e2-8b64-416a-bd16-cd4a3ca1ffbf">
<img width="1392" alt="Captura de Tela 2023-09-07 às 12 18 02" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/1f1ff7c7-f373-4f6f-83ae-a810947c765c">
This one would get stuck on the loading screen before reaching the title screen on my previous test (and weirdly enough, the animation would continue playing forever).

---

Testing is welcome. If you have a game that freezes frequently with Hypervisor, you can give it a try. Keep in mind that this doesn't fix crashes, the nature of this problem is that it would cause some threads to never run, and other to run forever. So it's not something that would cause crashes.

Would be nice to check if there's no performance regression on the hypervisor since the timer approach is a little less efficient.