### PR TITLE
Ava: Fix regressions by rewriting CheckLaunchState

### DIFF
--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -278,11 +278,23 @@ namespace Ryujinx.Ava.UI.Windows
 
                 if (LinuxHelper.PkExecPath is not null)
                 {
-                    ShowVmMaxMapCountDialog().Wait();
+                    Dispatcher.UIThread.Post(async () =>
+                    {
+                        if (OperatingSystem.IsLinux())
+                        {
+                            await ShowVmMaxMapCountDialog();
+                        }
+                    });
                 }
                 else
                 {
-                    ShowVmMaxMapCountWarning().Wait();
+                    Dispatcher.UIThread.Post(async () =>
+                    {
+                        if (OperatingSystem.IsLinux())
+                        {
+                            await ShowVmMaxMapCountWarning();
+                        }
+                    });
                 }
             }
 

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -265,13 +265,6 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void CheckLaunchState()
         {
-            if (ShowKeyErrorOnLoad)
-            {
-                ShowKeyErrorOnLoad = false;
-
-                Dispatcher.UIThread.Post(async () => await UserErrorDialog.ShowUserErrorDialog(UserError.NoKeys));
-            }
-
             if (OperatingSystem.IsLinux() && LinuxHelper.VmMaxMapCount < LinuxHelper.RecommendedVmMaxMapCount)
             {
                 Logger.Warning?.Print(LogClass.Application, $"The value of vm.max_map_count is lower than {LinuxHelper.RecommendedVmMaxMapCount}. ({LinuxHelper.VmMaxMapCount})");
@@ -298,11 +291,20 @@ namespace Ryujinx.Ava.UI.Windows
                 }
             }
 
-            if (_deferLoad)
+            if (!ShowKeyErrorOnLoad)
             {
-                _deferLoad = false;
+                if (_deferLoad)
+                {
+                    _deferLoad = false;
 
-                ViewModel.LoadApplication(_launchPath, _startFullscreen).Wait();
+                    ViewModel.LoadApplication(_launchPath, _startFullscreen).Wait();
+                }
+            }
+            else
+            {
+                ShowKeyErrorOnLoad = false;
+
+                Dispatcher.UIThread.Post(async () => await UserErrorDialog.ShowUserErrorDialog(UserError.NoKeys));
             }
 
             if (ConfigurationState.Instance.CheckUpdatesOnStart.Value && Updater.CanUpdate(false))

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -269,7 +269,7 @@ namespace Ryujinx.Ava.UI.Windows
             {
                 ShowKeyErrorOnLoad = false;
 
-                UserErrorDialog.ShowUserErrorDialog(UserError.NoKeys).Wait();
+                Dispatcher.UIThread.Post(async () => await UserErrorDialog.ShowUserErrorDialog(UserError.NoKeys));
             }
 
             if (OperatingSystem.IsLinux() && LinuxHelper.VmMaxMapCount < LinuxHelper.RecommendedVmMaxMapCount)


### PR DESCRIPTION
This fix a regression caused by #5516 when CheckLaunchState is assumed to be executed async.
Since the UI isn't created when launch state are check, the vmcount popup, the missing keys popup or the fullscreen game loading on startup just make the UI hang.
if we revert the async changes to use the dispatcher and rewrite the method, it works as expected.