### PR TITLE
Use compiled binding for localizations

### DIFF
--- a/src/Ryujinx.Ava/Common/Locale/LocaleExtension.cs
+++ b/src/Ryujinx.Ava/Common/Locale/LocaleExtension.cs
@@ -1,6 +1,7 @@
-﻿using Avalonia.Data;
+﻿using Avalonia.Data.Core;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings;
 using System;
 
 namespace Ryujinx.Ava.Common.Locale
@@ -18,11 +19,20 @@ namespace Ryujinx.Ava.Common.Locale
         {
             LocaleKeys keyToUse = Key;
 
-            ReflectionBindingExtension binding = new($"[{keyToUse}]")
-            {
-                Mode = BindingMode.OneWay,
-                Source = LocaleManager.Instance,
-            };
+            var builder = new CompiledBindingPathBuilder();
+
+            builder.SetRawSource(LocaleManager.Instance)
+                .Property(new ClrPropertyInfo("Item",
+                obj => (LocaleManager.Instance[keyToUse]),
+                null,
+                typeof(string)), (weakRef, iPropInfo) =>
+                {
+                    return PropertyInfoAccessorFactory.CreateInpcPropertyAccessor(weakRef, iPropInfo);
+                });
+
+            var path = builder.Build();
+
+            var binding = new CompiledBindingExtension(path);
 
             return binding.ProvideValue(serviceProvider);
         }


### PR DESCRIPTION
This removes one of the few places reflections is used in the Avalonia ui project.