### PR TITLE
Fix audio renderer compressor effect

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/AuxiliaryBufferCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/AuxiliaryBufferCommand.cs
@@ -31,9 +31,18 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public bool IsEffectEnabled { get; }
 
-        public AuxiliaryBufferCommand(uint bufferOffset, byte inputBufferOffset, byte outputBufferOffset,
-                          ref AuxiliaryBufferAddresses sendBufferInfo, bool isEnabled, uint countMax,
-                          CpuAddress outputBuffer, CpuAddress inputBuffer, uint updateCount, uint writeOffset, int nodeId)
+        public AuxiliaryBufferCommand(
+            uint bufferOffset,
+            byte inputBufferOffset,
+            byte outputBufferOffset,
+            ref AuxiliaryBufferAddresses sendBufferInfo,
+            bool isEnabled,
+            uint countMax,
+            CpuAddress outputBuffer,
+            CpuAddress inputBuffer,
+            uint updateCount,
+            uint writeOffset,
+            int nodeId)
         {
             Enabled = true;
             NodeId = nodeId;

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/BiquadFilterCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/BiquadFilterCommand.cs
@@ -21,7 +21,14 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         private BiquadFilterParameter _parameter;
 
-        public BiquadFilterCommand(int baseIndex, ref BiquadFilterParameter filter, Memory<BiquadFilterState> biquadFilterStateMemory, int inputBufferOffset, int outputBufferOffset, bool needInitialization, int nodeId)
+        public BiquadFilterCommand(
+            int baseIndex,
+            ref BiquadFilterParameter filter,
+            Memory<BiquadFilterState> biquadFilterStateMemory,
+            int inputBufferOffset,
+            int outputBufferOffset,
+            bool needInitialization,
+            int nodeId)
         {
             _parameter = filter;
             BiquadFilterState = biquadFilterStateMemory;

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/CommandList.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/CommandList.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void ClearBuffer(int index)
         {
-            Unsafe.InitBlock((void*)GetBufferPointer(index), 0, SampleCount);
+            Unsafe.InitBlock((void*)GetBufferPointer(index), 0, SampleCount* sizeof(float));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -89,7 +89,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void CopyBuffer(int outputBufferIndex, int inputBufferIndex)
         {
-            Unsafe.CopyBlock((void*)GetBufferPointer(outputBufferIndex), (void*)GetBufferPointer(inputBufferIndex), SampleCount);
+            Unsafe.CopyBlock((void*)GetBufferPointer(outputBufferIndex), (void*)GetBufferPointer(inputBufferIndex), SampleCount * sizeof(float));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/CommandList.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/CommandList.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void ClearBuffer(int index)
         {
-            Unsafe.InitBlock((void*)GetBufferPointer(index), 0, SampleCount* sizeof(float));
+            Unsafe.InitBlock((void*)GetBufferPointer(index), 0, SampleCount * sizeof(float));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/CompressorCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/CompressorCommand.cs
@@ -94,18 +94,18 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
                     float newMean = inputMovingAverage.Update(FloatingPointHelper.MeanSquare(channelInput), _parameter.InputGain);
                     float y = FloatingPointHelper.Log10(newMean) * 10.0f;
-                    float z = 0.0f;
+                    float z = 1.0f;
 
-                    bool unknown10OutOfRange = false;
+                    bool unknown10OutOfRange = y >= state.Unknown10;
 
                     if (newMean < 1.0e-10f)
                     {
-                        z = 1.0f;
+                        y = -100.0f;
 
                         unknown10OutOfRange = state.Unknown10 <= -100.0f;
                     }
 
-                    if (y >= state.Unknown10 || unknown10OutOfRange)
+                    if (unknown10OutOfRange)
                     {
                         float tmpGain;
 

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/CompressorCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/CompressorCommand.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                     {
                         z = 1.0f;
 
-                        unknown10OutOfRange = state.Unknown10 < -100.0f;
+                        unknown10OutOfRange = state.Unknown10 <= -100.0f;
                     }
 
                     if (y >= state.Unknown10 || unknown10OutOfRange)
@@ -118,7 +118,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                             tmpGain = (y - state.Unknown10) * ((y - state.Unknown10) * -state.CompressorGainReduction);
                         }
 
-                        z = FloatingPointHelper.DecibelToLinearExtended(tmpGain);
+                        z = FloatingPointHelper.DecibelToLinear(tmpGain);
                     }
 
                     float unknown4New = z;

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
@@ -88,7 +88,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             float outGain = FixedPointHelper.ToFloat(Parameter.OutGain, FixedPointPrecision);
 
             Matrix2x2 delayFeedback = new(delayFeedbackBaseGain, delayFeedbackCrossGain,
-                                                    delayFeedbackCrossGain, delayFeedbackBaseGain);
+                                          delayFeedbackCrossGain, delayFeedbackBaseGain);
 
             for (int i = 0; i < sampleCount; i++)
             {
@@ -125,9 +125,9 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             float outGain = FixedPointHelper.ToFloat(Parameter.OutGain, FixedPointPrecision);
 
             Matrix4x4 delayFeedback = new(delayFeedbackBaseGain, delayFeedbackCrossGain, delayFeedbackCrossGain, 0.0f,
-                                                    delayFeedbackCrossGain, delayFeedbackBaseGain, 0.0f, delayFeedbackCrossGain,
-                                                    delayFeedbackCrossGain, 0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain,
-                                                    0.0f, delayFeedbackCrossGain, delayFeedbackCrossGain, delayFeedbackBaseGain);
+                                          delayFeedbackCrossGain, delayFeedbackBaseGain, 0.0f, delayFeedbackCrossGain,
+                                          delayFeedbackCrossGain, 0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain,
+                                          0.0f, delayFeedbackCrossGain, delayFeedbackCrossGain, delayFeedbackBaseGain);
 
 
             for (int i = 0; i < sampleCount; i++)
@@ -172,11 +172,11 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             float outGain = FixedPointHelper.ToFloat(Parameter.OutGain, FixedPointPrecision);
 
             Matrix6x6 delayFeedback = new(delayFeedbackBaseGain, 0.0f, delayFeedbackCrossGain, 0.0f, delayFeedbackCrossGain, 0.0f,
-                                                    0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackCrossGain,
-                                                    delayFeedbackCrossGain, delayFeedbackCrossGain, delayFeedbackBaseGain, 0.0f, 0.0f, 0.0f,
-                                                    0.0f, 0.0f, 0.0f, feedbackGain, 0.0f, 0.0f,
-                                                    delayFeedbackCrossGain, 0.0f, 0.0f, 0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain,
-                                                    0.0f, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackCrossGain, delayFeedbackBaseGain);
+                                          0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackCrossGain,
+                                          delayFeedbackCrossGain, delayFeedbackCrossGain, delayFeedbackBaseGain, 0.0f, 0.0f, 0.0f,
+                                          0.0f, 0.0f, 0.0f, feedbackGain, 0.0f, 0.0f,
+                                          delayFeedbackCrossGain, 0.0f, 0.0f, 0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain,
+                                          0.0f, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackCrossGain, delayFeedbackBaseGain);
 
             for (int i = 0; i < sampleCount; i++)
             {

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion2.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion2.cs
@@ -28,7 +28,14 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         private LimiterParameter _parameter;
 
-        public LimiterCommandVersion2(uint bufferOffset, LimiterParameter parameter, Memory<LimiterState> state, Memory<EffectResultState> resultState, bool isEnabled, ulong workBuffer, int nodeId)
+        public LimiterCommandVersion2(
+            uint bufferOffset,
+            LimiterParameter parameter,
+            Memory<LimiterState> state,
+            Memory<EffectResultState> resultState,
+            bool isEnabled,
+            ulong workBuffer,
+            int nodeId)
         {
             Enabled = true;
             NodeId = nodeId;

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/ReverbCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/ReverbCommand.cs
@@ -79,53 +79,57 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessReverbMono(ref ReverbState state, ReadOnlySpan<IntPtr> outputBuffers, ReadOnlySpan<IntPtr> inputBuffers, uint sampleCount)
         {
-            ProcessReverbGeneric(ref state,
-                     outputBuffers,
-                     inputBuffers,
-                     sampleCount,
-                     _outputEarlyIndicesTableMono,
-                     _targetEarlyDelayLineIndicesTableMono,
-                     _targetOutputFeedbackIndicesTableMono,
-                     _outputIndicesTableMono);
+            ProcessReverbGeneric(
+                ref state,
+                outputBuffers,
+                inputBuffers,
+                sampleCount,
+                _outputEarlyIndicesTableMono,
+                _targetEarlyDelayLineIndicesTableMono,
+                _targetOutputFeedbackIndicesTableMono,
+                _outputIndicesTableMono);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessReverbStereo(ref ReverbState state, ReadOnlySpan<IntPtr> outputBuffers, ReadOnlySpan<IntPtr> inputBuffers, uint sampleCount)
         {
-            ProcessReverbGeneric(ref state,
-                     outputBuffers,
-                     inputBuffers,
-                     sampleCount,
-                     _outputEarlyIndicesTableStereo,
-                     _targetEarlyDelayLineIndicesTableStereo,
-                     _targetOutputFeedbackIndicesTableStereo,
-                     _outputIndicesTableStereo);
+            ProcessReverbGeneric(
+                ref state,
+                outputBuffers,
+                inputBuffers,
+                sampleCount,
+                _outputEarlyIndicesTableStereo,
+                _targetEarlyDelayLineIndicesTableStereo,
+                _targetOutputFeedbackIndicesTableStereo,
+                _outputIndicesTableStereo);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessReverbQuadraphonic(ref ReverbState state, ReadOnlySpan<IntPtr> outputBuffers, ReadOnlySpan<IntPtr> inputBuffers, uint sampleCount)
         {
-            ProcessReverbGeneric(ref state,
-                     outputBuffers,
-                     inputBuffers,
-                     sampleCount,
-                     _outputEarlyIndicesTableQuadraphonic,
-                     _targetEarlyDelayLineIndicesTableQuadraphonic,
-                     _targetOutputFeedbackIndicesTableQuadraphonic,
-                     _outputIndicesTableQuadraphonic);
+            ProcessReverbGeneric(
+                ref state,
+                outputBuffers,
+                inputBuffers,
+                sampleCount,
+                _outputEarlyIndicesTableQuadraphonic,
+                _targetEarlyDelayLineIndicesTableQuadraphonic,
+                _targetOutputFeedbackIndicesTableQuadraphonic,
+                _outputIndicesTableQuadraphonic);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessReverbSurround(ref ReverbState state, ReadOnlySpan<IntPtr> outputBuffers, ReadOnlySpan<IntPtr> inputBuffers, uint sampleCount)
         {
-            ProcessReverbGeneric(ref state,
-                     outputBuffers,
-                     inputBuffers,
-                     sampleCount,
-                     _outputEarlyIndicesTableSurround,
-                     _targetEarlyDelayLineIndicesTableSurround,
-                     _targetOutputFeedbackIndicesTableSurround,
-                     _outputIndicesTableSurround);
+            ProcessReverbGeneric(
+                ref state,
+                outputBuffers,
+                inputBuffers,
+                sampleCount,
+                _outputEarlyIndicesTableSurround,
+                _targetEarlyDelayLineIndicesTableSurround,
+                _targetOutputFeedbackIndicesTableSurround,
+                _outputIndicesTableSurround);
         }
 
         private unsafe void ProcessReverbGeneric(ref ReverbState state, ReadOnlySpan<IntPtr> outputBuffers, ReadOnlySpan<IntPtr> inputBuffers, uint sampleCount, ReadOnlySpan<int> outputEarlyIndicesTable, ReadOnlySpan<int> targetEarlyDelayLineIndicesTable, ReadOnlySpan<int> targetOutputFeedbackIndicesTable, ReadOnlySpan<int> outputIndicesTable)

--- a/src/Ryujinx.Audio/Renderer/Dsp/FloatingPointHelper.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/FloatingPointHelper.cs
@@ -62,7 +62,8 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
             foreach (float input in inputs)
             {
-                res += (input * input);
+                float normInput = input * (1f / 32768f);
+                res += normInput * normInput;
             }
 
             res /= inputs.Length;

--- a/src/Ryujinx.Audio/Renderer/Dsp/FloatingPointHelper.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/FloatingPointHelper.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
         {
             // NOTE: Nintendo uses an approximation of log10, we don't.
             // As such, we support the same ranges as Nintendo to avoid unexpected behaviours.
-            return MathF.Pow(10, MathF.Max(x, 1.0e-10f));
+            return MathF.Log10(MathF.Max(x, 1.0e-10f));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -79,19 +79,6 @@ namespace Ryujinx.Audio.Renderer.Dsp
         public static float DecibelToLinear(float db)
         {
             return MathF.Pow(10.0f, db / 20.0f);
-        }
-
-        /// <summary>
-        /// Map decibel to linear in [0, 2] range.
-        /// </summary>
-        /// <param name="db">The decibel value to convert</param>
-        /// <returns>Converted linear value in [0, 2] range</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float DecibelToLinearExtended(float db)
-        {
-            float tmp = MathF.Log2(DecibelToLinear(db));
-
-            return MathF.Truncate(tmp) + MathF.Pow(2.0f, tmp - MathF.Truncate(tmp));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/CompressorState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/CompressorState.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.State
             CompressorGainReduction = (1.0f - ratio) / Constants.ChannelCountMax;
             Unknown10 = threshold - 1.5f;
             Unknown14 = threshold + 1.5f;
-            OutputGain = FloatingPointHelper.DecibelToLinearExtended(parameter.OutputGain + makeupGain);
+            OutputGain = FloatingPointHelper.DecibelToLinear(parameter.OutputGain + makeupGain);
         }
     }
 }

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/CompressorState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/CompressorState.cs
@@ -3,7 +3,7 @@ using Ryujinx.Audio.Renderer.Parameter.Effect;
 
 namespace Ryujinx.Audio.Renderer.Dsp.State
 {
-    public class CompressorState
+    public struct CompressorState
     {
         public ExponentialMovingAverage InputMovingAverage;
         public float Unknown4;

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/DelayState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/DelayState.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Audio.Renderer.Dsp.State
 {
-    public class DelayState
+    public struct DelayState
     {
         public DelayLine[] DelayLines { get; }
         public float[] LowPassZ { get; set; }

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/DelayState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/DelayState.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.State
             LowPassBaseGain = 1.0f - LowPassFeedbackGain;
         }
 
-        public void UpdateLowPassFilter(ref float tempRawRef, uint channelCount)
+        public readonly void UpdateLowPassFilter(ref float tempRawRef, uint channelCount)
         {
             for (int i = 0; i < channelCount; i++)
             {

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/LimiterState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/LimiterState.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Ryujinx.Audio.Renderer.Dsp.State
 {
-    public class LimiterState
+    public struct LimiterState
     {
         public ExponentialMovingAverage[] DetectorAverage;
         public ExponentialMovingAverage[] CompressionGainAverage;

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/Reverb3dState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/Reverb3dState.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Ryujinx.Audio.Renderer.Dsp.State
 {
-    public class Reverb3dState
+    public struct Reverb3dState
     {
         private readonly float[] _fdnDelayMinTimes = new float[4] { 5.0f, 6.0f, 13.0f, 14.0f };
         private readonly float[] _fdnDelayMaxTimes = new float[4] { 45.704f, 82.782f, 149.94f, 271.58f };

--- a/src/Ryujinx.Audio/Renderer/Dsp/State/ReverbState.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/State/ReverbState.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Ryujinx.Audio.Renderer.Dsp.State
 {
-    public class ReverbState
+    public struct ReverbState
     {
         private static readonly float[] _fdnDelayTimes = new float[20]
         {
@@ -54,7 +54,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.State
             // Room
             0.70f, 0.68f, 0.70f, 0.68f, 0.70f, 0.68f, 0.70f, 0.68f, 0.68f, 0.68f,
             // Chamber
-            0.70f, 0.68f, 0.70f, 0.68f, 0.70f, 0.68f, 0.68f, 0.68f, 0.68f, 0.68f, 
+            0.70f, 0.68f, 0.70f, 0.68f, 0.70f, 0.68f, 0.68f, 0.68f, 0.68f, 0.68f,
             // Hall
             0.50f, 0.70f, 0.70f, 0.68f, 0.50f, 0.68f, 0.68f, 0.70f, 0.68f, 0.00f,
             // Cathedral


### PR DESCRIPTION
This fixes a few audio renderer issues (mostly related to the compressor effect):
- The `DecibelToLinearExtended` function doesn't exist, it is supposed to be the same as `DecibelToLinear`.
- `FloatingPointHelper.Log10` was wrong, it was doing `pow(10, x)` rather than `log(x, 10)`.
- `FloatingPointHelper.MeanSquare` was not normalizing the input values, causing the result to be too high.
- Incorrect control flow on `ProcessCompressor`, `z` was being intialized to the wrong value in one case (0.0 instead of 1.0).
- `CommandList.ClearBuffer` and `CommandList.CopyBuffer` had wrong lengths, it was using the raw sample count as length, instead of multiplying it by sample size, so it was not actually clearing/copying everything.
- A few of the effect state were classes rather than struct. I assume this is an oversight since they are passed using `ref` and stored in a `Memory<T>`, which would not be necessary for classes which are already passed by reference anyway. This was actually causing a NRE on the `CompressorCommand` when I added some logging, because the state was not being initialized since the status was never `Invalid` or `New`, although this was probably a different bug.

I also changed some formatting to make the code more readable.
This fixes games using the compressor effect having no sound, the broken calculation made the output be NaN which would be converted to integer 0.

Fixes #5740.
Testing is welcome (not only on this bug other games using audren to ensure that nothing broke).