### PR TITLE
Fix gl_Layer to geometry shader change not writing gl_Layer

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5668;
+        private const uint CodeGenVersion = 5682;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -576,6 +576,11 @@ namespace Ryujinx.Graphics.Shader.Translation
             int outputAttributesMask = AttributeUsage.UsedOutputAttributes;
             int layerOutputAttr = LayerOutputAttribute;
 
+            if (LayerOutputWritten)
+            {
+                outputAttributesMask |= 1 << ((layerOutputAttr - AttributeConsts.UserAttributeBase) / 16);
+            }
+
             OutputTopology outputTopology;
             int maxOutputVertices;
 


### PR DESCRIPTION
This fixes a regression ~~from #5551~~ (actually I think the regression happened before that change, probably on the one that refactors `TranslatorContext`?) that caused the generated geometry shader used to assign `gl_Layer` on older GPUs to not actually assign it, which caused Pokémon Scarlet/Violet to render mostly black.

Only affects old GPUs that do not support `gl_Layer` on vertex shaders.