### PR TITLE
Reduce the amount of descriptor pool allocations on Vulkan

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/CommandBufferPool.cs
+++ b/src/Ryujinx.Graphics.Vulkan/CommandBufferPool.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             public bool InUse;
             public bool InConsumption;
+            public int SubmissionCount;
             public CommandBuffer CommandBuffer;
             public FenceHolder Fence;
             public SemaphoreHolder Semaphore;
@@ -193,6 +194,11 @@ namespace Ryujinx.Graphics.Vulkan
             return _commandBuffers[cbIndex].Fence;
         }
 
+        public int GetSubmissionCount(int cbIndex)
+        {
+            return _commandBuffers[cbIndex].SubmissionCount;
+        }
+
         private int FreeConsumed(bool wait)
         {
             int freeEntry = 0;
@@ -282,6 +288,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Debug.Assert(entry.CommandBuffer.Handle == cbs.CommandBuffer.Handle);
                 entry.InUse = false;
                 entry.InConsumption = true;
+                entry.SubmissionCount++;
                 _inUseCount--;
 
                 var commandBuffer = entry.CommandBuffer;

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetManager.cs
@@ -12,7 +12,6 @@ namespace Ryujinx.Graphics.Vulkan
         {
             public Vk Api { get; }
             public Device Device { get; }
-            private DescriptorType _type;
 
             private readonly DescriptorPool _pool;
             private int _freeDescriptors;
@@ -24,7 +23,6 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 Api = api;
                 Device = device;
-                _type = poolSizes[0].Type;
 
                 foreach (var poolSize in poolSizes)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void UpdateCommandBufferIndex(int commandBufferIndex)
         {
-            int submissionCount = _gd.CommandBufferPool.GetSubmissionCount(commandBufferIndex) ;
+            int submissionCount = _gd.CommandBufferPool.GetSubmissionCount(commandBufferIndex);
 
             if (_dsLastCbIndex != commandBufferIndex || _dsLastSubmissionCount != submissionCount)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
@@ -110,7 +110,7 @@ namespace Ryujinx.Graphics.Vulkan
                     break;
             }
 
-            return output.Slice(0, count);
+            return output[..count];
         }
 
         protected virtual unsafe void Dispose(bool disposing)

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.Graphics.Vulkan
             return list[index];
         }
 
-        private Span<DescriptorPoolSize> GetDescriptorPoolSizes(Span<DescriptorPoolSize> output, int setIndex)
+        private static Span<DescriptorPoolSize> GetDescriptorPoolSizes(Span<DescriptorPoolSize> output, int setIndex)
         {
             uint multiplier = DescriptorPoolMultiplier;
             int count = 1;

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -464,13 +464,14 @@ namespace Ryujinx.Graphics.Vulkan
             return true;
         }
 
-        public Auto<DescriptorSetCollection> GetNewDescriptorSetCollection(
-            VulkanRenderer gd,
-            int commandBufferIndex,
-            int setIndex,
-            out bool isNew)
+        public void UpdateDescriptorCacheCommandBufferIndex(int commandBufferIndex)
         {
-            return _plce.GetNewDescriptorSetCollection(gd, commandBufferIndex, setIndex, out isNew);
+            _plce.UpdateCommandBufferIndex(commandBufferIndex);
+        }
+
+        public Auto<DescriptorSetCollection> GetNewDescriptorSetCollection(int setIndex, out bool isNew)
+        {
+            return _plce.GetNewDescriptorSetCollection(setIndex, out isNew);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -346,7 +346,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             CommandBufferPool = new CommandBufferPool(Api, _device, Queue, QueueLock, queueFamilyIndex);
 
-            DescriptorSetManager = new DescriptorSetManager(_device);
+            DescriptorSetManager = new DescriptorSetManager(_device, PipelineBase.DescriptorSetLayouts);
 
             PipelineLayoutCache = new PipelineLayoutCache();
 


### PR DESCRIPTION
This was started by extracting some changes from #3001: I changed the descriptor pool creation there to use lower pool sizes. Before the change, it would create a pool with sizes for all used descriptor types (uniform/storage buffer, combined image sampler, storage buffers, uniform texel buffers and storage texel buffers). Since it creates a descriptor pool per set, and each set can only use some of those types, this change the descriptor pool to only have pool sizes for the descriptor types that the set uses.

The other change is a bug fix. `PipelineLayoutCacheEntry.GetNewDescriptorSetCollection` knows that the command buffer changed by checking `_dsLastCbIndex != commandBufferIndex`. When the command buffer changes, it sets the current cache entry index to 0, which allows it to re-use descriptor pools that have already been allocated. However, it is possible for a pipeline layout cache entry to be used consecutively with the same command buffer, even after it has been submitted. In other words, there are cases where it would create a lot of new descriptor pools even when it's valid to re-use existing ones, just because it doesn't know that the buffer has already been submitted since the last call. To fix this I added a `SubmissionCount` that is used in addition to the command buffer index to know if it's valid to re-use existing descriptor pools.

This fixes cases where descriptor pool creation would return VK_ERROR_UNKNOWN result on AMD, likely because it was creating hundreds of thousands of descriptor pools in some cases. The issue is very easy to reproduce on Puyo Puyo Tetris by just letting it run for a few minutes.

Some logic from `GetNewDescriptorSetCollection` was moved to `UpdateCommandBufferIndex` which is called less often, to avoid performance hit from the extra check.

Testing is welcome to ensure this doesn't break anything.