### PR TITLE
GPU: Don't create tracking handles for buffer textures

### DIFF
--- a/src/ARMeilleure/Translation/IntervalTree.cs
+++ b/src/ARMeilleure/Translation/IntervalTree.cs
@@ -189,7 +189,7 @@ namespace ARMeilleure.Translation
             {
                 if (start.CompareTo(node.End) < 0)
                 {
-                    if (overlaps.Length >= overlapCount)
+                    if (overlaps.Length <= overlapCount)
                     {
                         Array.Resize(ref overlaps, overlapCount + ArrayGrowthSize);
                     }

--- a/src/Ryujinx.Common/Collections/IntervalTree.cs
+++ b/src/Ryujinx.Common/Collections/IntervalTree.cs
@@ -192,7 +192,7 @@ namespace Ryujinx.Common.Collections
                     {
                         if (start.CompareTo(overlap.End) < 0)
                         {
-                            if (overlaps.Length >= overlapCount)
+                            if (overlaps.Length <= overlapCount)
                             {
                                 Array.Resize(ref overlaps, overlapCount + ArrayGrowthSize);
                             }

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -642,11 +642,14 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             // Find view compatible matches.
-            int overlapsCount;
+            int overlapsCount = 0;
 
-            lock (_textures)
+            if (info.Target != Target.TextureBuffer)
             {
-                overlapsCount = _textures.FindOverlaps(range.Value, ref _textureOverlaps);
+                lock (_textures)
+                {
+                    overlapsCount = _textures.FindOverlaps(range.Value, ref _textureOverlaps);
+                }
             }
 
             if (_overlapInfo.Length != _textureOverlaps.Length)

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -79,6 +79,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         private int[] _allOffsets;
         private int[] _sliceSizes;
         private readonly bool _is3D;
+        private readonly bool _isBuffer;
         private bool _hasMipViews;
         private bool _hasLayerViews;
         private readonly int _layers;
@@ -118,6 +119,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             _physicalMemory = physicalMemory;
 
             _is3D = storage.Info.Target == Target.Texture3D;
+            _isBuffer = storage.Info.Target == Target.TextureBuffer;
             _layers = storage.Info.GetSlices();
             _levels = storage.Info.Levels;
 
@@ -776,7 +778,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             int targetLayerHandles = _hasLayerViews ? slices : 1;
             int targetLevelHandles = _hasMipViews ? levels : 1;
 
-            if (_is3D)
+            if (_isBuffer)
+            {
+                return;
+            }
+            else if (_is3D)
             {
                 // Future mip levels come after all layers of the last mip level. Each mipmap has less layers (depth) than the last.
 
@@ -1309,7 +1315,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             TextureGroupHandle[] handles;
 
-            if (!(_hasMipViews || _hasLayerViews))
+            if (_isBuffer)
+            {
+                handles = Array.Empty<TextureGroupHandle>();
+            }
+            else if (!(_hasMipViews || _hasLayerViews))
             {
                 // Single dirty region.
                 var cpuRegionHandles = new RegionHandle[TextureRange.Count];


### PR DESCRIPTION
Buffer texture memory is handled by the buffer cache - the texture shouldn't create any tracking handles as they aren't used. This change simply makes them create and iterate 0 tracking handles, while keeping the rest of the texture group around.

This prevents a possible issue where many buffer textures are created as views of overlapping buffer ranges, and virtual regions have many dependant textures that don't actually contribute anything to handle state.

Also included:
- Fix a longstanding issue where every texture returned from the interval tree lookup would resize the lookup array. (yes, every)
- Buffer textures now skip checking view compatibility with any other textures, since they are never compatible and don't remove each other due to overlap.
  - In MK1, more than 100 buffer textures would overlap at once, making this overlap check very expensive as well as pointless.

This PR is thanks to testing and profiling by @gdkchan. I don't have an affected game myself.

Should improve performance in Mortal Kombat 1, possibly certain UE4 games when FIFO raises to 100%. Needs testing in UE4 games and the 2 Mortal Kombat games.