### PR TITLE
Fix: Improve loose file mod time

### DIFF
--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -542,15 +542,14 @@ namespace Ryujinx.HLE.HOS
 
         private class LazyFsFile : IFile
         {
-            private IFileSystem Fs { get; }
+            private readonly IFileSystem _fs;
             private readonly string _filePath;
             private readonly UniqueRef<IFile> _fileReference = new();
             private readonly FileInfo _fileInfo;
-
-
+            
             public LazyFsFile(string filePath, string prefix, IFileSystem fs)
             {
-                Fs = fs;
+                _fs = fs;
                 _filePath = filePath;
                 _fileInfo = new FileInfo(prefix + "/" + filePath);
             }
@@ -559,7 +558,7 @@ namespace Ryujinx.HLE.HOS
             {
                 if (_fileReference.Get == null)
                 {
-                    Fs.OpenFile(ref _fileReference.Ref, _filePath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                    _fs.OpenFile(ref _fileReference.Ref, _filePath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
                 }
             }
 

--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -546,7 +546,7 @@ namespace Ryujinx.HLE.HOS
             private readonly string _filePath;
             private readonly UniqueRef<IFile> _fileReference = new();
             private readonly FileInfo _fileInfo;
-            
+
             public LazyFsFile(string filePath, string prefix, IFileSystem fs)
             {
                 _fs = fs;

--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -519,7 +519,7 @@ namespace Ryujinx.HLE.HOS
                 }
             }
         }
-        
+
         private static void AddLooseFiles(IFileSystem fs, string modName, string rootPath, ISet<string> fileSet, RomFsBuilder builder)
         {
             foreach (var entry in fs.EnumerateEntries()
@@ -538,8 +538,8 @@ namespace Ryujinx.HLE.HOS
                 }
             }
         }
-        
-        
+
+
         private class LazyFsFile : IFile
         {
             private string FilePath { get; }

--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -523,9 +523,9 @@ namespace Ryujinx.HLE.HOS
         private static void AddLooseFiles(IFileSystem fs, string modName, string rootPath, ISet<string> fileSet, RomFsBuilder builder)
         {
             foreach (var entry in fs.EnumerateEntries()
-                         .AsParallel()
-                         .Where(f => f.Type == DirectoryEntryType.File)
-                         .OrderBy(f => f.FullPath, StringComparer.Ordinal))
+                                    .AsParallel()
+                                    .Where(f => f.Type == DirectoryEntryType.File)
+                                    .OrderBy(f => f.FullPath, StringComparer.Ordinal))
             {
                 var file = new LazyFsFile(entry.FullPath, rootPath, fs);
                 if (fileSet.Add(entry.FullPath))
@@ -542,16 +542,16 @@ namespace Ryujinx.HLE.HOS
 
         private class LazyFsFile : IFile
         {
-            private string FilePath { get; }
             private IFileSystem Fs { get; }
-            private readonly UniqueRef<IFile> _fileReference;
+            private readonly string _filePath;
+            private readonly UniqueRef<IFile> _fileReference = new();
             private readonly FileInfo _fileInfo;
 
 
             public LazyFsFile(string filePath, string prefix, IFileSystem fs)
             {
                 Fs = fs;
-                FilePath = filePath;
+                _filePath = filePath;
                 _fileInfo = new FileInfo(prefix + "/" + filePath);
             }
 
@@ -559,7 +559,7 @@ namespace Ryujinx.HLE.HOS
             {
                 if (_fileReference.Get == null)
                 {
-                    Fs.OpenFile(ref _fileReference.Ref, FilePath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                    Fs.OpenFile(ref _fileReference.Ref, _filePath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
                 }
             }
 


### PR DESCRIPTION
This PR updates the Loose file mod logic to handle mods in a more similar way to hardware by grabbing file "Metadata" at startup and then opening files as needed later on.

Closes #5661 

https://github.com/Ryujinx/Ryujinx/assets/25501603/bc3f3d3d-7835-4acf-b033-18ed7b41e2d7

![image](https://github.com/Ryujinx/Ryujinx/assets/25501603/42d01dbe-3efa-444a-83cd-a2657c36fb81)

Here is the original (its still counting but it works out to around 10 minutes I'm just not patient as you should be able to tell by this PR)
![image](https://github.com/Ryujinx/Ryujinx/assets/25501603/4040efe1-3230-48c3-8b6f-95c32e6649f9)

