### PR TITLE
Vulkan: Fix barriers on macOS

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -454,13 +454,33 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (lastReadStage != PipelineStageFlags.None)
             {
-                TextureView.InsertMemoryBarrier(
-                    _gd.Api,
-                    cbs.CommandBuffer,
-                    _lastReadAccess,
-                    dstAccessFlags,
-                    lastReadStage,
-                    dstStageFlags);
+                if (OperatingSystem.IsMacOS())
+                {
+                    ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
+                    TextureView.InsertImageBarrier(
+                        _gd.Api,
+                        cbs.CommandBuffer,
+                        _imageAuto.Get(cbs).Value,
+                        _lastReadAccess,
+                        dstAccessFlags,
+                        _lastReadStage,
+                        dstStageFlags,
+                        aspectFlags,
+                        0,
+                        0,
+                        _info.GetLayers(),
+                        _info.Levels);
+                }
+                else
+                {
+                    TextureView.InsertMemoryBarrier(
+                        _gd.Api,
+                        cbs.CommandBuffer,
+                        _lastReadAccess,
+                        dstAccessFlags,
+                        lastReadStage,
+                        dstStageFlags);
+                }
 
                 _lastReadAccess = AccessFlags.None;
                 _lastReadStage = PipelineStageFlags.None;
@@ -474,13 +494,33 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.None)
             {
-                TextureView.InsertMemoryBarrier(
-                    _gd.Api,
-                    cbs.CommandBuffer,
-                    _lastModificationAccess,
-                    dstAccessFlags,
-                    _lastModificationStage,
-                    dstStageFlags);
+                if (OperatingSystem.IsMacOS())
+                {
+                    ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
+                    TextureView.InsertImageBarrier(
+                        _gd.Api,
+                        cbs.CommandBuffer,
+                        _imageAuto.Get(cbs).Value,
+                        _lastModificationAccess,
+                        dstAccessFlags,
+                        _lastModificationStage,
+                        dstStageFlags,
+                        aspectFlags,
+                        0,
+                        0,
+                        _info.GetLayers(),
+                        _info.Levels);
+                }
+                else
+                {
+                    TextureView.InsertMemoryBarrier(
+                        _gd.Api,
+                        cbs.CommandBuffer,
+                        _lastModificationAccess,
+                        dstAccessFlags,
+                        _lastModificationStage,
+                        dstStageFlags);
+                }
 
                 _lastModificationAccess = AccessFlags.None;
             }

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -498,7 +498,7 @@ namespace Ryujinx.Graphics.Vulkan
             if (_lastModificationAccess != AccessFlags.None)
             {
                 // This would result in a validation error, but is
-                // required on MoltenVK as the generic buffer results in
+                // required on MoltenVK as the generic barrier results in
                 // severe texture flickering in some scenarios.
                 if (_gd.IsMoltenVk)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -454,7 +454,10 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (lastReadStage != PipelineStageFlags.None)
             {
-                if (OperatingSystem.IsMacOS())
+                // This would result in a validation error, but is
+                // required on MoltenVK as the generic buffer results in
+                // severe texture flickering in some scenarios.
+                if (_gd.IsMoltenVk)
                 {
                     ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
                     TextureView.InsertImageBarrier(
@@ -494,7 +497,10 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.None)
             {
-                if (OperatingSystem.IsMacOS())
+                // This would result in a validation error, but is
+                // required on MoltenVK as the generic buffer results in
+                // severe texture flickering in some scenarios.
+                if (_gd.IsMoltenVk)
                 {
                     ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
                     TextureView.InsertImageBarrier(

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -455,7 +455,7 @@ namespace Ryujinx.Graphics.Vulkan
             if (lastReadStage != PipelineStageFlags.None)
             {
                 // This would result in a validation error, but is
-                // required on MoltenVK as the generic buffer results in
+                // required on MoltenVK as the generic barrier results in
                 // severe texture flickering in some scenarios.
                 if (_gd.IsMoltenVk)
                 {


### PR DESCRIPTION
On macOS, using the generic MemoryBarrier in `InsertWriteToReadBarrier` causes flickering in some scenarios. This patches that by using the old ImageBarrier path on macOS. At the request of gdk I have added this workaround for both `InsertWriteToReadBarrier` and `InsertReadToWriteBarrier` even though it should only be necessary for `InsertWriteToReadBarrier`. As described in #5603, this is technically invalid in Vulkan and would result in a validation error.

Fixes #5685, #5694