### PR TITLE
Replace ShaderOutputLayer with equivalent ShaderViewportIndexLayerEXT capability

### DIFF
--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/SpirvGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/SpirvGenerator.cs
@@ -89,6 +89,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 context.AddCapability(Capability.DrawParameters);
             }
 
+            if (context.Definitions.Stage != ShaderStage.Fragment &&
+                context.Definitions.Stage != ShaderStage.Geometry &&
+                context.Definitions.Stage != ShaderStage.Compute &&
+                (context.Info.IoDefinitions.Contains(new IoDefinition(StorageKind.Output, IoVariable.Layer)) ||
+                context.Info.IoDefinitions.Contains(new IoDefinition(StorageKind.Output, IoVariable.ViewportIndex))))
+            {
+                context.AddExtension("SPV_EXT_shader_viewport_index_layer");
+                context.AddCapability(Capability.ShaderViewportIndexLayerEXT);
+            }
+
             if (context.Info.IoDefinitions.Contains(new IoDefinition(StorageKind.Output, IoVariable.ViewportMask)))
             {
                 context.AddExtension("SPV_NV_viewport_array2");
@@ -275,14 +285,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                         localSizeX,
                         localSizeY,
                         localSizeZ);
-                }
-
-                if (context.Definitions.Stage != ShaderStage.Fragment &&
-                    context.Definitions.Stage != ShaderStage.Geometry &&
-                    context.Definitions.Stage != ShaderStage.Compute &&
-                    context.Info.IoDefinitions.Contains(new IoDefinition(StorageKind.Output, IoVariable.Layer)))
-                {
-                    context.AddCapability(Capability.ShaderLayer);
                 }
 
                 if (context.Definitions.TransformFeedbackEnabled && context.Definitions.LastInVertexPipeline)


### PR DESCRIPTION
This replaces the use of the `ShaderOutputLayer` SPIR-V capability with the `ShaderViewportIndexLayerEXT` capability from the `SPV_EXT_shader_viewport_index_layer` extension. `ShaderOutputLayer` requires SPIR-V 1.5 which older drivers might not support, while the extension is much older and has a higher chance of being supported. `ShaderViewportIndexLayerEXT` as the name implies allow the usage of both `Layer` and `ViewportIndex`, while SPIR-V 1.5 added separate capabilities for them.

Fixes #5662.