### PR TITLE
Fix shader GlobalToStorage pass when base address comes from local or shared memory

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5551;
+        private const uint CodeGenVersion = 5668;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -1126,7 +1126,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             // so we want to get the byte offset back, since each one of those word
             // offsets are a new "local variable" which will not match.
 
-            if (operation.GetSource(0).AsgOp is Operation shiftRightOp &&
+            if (operation.GetSource(1).AsgOp is Operation shiftRightOp &&
                 shiftRightOp.Inst == Instruction.ShiftRightU32 &&
                 shiftRightOp.GetSource(1).Type == OperandType.Constant &&
                 shiftRightOp.GetSource(1).Value == 2)
@@ -1158,9 +1158,11 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
         private static bool TryGetLocalMemoryOffset(Operation operation, out int constOffset)
         {
-            if (operation.GetSource(0).Type == OperandType.Constant)
+            Operand offset = operation.GetSource(1);
+
+            if (offset.Type == OperandType.Constant)
             {
-                constOffset = operation.GetSource(0).Value;
+                constOffset = offset.Value;
                 return true;
             }
 


### PR DESCRIPTION
This fixes a regression introduced on #5241 where the shader translator would fail to find the base address for global memory operations if it comes from a local or shared memory. The issue is that I updated the IR to place a "ID" value to identify the memory being accessed, but by doing that I moved the offset value to the operand at index 1, but did not update `GlobalToStorage` code to account for that change.

This fixes a few failures to find storage buffers on Splatoon 3 and probably other games, though I'm not sure which visible effects that may have (I didn't notice anything visibly broken on master at a first glance).