### PR TITLE
Ryujinx.Ava: Fix menus on gamescope

### DIFF
--- a/src/Ryujinx.Ava/Program.cs
+++ b/src/Ryujinx.Ava/Program.cs
@@ -60,6 +60,7 @@ namespace Ryujinx.Ava
                     EnableMultiTouch = true,
                     EnableIme = true,
                     RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Software },
+                    OverlayPopups = true,
                 })
                 .With(new Win32PlatformOptions
                 {


### PR DESCRIPTION
gamescope seems to only support rendering one surface window at a time.

This works fine for our GTK frontend as everything is embedded in the same window.

Avalonia on the other hand will attempt to create a new window for every menu, making them not render properly.

Adding insult to the injury, gamescope seems to ignore the surface update for those Avalonia's menus and refuse to present them.

To workaround all of this, we switch OverlayPopups to true to ensure we embed all popups in the window.

Note that all our current dialogs (about us, warning about keys,...) will still show on top without the main window behind because of gamescope behavior.