### PR TITLE
desktop shortcut support

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/de_DE.json
+++ b/src/Ryujinx.Ava/Assets/Locales/de_DE.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Dateiformat",
   "GameListHeaderFileSize": "Dateigröße",
   "GameListHeaderPath": "Pfad",
+  "GameListContextMenuCreateDesktopShortcut": "Verknüpfung Erstellen",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Erstellt eine Verknüpfung auf dem Desktop für das ausgewählte Spiel",
   "GameListContextMenuOpenUserSaveDirectory": "Spielstand-Verzeichnis öffnen",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Öffnet das Verzeichnis, welches den Benutzer-Spielstand beinhaltet",
   "GameListContextMenuOpenDeviceSaveDirectory": "Benutzer-Geräte-Verzeichnis öffnen",

--- a/src/Ryujinx.Ava/Assets/Locales/el_GR.json
+++ b/src/Ryujinx.Ava/Assets/Locales/el_GR.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Κατάληξη",
   "GameListHeaderFileSize": "Μέγεθος Αρχείου",
   "GameListHeaderPath": "Τοποθεσία",
+  "GameListContextMenuCreateDesktopShortcut": "Δημιουργία συντόμευσης",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Δημιουργεί μια συντόμευση στην επιφάνεια εργασίας για το επιλεγμένο παιχνίδι",
   "GameListContextMenuOpenUserSaveDirectory": "Άνοιγμα Τοποθεσίας Αποθήκευσης Χρήστη",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Ανοίγει την τοποθεσία που περιέχει την Αποθήκευση Χρήστη της εφαρμογής",
   "GameListContextMenuOpenDeviceSaveDirectory": "Άνοιγμα Τοποθεσίας Συσκευής Χρήστη",

--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "File Ext",
   "GameListHeaderFileSize": "File Size",
   "GameListHeaderPath": "Path",
+  "GameListContextMenuCreateDesktopShortcut": "Create Shortcut",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Creates a desktop shortcut for the selected game",
   "GameListContextMenuOpenUserSaveDirectory": "Open User Save Directory",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Opens the directory which contains Application's User Save",
   "GameListContextMenuOpenDeviceSaveDirectory": "Open Device Save Directory",

--- a/src/Ryujinx.Ava/Assets/Locales/es_ES.json
+++ b/src/Ryujinx.Ava/Assets/Locales/es_ES.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Extensión",
   "GameListHeaderFileSize": "Tamaño del archivo",
   "GameListHeaderPath": "Directorio",
+  "GameListContextMenuCreateDesktopShortcut": "Crear Acceso Directo",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Crea un acceso directo en el escritorio para el juego seleccionado",
   "GameListContextMenuOpenUserSaveDirectory": "Abrir carpeta de guardado de este usuario",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Abre la carpeta que contiene la partida guardada del usuario para esta aplicación",
   "GameListContextMenuOpenDeviceSaveDirectory": "Abrir carpeta de guardado del sistema para el usuario actual",

--- a/src/Ryujinx.Ava/Assets/Locales/fr_FR.json
+++ b/src/Ryujinx.Ava/Assets/Locales/fr_FR.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Fichier externe",
   "GameListHeaderFileSize": "Taille du Fichier",
   "GameListHeaderPath": "Chemin",
+  "GameListContextMenuCreateDesktopShortcut": "Créer un Raccourci",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Crée un raccourci sur le bureau pour le jeu sélectionné",
   "GameListContextMenuOpenUserSaveDirectory": "Ouvrir le dossier de sauvegarde utilisateur",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Ouvre le dossier contenant la sauvegarde utilisateur du jeu",
   "GameListContextMenuOpenDeviceSaveDirectory": "Ouvrir le dossier de sauvegarde console",

--- a/src/Ryujinx.Ava/Assets/Locales/he_IL.json
+++ b/src/Ryujinx.Ava/Assets/Locales/he_IL.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "סיומת קובץ",
   "GameListHeaderFileSize": "גודל הקובץ",
   "GameListHeaderPath": "נתיב",
+  "GameListContextMenuCreateDesktopShortcut": "צור קיצור דרך",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "יוצר קיצור דרך בשולחן העבודה למשחק שנבחר",
   "GameListContextMenuOpenUserSaveDirectory": "פתח את תקיית השמור של המשתמש",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "פותח את תקיית השמור של המשתמש ביישום הנוכחי",
   "GameListContextMenuOpenDeviceSaveDirectory": "פתח את תקיית השמור של המכשיר",

--- a/src/Ryujinx.Ava/Assets/Locales/it_IT.json
+++ b/src/Ryujinx.Ava/Assets/Locales/it_IT.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Estensione",
   "GameListHeaderFileSize": "Dimensione file",
   "GameListHeaderPath": "Percorso",
+  "GameListContextMenuCreateDesktopShortcut": "Crea Scorciatoia",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Crea una scorciatoia sul desktop per il gioco selezionato",
   "GameListContextMenuOpenUserSaveDirectory": "Apri la cartella salvataggi dell'utente",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Apre la cartella che contiene i salvataggi di gioco dell'utente",
   "GameListContextMenuOpenDeviceSaveDirectory": "Apri la cartella dispositivo dell'utente",

--- a/src/Ryujinx.Ava/Assets/Locales/ja_JP.json
+++ b/src/Ryujinx.Ava/Assets/Locales/ja_JP.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "ファイル拡張子",
   "GameListHeaderFileSize": "ファイルサイズ",
   "GameListHeaderPath": "パス",
+  "GameListContextMenuCreateDesktopShortcut": "ショートカットを作成する",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "選択したゲームのデスクトップショートカットを作成します",
   "GameListContextMenuOpenUserSaveDirectory": "セーブディレクトリを開く",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "アプリケーションのユーザセーブデータを格納するディレクトリを開きます",
   "GameListContextMenuOpenDeviceSaveDirectory": "デバイスディレクトリを開く",

--- a/src/Ryujinx.Ava/Assets/Locales/ko_KR.json
+++ b/src/Ryujinx.Ava/Assets/Locales/ko_KR.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "파일 확장자",
   "GameListHeaderFileSize": "파일 크기",
   "GameListHeaderPath": "경로",
+  "GameListContextMenuCreateDesktopShortcut": "바로가기 생성",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "선택한 게임의 바탕 화면 바로가기를 생성합니다",
   "GameListContextMenuOpenUserSaveDirectory": "사용자 저장 디렉터리 열기",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "응용프로그램의 사용자 저장이 포함된 디렉터리 열기",
   "GameListContextMenuOpenDeviceSaveDirectory": "사용자 장치 디렉터리 열기",

--- a/src/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/src/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Rozsz. Pliku",
   "GameListHeaderFileSize": "Rozm. Pliku",
   "GameListHeaderPath": "Ścieżka",
+  "GameListContextMenuCreateDesktopShortcut": "Utwórz Skrót",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Tworzy skrót na pulpicie do wybranej gry",
   "GameListContextMenuOpenUserSaveDirectory": "Otwórz Katalog Zapisów Użytkownika",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Otwiera katalog, który zawiera Zapis Użytkownika Aplikacji",
   "GameListContextMenuOpenDeviceSaveDirectory": "Otwórz Katalog Urządzeń Użytkownika",

--- a/src/Ryujinx.Ava/Assets/Locales/pt_BR.json
+++ b/src/Ryujinx.Ava/Assets/Locales/pt_BR.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Extensão",
   "GameListHeaderFileSize": "Tamanho",
   "GameListHeaderPath": "Caminho",
+  "GameListContextMenuCreateDesktopShortcut": "Criar Atalho",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Cria um atalho na área de trabalho para o jogo selecionado",
   "GameListContextMenuOpenUserSaveDirectory": "Abrir diretório de saves do usuário",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Abre o diretório que contém jogos salvos para o usuário atual",
   "GameListContextMenuOpenDeviceSaveDirectory": "Abrir diretório de saves de dispositivo do usuário",

--- a/src/Ryujinx.Ava/Assets/Locales/ru_RU.json
+++ b/src/Ryujinx.Ava/Assets/Locales/ru_RU.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Расширение файла",
   "GameListHeaderFileSize": "Размер файла",
   "GameListHeaderPath": "Путь",
+  "GameListContextMenuCreateDesktopShortcut": "Создать ярлык",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Создает ярлык на рабочем столе для выбранной игры",
   "GameListContextMenuOpenUserSaveDirectory": "Открыть папку сохранений пользователя",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Открывает папку, содержащую пользовательские сохранения",
   "GameListContextMenuOpenDeviceSaveDirectory": "Открыть папку сохраненных устройств",

--- a/src/Ryujinx.Ava/Assets/Locales/tr_TR.json
+++ b/src/Ryujinx.Ava/Assets/Locales/tr_TR.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Dosya Uzantısı",
   "GameListHeaderFileSize": "Dosya Boyutu",
   "GameListHeaderPath": "Yol",
+  "GameListContextMenuCreateDesktopShortcut": "Kısayol Oluştur",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Seçilen oyun için masaüstünde kısayol oluşturur",
   "GameListContextMenuOpenUserSaveDirectory": "Kullanıcı Kayıt Dosyası Dizinini Aç",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Uygulamanın Kullanıcı Kaydı'nın bulunduğu dizini açar",
   "GameListContextMenuOpenDeviceSaveDirectory": "Kullanıcı Cihaz Dizinini Aç",

--- a/src/Ryujinx.Ava/Assets/Locales/uk_UA.json
+++ b/src/Ryujinx.Ava/Assets/Locales/uk_UA.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "Розширення файлу",
   "GameListHeaderFileSize": "Розмір файлу",
   "GameListHeaderPath": "Шлях",
+  "GameListContextMenuCreateDesktopShortcut": "Створити ярлик",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "Створює ярлик на робочому столі для вибраної гри",
   "GameListContextMenuOpenUserSaveDirectory": "Відкрити каталог збереження користувача",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Відкриває каталог, який містить збереження користувача програми",
   "GameListContextMenuOpenDeviceSaveDirectory": "Відкрити каталог пристроїв користувача",

--- a/src/Ryujinx.Ava/Assets/Locales/zh_CN.json
+++ b/src/Ryujinx.Ava/Assets/Locales/zh_CN.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "扩展名",
   "GameListHeaderFileSize": "大小",
   "GameListHeaderPath": "路径",
+  "GameListContextMenuCreateDesktopShortcut": "创建快捷方式",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "为所选游戏创建桌面快捷方式",
   "GameListContextMenuOpenUserSaveDirectory": "打开用户存档目录",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "打开储存游戏存档的目录",
   "GameListContextMenuOpenDeviceSaveDirectory": "打开系统目录",

--- a/src/Ryujinx.Ava/Assets/Locales/zh_TW.json
+++ b/src/Ryujinx.Ava/Assets/Locales/zh_TW.json
@@ -44,6 +44,8 @@
   "GameListHeaderFileExtension": "副檔名",
   "GameListHeaderFileSize": "檔案大小",
   "GameListHeaderPath": "路徑",
+  "GameListContextMenuCreateDesktopShortcut": "創建快捷方式",
+  "GameListContextMenuCreateDesktopShortcutToolTip": "為所選遊戲創建桌面快捷方式",
   "GameListContextMenuOpenUserSaveDirectory": "開啟使用者存檔資料夾",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "開啟此遊戲的存檔資料夾",
   "GameListContextMenuOpenDeviceSaveDirectory": "開啟系統資料夾",

--- a/src/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/src/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -145,4 +145,15 @@
   <ItemGroup>
     <AdditionalFiles Include="Assets\Locales\en_US.json" />
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="IWshRuntimeLibrary">
+      <WrapperTool>tlbimp</WrapperTool>
+      <VersionMinor>0</VersionMinor>
+      <VersionMajor>1</VersionMajor>
+      <Guid>f935dc20-1cf0-11d0-adb9-00c04fd58a0b</Guid>
+      <Lcid>0</Lcid>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
 </Project>

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
@@ -9,6 +9,10 @@
         Click="RunApplication_Click"
         Header="{locale:Locale GameListContextMenuRunApplication}" />
     <MenuItem
+        Click="CreateDesktopShortcutMenuItem_Click"
+        Header="{locale:Locale GameListContextMenuCreateDesktopShortcut}"
+        ToolTip.Tip="{locale:Locale GameListContextMenuCreateDesktopShortcutToolTip}" />
+    <MenuItem
         Click="ToggleFavorite_Click"
         Header="{locale:Locale GameListContextMenuToggleFavorite}"
         ToolTip.Tip="{locale:Locale GameListContextMenuToggleFavoriteToolTip}" />

--- a/src/Ryujinx/Ryujinx.csproj
+++ b/src/Ryujinx/Ryujinx.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="SPB" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
   <ItemGroup>
@@ -88,6 +89,18 @@
     <None Remove="Ui\Windows\SettingsWindow.glade" />
     <None Remove="Ui\Windows\TitleUpdateWindow.glade" />
     <None Remove="Modules\Updater\UpdateDialog.glade" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <COMReference Include="IWshRuntimeLibrary">
+      <WrapperTool>tlbimp</WrapperTool>
+      <VersionMinor>0</VersionMinor>
+      <VersionMajor>1</VersionMajor>
+      <Guid>f935dc20-1cf0-11d0-adb9-00c04fd58a0b</Guid>
+      <Lcid>0</Lcid>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </COMReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/src/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -4,6 +4,8 @@ namespace Ryujinx.Ui.Widgets
 {
     public partial class GameTableContextMenu : Menu
     {
+        private MenuItem _runApplicationMenuItem;
+        private MenuItem _createDesktopShortcutMenuItem;
         private MenuItem _openSaveUserDirMenuItem;
         private MenuItem _openSaveDeviceDirMenuItem;
         private MenuItem _openSaveBcatDirMenuItem;
@@ -26,6 +28,24 @@ namespace Ryujinx.Ui.Widgets
 
         private void InitializeComponent()
         {
+            //
+            // _runApplicationMenuItem
+            //
+            _runApplicationMenuItem = new MenuItem("Run Application")
+            {
+                TooltipText = "Start selected game",
+            };
+            _runApplicationMenuItem.Activated += _RunApplicationMenuItem_Clicked;
+
+            //
+            // _createDesktopShortcutMenuItem
+            //
+            _createDesktopShortcutMenuItem = new MenuItem("Create Shortcut")
+            {
+                TooltipText = "Creates a desktop shortcut for the selected game",
+            };
+            _createDesktopShortcutMenuItem.Activated += CreateDesktopShortcut_Clicked;
+
             //
             // _openSaveUserDirMenuItem
             //
@@ -201,6 +221,9 @@ namespace Ryujinx.Ui.Widgets
             _manageSubMenu.Append(_openPtcDirMenuItem);
             _manageSubMenu.Append(_openShaderCacheDirMenuItem);
 
+            Add(_runApplicationMenuItem);
+            Add(_createDesktopShortcutMenuItem);
+            Add(new SeparatorMenuItem());
             Add(_openSaveUserDirMenuItem);
             Add(_openSaveDeviceDirMenuItem);
             Add(_openSaveBcatDirMenuItem);


### PR DESCRIPTION
This pull request adds two new options to the submenu:

1. **Start Game**: This option allows users to start the game directly from the submenu.
2. **Create Shortcut**: This option allows users to create a shortcut for the game on the desktop.

Here you can see the buttons in the menu:
![print2](https://github.com/Ryujinx/Ryujinx/assets/28203966/51f7b98a-6132-42d0-911d-88cbb3f10269)


However, there are two issues that need to be resolved:

1. **Image conversion to .ico**: The current conversion of the JPEG image to an .ico file is not producing a high-quality image. We need to improve the `GenerateStandardFaviconIco` function to ensure that the converted image maintains its quality.
![image](https://github.com/Ryujinx/Ryujinx/assets/28203966/2c3c1f5d-1187-4522-a5e1-08e4aa6afc61)
2. **Setting desiredTitleLanguage in GetApplicationIcon**: Currently, the `GetApplicationIcon` function is not correctly setting the `desiredTitleLanguage`. As a result, the generated icon is in a different language than expected. We need to fix this to ensure that the icon is displayed in the correct language.
![image](https://github.com/Ryujinx/Ryujinx/assets/28203966/eaa61f45-5f58-49b7-b5c0-1d28cb9fc06e)


To add the IWshRuntimeLibrary to your project in Visual Studio, you can follow these steps:

Right-click on the project name within the Solution Explorer.
Select “Add Reference”.
Select the “COM” tab, find and select the “Windows Script Host Object Model” in the listbox.
Click “Select”, and then click "OK"


