### PR TITLE
GPU: Discard data when getting texture before full clear

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Format.cs
+++ b/src/Ryujinx.Graphics.GAL/Format.cs
@@ -336,6 +336,45 @@ namespace Ryujinx.Graphics.GAL
         }
 
         /// <summary>
+        /// Checks if the texture format is a depth or depth-stencil format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the format is a depth or depth-stencil format, false otherwise</returns>
+        public static bool HasDepth(this Format format)
+        {
+            switch (format)
+            {
+                case Format.D16Unorm:
+                case Format.D24UnormS8Uint:
+                case Format.S8UintD24Unorm:
+                case Format.D32Float:
+                case Format.D32FloatS8Uint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is a stencil or depth-stencil format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the format is a stencil or depth-stencil format, false otherwise</returns>
+        public static bool HasStencil(this Format format)
+        {
+            switch (format)
+            {
+                case Format.D24UnormS8Uint:
+                case Format.S8UintD24Unorm:
+                case Format.D32FloatS8Uint:
+                case Format.S8Uint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Checks if the texture format is valid to use as image format.
         /// </summary>
         /// <param name="format">Texture format</param>

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -856,7 +856,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                         fullClear = false;
                     }
                 }
-                
+
                 if (fullClear)
                 {
                     updateFlags |= RenderTargetUpdateFlags.DiscardClip;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -1,6 +1,7 @@
 ﻿using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw;
 using Ryujinx.Graphics.Gpu.Engine.Types;
+using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.Memory;
 using System;
 
@@ -806,7 +807,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 updateFlags |= RenderTargetUpdateFlags.Layered;
             }
 
-            if (clearDepth || clearStencil)
+            bool clearDS = clearDepth || clearStencil;
+
+            if (clearDS)
             {
                 updateFlags |= RenderTargetUpdateFlags.UpdateDepthStencil;
             }
@@ -816,16 +819,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             // host clipping.
             var screenScissorState = _state.State.ScreenScissorState;
 
-            // Must happen after UpdateRenderTargetState to have up-to-date clip region values.
-            bool clipMismatch = (screenScissorState.X | screenScissorState.Y) != 0 ||
-                                screenScissorState.Width != _channel.TextureManager.ClipRegionWidth ||
-                                screenScissorState.Height != _channel.TextureManager.ClipRegionHeight;
-
             bool clearAffectedByStencilMask = (_state.State.ClearFlags & 1) != 0;
             bool clearAffectedByScissor = (_state.State.ClearFlags & 0x100) != 0;
-            bool needsCustomScissor = !clearAffectedByScissor || clipMismatch;
 
-            if (clearDepth || clearStencil || componentMask == 15)
+            if (clearDS || componentMask == 15)
             {
                 // A full clear if scissor is disabled, or it matches the screen scissor state.
 
@@ -837,14 +834,43 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                     fullClear = scissorState.X1 == screenScissorState.X &&
                         scissorState.Y1 == screenScissorState.Y &&
-                        scissorState.X2 == screenScissorState.X + screenScissorState.Width &&
-                        scissorState.Y2 == screenScissorState.Y + screenScissorState.Height;
+                        scissorState.X2 >= screenScissorState.X + screenScissorState.Width &&
+                        scissorState.Y2 >= screenScissorState.Y + screenScissorState.Height;
                 }
 
-                updateFlags |= RenderTargetUpdateFlags.DiscardClip;
+                if (fullClear && clearDS)
+                {
+                    // Must clear all aspects of the depth-stencil format.
+
+                    FormatInfo dsFormat = _state.State.RtDepthStencilState.Format.Convert();
+
+                    bool hasDepth = dsFormat.Format.HasDepth();
+                    bool hasStencil = dsFormat.Format.HasStencil();
+
+                    if (hasStencil && (!clearStencil || (clearAffectedByStencilMask && _state.State.StencilTestState.FrontMask != 0xff)))
+                    {
+                        fullClear = false;
+                    }
+                    else if (hasDepth && !clearDepth)
+                    {
+                        fullClear = false;
+                    }
+                }
+                
+                if (fullClear)
+                {
+                    updateFlags |= RenderTargetUpdateFlags.DiscardClip;
+                }
             }
 
             engine.UpdateRenderTargetState(updateFlags, singleUse: componentMask != 0 ? index : -1);
+
+            // Must happen after UpdateRenderTargetState to have up-to-date clip region values.
+            bool clipMismatch = (screenScissorState.X | screenScissorState.Y) != 0 ||
+                                screenScissorState.Width != _channel.TextureManager.ClipRegionWidth ||
+                                screenScissorState.Height != _channel.TextureManager.ClipRegionHeight;
+
+            bool needsCustomScissor = !clearAffectedByScissor || clipMismatch;
 
             // Scissor and rasterizer discard also affect clears.
             ulong updateMask = 1UL << StateUpdater.RasterizerStateIndex;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/RenderTargetUpdateFlags.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/RenderTargetUpdateFlags.cs
@@ -34,6 +34,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         UpdateDepthStencil = 1 << 3,
 
         /// <summary>
+        /// Indicates that the data in the clip region can be discarded for the next use.
+        /// </summary>
+        DiscardClip = 1 << 4,
+
+        /// <summary>
         /// Default update flags for draw.
         /// </summary>
         UpdateAll = UseControl | UpdateDepthStencil,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -447,6 +447,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             bool useControl = updateFlags.HasFlag(RenderTargetUpdateFlags.UseControl);
             bool layered = updateFlags.HasFlag(RenderTargetUpdateFlags.Layered);
             bool singleColor = updateFlags.HasFlag(RenderTargetUpdateFlags.SingleColor);
+            bool discard = updateFlags.HasFlag(RenderTargetUpdateFlags.DiscardClip);
 
             int count = useControl ? rtControl.UnpackCount() : Constants.TotalRenderTargets;
 
@@ -486,6 +487,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     memoryManager,
                     colorState,
                     _vtgWritesRtLayer || layered,
+                    discard,
                     samplesInX,
                     samplesInY,
                     sizeHint);
@@ -525,6 +527,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     dsState,
                     dsSize,
                     _vtgWritesRtLayer || layered,
+                    discard,
                     samplesInX,
                     samplesInY,
                     sizeHint);

--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -571,6 +571,18 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Discards all data for this texture.
+        /// This clears all dirty flags, modified flags, and pending copies from other textures.
+        /// It should be used if the texture data will be fully overwritten by the next use.
+        /// </summary>
+        public void DiscardData()
+        {
+            Group.DiscardData(this);
+
+            _dirty = false;
+        }
+
+        /// <summary>
         /// Synchronizes guest and host memory.
         /// This will overwrite the texture data with the texture data on the guest memory, if a CPU
         /// modification is detected.

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -279,6 +279,24 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Discards all data for a given texture.
+        /// This clears all dirty flags, modified flags, and pending copies from other textures.
+        /// </summary>
+        /// <param name="texture">The texture being discarded</param>
+        public void DiscardData(Texture texture)
+        {
+            EvaluateRelevantHandles(texture, (baseHandle, regionCount, split) =>
+            {
+                for (int i = 0; i < regionCount; i++)
+                {
+                    TextureGroupHandle group = _handles[baseHandle + i];
+
+                    group.DiscardData();
+                }
+            });
+        }
+
+        /// <summary>
         /// Synchronize memory for a given texture.
         /// If overlapping tracking handles are dirty, fully or partially synchronize the texture data.
         /// </summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -2,7 +2,6 @@
 using Ryujinx.Memory.Tracking;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu.Image
@@ -152,6 +151,24 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 // Linear textures are presumed to be used for readback initially.
                 _flushBalance = FlushBalanceThreshold + FlushBalanceIncrement;
+            }
+        }
+
+        /// <summary>
+        /// Discards all data for this handle.
+        /// This clears all dirty flags, modified flags, and pending copies from other handles.
+        /// </summary>
+        public void DiscardData()
+        {
+            Modified = false;
+            DeferredCopy = null;
+
+            foreach (RegionHandle handle in Handles)
+            {
+                if (handle.Dirty)
+                {
+                    handle.Reprotect();
+                }
             }
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -14,5 +14,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         DepthAlias = 1 << 3,
         WithUpscale = 1 << 4,
         NoCreate = 1 << 5,
+        DiscardData = 1 << 6,
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Window.cs
+++ b/src/Ryujinx.Graphics.Gpu/Window.cs
@@ -200,7 +200,7 @@ namespace Ryujinx.Graphics.Gpu
             {
                 pt.AcquireCallback(_context, pt.UserObj);
 
-                Image.Texture texture = pt.Cache.FindOrCreateTexture(null, TextureSearchFlags.WithUpscale, pt.Info, 0, pt.Range);
+                Image.Texture texture = pt.Cache.FindOrCreateTexture(null, TextureSearchFlags.WithUpscale, pt.Info, 0, range: pt.Range);
 
                 pt.Cache.Tick();
 


### PR DESCRIPTION
When binding a render target, we ask the texture cache for the texture, which synchronizes the data both from guest memory, and performs any deferred copies from other textures with a copy dependency. When clearing a texture, this same path is taken, but it's possible that none of that data that was synchronized or copied would ever be used, meaning it just wasted time.

For us to say we can fully ignore the existing data when clearing a texture, the following conditions need to be met:
- All aspects of the texture must be cleared. For color textures, that's a component mask of 15 (RGBA), and for depth textures, that's depth and stencil clears (including stencil mask) when the texture has depth or stencil aspects.
- Viewport scissor must be disabled or larger than the screen scissor state.
- The texture size must be less than or equal to the screen scissor. (this is passed as the sizeHint to the texture cache)

When all these conditions are met, loading texture data from guest memory and incoming copy dependencies can be entirely skipped.

This aims to unblock https://github.com/Ryujinx/Ryujinx/pull/4365, as it prevents the extra copies from happening in BOTW and TOTK for depth/color aliasing, as these R32/D32 textures are _not_ actually used for the same purpose, but just happen to overlap in memory.

### Benefit:
- When creating textures going directly into a clear, their data does not need to be loaded from guest memory. This saves layout conversion and upload time, which could reduce the stutter when these textures first show up, or need to recreate for some reason.
  - When overlapping incompatible textures already exist (and their data has not been overwritten), the emulator already knows that the data is garbage, so will not load it. The new clear rule has the benefit of not needing any overlapping textures to work, and never accidentally losing any data.
- This could prevent copies from format aliased textures. Most of these actually alias memory right now, but this isn't always optimal and can actually be broken in some cases (older opengl drivers, amd gpus). For cases where it's optimal or required, copying between aliased textures introduces cost that we'd like to skip when possible.
  - One such case is D32->R32 aliasing, which does affect all GPUs. This becomes important with https://github.com/Ryujinx/Ryujinx/pull/4365, which is required for some games to function properly.
  
This rule could become important for a future rewrite of how the texture cache works to better support games like Fast RMX which rapidly rearrange render targets in memory. Generally, the more cases we can "steal" a host texture from another texture whose data has become invalid, the better.

It's probably worth testing this in a variety of games. You probably won't perceive anything being any faster due to this mostly affecting initial texture creation without #4365, but the improvement is there. (games like MK8D/SMO do avoid setting texture data for render targets on creation)