### PR TITLE
Optimize memory usage with yield return and allocation strategies

### DIFF
--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
@@ -467,8 +467,6 @@ namespace Ryujinx.Cpu.Jit
         {
             int pages = GetPagesCount(va, (uint)size, out va);
 
-            var regions = new List<MemoryRange>();
-
             ulong regionStart = GetPhysicalAddressChecked(va);
             ulong regionSize = PageSize;
 
@@ -476,14 +474,14 @@ namespace Ryujinx.Cpu.Jit
             {
                 if (!ValidateAddress(va + PageSize))
                 {
-                    return null;
+                    yield break;
                 }
 
                 ulong newPa = GetPhysicalAddressChecked(va + PageSize);
 
                 if (GetPhysicalAddressChecked(va) + PageSize != newPa)
                 {
-                    regions.Add(new MemoryRange(regionStart, regionSize));
+                    yield return new MemoryRange(regionStart, regionSize);
                     regionStart = newPa;
                     regionSize = 0;
                 }
@@ -492,9 +490,7 @@ namespace Ryujinx.Cpu.Jit
                 regionSize += PageSize;
             }
 
-            regions.Add(new MemoryRange(regionStart, regionSize));
-
-            return regions;
+            yield return new MemoryRange(regionStart, regionSize);
         }
 
         private ulong GetPhysicalAddressChecked(ulong va)

--- a/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
+++ b/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
@@ -293,13 +293,11 @@ namespace Ryujinx.Graphics.Texture.Astc
             int layers,
             out byte[] decoded)
         {
-            byte[] output = new byte[QueryDecompressedSize(width, height, depth, levels, layers)];
+            decoded = new byte[QueryDecompressedSize(width, height, depth, levels, layers)];
 
-            AstcDecoder decoder = new(data, output, blockWidth, blockHeight, width, height, depth, levels, layers);
+            AstcDecoder decoder = new(data, decoded, blockWidth, blockHeight, width, height, depth, levels, layers);
 
             Enumerable.Range(0, decoder.TotalBlockCount).AsParallel().ForAll(x => decoder.ProcessBlock(x));
-
-            decoded = output;
 
             return decoder.Success;
         }

--- a/src/Ryujinx.Memory/Range/MultiRangeList.cs
+++ b/src/Ryujinx.Memory/Range/MultiRangeList.cs
@@ -181,20 +181,17 @@ namespace Ryujinx.Memory.Range
             return insertPtr;
         }
 
-        private List<T> GetList()
+        private IEnumerable<T> GetList()
         {
             var items = _items.AsList();
-            var result = new List<T>();
 
             foreach (RangeNode<ulong, T> item in items)
             {
                 if (item.Start == item.Value.BaseAddress)
                 {
-                    result.Add(item.Value);
+                    yield return item.Value;
                 }
             }
-
-            return result;
         }
 
         public IEnumerator<T> GetEnumerator()


### PR DESCRIPTION
I just tried to refactor multiple methods in the codebase to use `yield return` instead of creating and returning lists or arrays. This change aims to improve memory efficiency and readability.

Also, the `TryDecodeToRgba8P` method has been refactored to improve its memory allocation strategy. While it doesn't directly use `yield return`, the changes are in line with the overall goal of improving memory efficiency. Before this change, I was receiving this error running with VS2022:
```sh
00:03:15.900 |E| GPU.MainThread Application : Unhandled exception caught: System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
   at Ryujinx.Graphics.Texture.Astc.AstcDecoder.TryDecodeToRgba8P(ReadOnlyMemory`1 data, Int32 blockWidth, Int32 blockHeight, Int32 width, Int32 height, Int32 depth, Int32 levels, Int32 layers, Byte[]& decoded) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Texture\Astc\AstcDecoder.cs:line 296
   at Ryujinx.Graphics.Gpu.Image.Texture.ConvertToHostCompatibleFormat(ReadOnlySpan`1 data, Int32 level, Boolean single) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\Texture.cs:line 782
   at Ryujinx.Graphics.Gpu.Image.Texture.SynchronizeFull() in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\Texture.cs:line 651
   at Ryujinx.Graphics.Gpu.Image.Texture.InitializeData(Boolean isView, Boolean withData) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\Texture.cs:line 283
   at Ryujinx.Graphics.Gpu.Image.TextureCache.FindOrCreateTexture(MemoryManager memoryManager, TextureSearchFlags flags, TextureInfo info, Int32 layerSize, Nullable`1 range) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\TextureCache.cs:line 991
   at Ryujinx.Graphics.Gpu.Image.TexturePool.GetForBinding(Int32 id, Texture& texture) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\TexturePool.cs:line 188
   at Ryujinx.Graphics.Gpu.Image.TextureBindingsManager.CommitTextureBindings(TexturePool texturePool, SamplerPool samplerPool, ShaderStage stage, Int32 stageIndex, Boolean poolModified, ShaderSpecializationState specState) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\TextureBindingsManager.cs:line 444
   at Ryujinx.Graphics.Gpu.Image.TextureBindingsManager.CommitBindings(ShaderSpecializationState specState) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Image\TextureBindingsManager.cs:line 302
   at Ryujinx.Graphics.Gpu.Engine.Threed.DrawManager.DrawEnd(ThreedClass engine, Int32 firstIndex, Int32 indexCount, Int32 drawFirstVertex, Int32 drawVertexCount) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Engine\Threed\DrawManager.cs:line 123
   at Ryujinx.Graphics.Gpu.Engine.Threed.DrawManager.DrawEnd(ThreedClass engine, Int32 argument) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Engine\Threed\DrawManager.cs:line 110
   at Macro(MacroJitContext, IDeviceState, Int32)
   at Ryujinx.Graphics.Gpu.Engine.GPFifo.GPFifoProcessor.Send(UInt64 gpuVa, Int32 offset, Int32 argument, Int32 subChannel, Boolean isLastCall) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Engine\GPFifo\GPFifoProcessor.cs:line 213
   at Ryujinx.Graphics.Gpu.Engine.GPFifo.GPFifoProcessor.Process(UInt64 baseGpuVa, ReadOnlySpan`1 commandBuffer) in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Engine\GPFifo\GPFifoProcessor.cs:line 82
   at Ryujinx.Graphics.Gpu.Engine.GPFifo.GPFifoDevice.DispatchCalls() in D:\Git\Ryujinx\src\Ryujinx.Graphics.Gpu\Engine\GPFifo\GPFifoDevice.cs:line 206
   at Ryujinx.Ui.RendererWidgetBase.<Render>b__79_0() in D:\Git\Ryujinx\src\Ryujinx\Ui\RendererWidgetBase.cs:line 450
```