### PR TITLE
Horizon: Migrate wlan and stubs latest services

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Wlan/IInfraManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/IInfraManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:inf")]
-    class IInfraManager : IpcService
-    {
-        public IInfraManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Wlan/ILocalGetActionFrame.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/ILocalGetActionFrame.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:lga")]
-    class ILocalGetActionFrame : IpcService
-    {
-        public ILocalGetActionFrame(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Wlan/ILocalGetFrame.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/ILocalGetFrame.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:lg")]
-    class ILocalGetFrame : IpcService
-    {
-        public ILocalGetFrame(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Wlan/ILocalManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/ILocalManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:lcl")]
-    class ILocalManager : IpcService
-    {
-        public ILocalManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Wlan/ISocketGetFrame.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/ISocketGetFrame.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:sg")]
-    class ISocketGetFrame : IpcService
-    {
-        public ISocketGetFrame(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Wlan/ISocketManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/ISocketManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:soc")]
-    class ISocketManager : IpcService
-    {
-        public ISocketManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Wlan/IUnknown1.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Wlan/IUnknown1.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Wlan
-{
-    [Service("wlan:dtc")] // 6.0.0+
-    class IUnknown1 : IpcService
-    {
-        public IUnknown1(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/IDetectManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/IDetectManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface IDetectManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/IGeneralServiceCreator.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/IGeneralServiceCreator.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface IGeneralServiceCreator : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/IInfraManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/IInfraManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface IInfraManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/ILocalGetActionFrame.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/ILocalGetActionFrame.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface ILocalGetActionFrame : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/ILocalGetFrame.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/ILocalGetFrame.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface ILocalGetFrame : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/ILocalManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/ILocalManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface ILocalManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/IPrivateServiceCreator.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/IPrivateServiceCreator.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface IPrivateServiceCreator : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/ISfDriverServiceCreator.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/ISfDriverServiceCreator.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface ISfDriverServiceCreator : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/ISocketGetFrame.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/ISocketGetFrame.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface ISocketGetFrame : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Wlan/ISocketManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Wlan/ISocketManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Wlan
+{
+    interface ISocketManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/ServiceTable.cs
+++ b/src/Ryujinx.Horizon/ServiceTable.cs
@@ -3,6 +3,7 @@ using Ryujinx.Horizon.Lbl;
 using Ryujinx.Horizon.LogManager;
 using Ryujinx.Horizon.MmNv;
 using Ryujinx.Horizon.Prepo;
+using Ryujinx.Horizon.Wlan;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -29,6 +30,7 @@ namespace Ryujinx.Horizon
             RegisterService<LmMain>();
             RegisterService<MmNvMain>();
             RegisterService<PrepoMain>();
+            RegisterService<WlanMain>();
 
             _totalServices = entries.Count;
 

--- a/src/Ryujinx.Horizon/Wlan/Ipc/DetectManager.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/DetectManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class DetectManager : IDetectManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/GeneralServiceCreator.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/GeneralServiceCreator.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class GeneralServiceCreator : IGeneralServiceCreator
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/InfraManager.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/InfraManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class InfraManager : IInfraManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/LocalGetActionFrame.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/LocalGetActionFrame.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class LocalGetActionFrame : ILocalGetActionFrame
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/LocalGetFrame.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/LocalGetFrame.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class LocalGetFrame : ILocalGetFrame
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/LocalManager.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/LocalManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class LocalManager : ILocalManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/PrivateServiceCreator.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/PrivateServiceCreator.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class PrivateServiceCreator : IPrivateServiceCreator
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/SfDriverServiceCreator.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/SfDriverServiceCreator.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class SfDriverServiceCreator : ISfDriverServiceCreator
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/SocketGetFrame.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/SocketGetFrame.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class SocketGetFrame : ISocketGetFrame
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/Ipc/SocketManager.cs
+++ b/src/Ryujinx.Horizon/Wlan/Ipc/SocketManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Wlan;
+
+namespace Ryujinx.Horizon.Wlan.Ipc
+{
+    partial class SocketManager : ISocketManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/WlanIpcServer.cs
+++ b/src/Ryujinx.Horizon/Wlan/WlanIpcServer.cs
@@ -1,6 +1,6 @@
-﻿using Ryujinx.Horizon.Wlan.Ipc;
-using Ryujinx.Horizon.Sdk.Sf.Hipc;
+﻿using Ryujinx.Horizon.Sdk.Sf.Hipc;
 using Ryujinx.Horizon.Sdk.Sm;
+using Ryujinx.Horizon.Wlan.Ipc;
 
 namespace Ryujinx.Horizon.Wlan
 {

--- a/src/Ryujinx.Horizon/Wlan/WlanIpcServer.cs
+++ b/src/Ryujinx.Horizon/Wlan/WlanIpcServer.cs
@@ -1,0 +1,59 @@
+﻿using Ryujinx.Horizon.Wlan.Ipc;
+using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+
+namespace Ryujinx.Horizon.Wlan
+{
+    class WlanIpcServer
+    {
+        private const int WlanOtherMaxSessionsCount = 10;
+        private const int WlanDtcMaxSessionsCount = 4;
+        private const int WlanMaxSessionsCount = 30;
+        private const int WlanNdMaxSessionsCount = 5;
+        private const int WlanPMaxSessionsCount = 30;
+        private const int TotalMaxSessionsCount = WlanDtcMaxSessionsCount + WlanMaxSessionsCount + WlanNdMaxSessionsCount + WlanPMaxSessionsCount + WlanOtherMaxSessionsCount * 6;
+
+        private const int PointerBufferSize = 0x1000;
+        private const int MaxDomains = 16;
+        private const int MaxDomainObjects = 10;
+        private const int MaxPortsCount = 10;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+#pragma warning disable IDE0055 // Disable formatting
+            _serverManager.RegisterObjectForServer(new GeneralServiceCreator(),  ServiceName.Encode("wlan"),     WlanMaxSessionsCount);      // 15.0.0+
+            _serverManager.RegisterObjectForServer(new DetectManager(),          ServiceName.Encode("wlan:dtc"), WlanDtcMaxSessionsCount);   // 6.0.0-14.1.2
+            _serverManager.RegisterObjectForServer(new InfraManager(),           ServiceName.Encode("wlan:inf"), WlanOtherMaxSessionsCount); // 1.0.0-14.1.2
+            _serverManager.RegisterObjectForServer(new LocalManager(),           ServiceName.Encode("wlan:lcl"), WlanOtherMaxSessionsCount); // 1.0.0-14.1.2
+            _serverManager.RegisterObjectForServer(new LocalGetFrame(),          ServiceName.Encode("wlan:lg"),  WlanOtherMaxSessionsCount); // 1.0.0-14.1.2
+            _serverManager.RegisterObjectForServer(new LocalGetActionFrame(),    ServiceName.Encode("wlan:lga"), WlanOtherMaxSessionsCount); // 1.0.0-14.1.2
+            _serverManager.RegisterObjectForServer(new SfDriverServiceCreator(), ServiceName.Encode("wlan:nd"),  WlanNdMaxSessionsCount);    // 15.0.0+
+            _serverManager.RegisterObjectForServer(new PrivateServiceCreator(),  ServiceName.Encode("wlan:p"),   WlanPMaxSessionsCount);     // 15.0.0+
+            _serverManager.RegisterObjectForServer(new SocketGetFrame(),         ServiceName.Encode("wlan:sg"),  WlanOtherMaxSessionsCount); // 1.0.0-14.1.2
+            _serverManager.RegisterObjectForServer(new SocketManager(),          ServiceName.Encode("wlan:soc"), WlanOtherMaxSessionsCount); // 1.0.0-14.1.2
+#pragma warning restore IDE0055
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Wlan/WlanMain.cs
+++ b/src/Ryujinx.Horizon/Wlan/WlanMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Wlan
+{
+    class WlanMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            WlanIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}


### PR DESCRIPTION
This PR migrate empty wlan services from HLE project to Horizon project, values are found by RE.
Latest firmwares added some other services which are now stubbed and up-to-date.