### PR TITLE
Added option to invert gyroscope's Z motion 

### DIFF
--- a/src/Ryujinx.Common/Configuration/Hid/Controller/Motion/MotionConfigController.cs
+++ b/src/Ryujinx.Common/Configuration/Hid/Controller/Motion/MotionConfigController.cs
@@ -21,5 +21,10 @@ namespace Ryujinx.Common.Configuration.Hid.Controller.Motion
         /// Enable Motion Controls
         /// </summary>
         public bool EnableMotion { get; set; }
+
+        /// <summary>
+        /// Invert Z axis (Horizontal)
+        /// </summary>
+        public bool InvertZAxis { get; set; }
     }
 }

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -297,8 +297,9 @@ namespace Ryujinx.Input.HLE
 
                             accelerometer = new Vector3(accelerometer.X, -accelerometer.Z, accelerometer.Y);
 
-                            var gyroZ = -gyroscope.Z;
-                            if (controllerConfig.Motion.InvertZAxis) gyroZ *= -1;
+                            float gyroZ = -gyroscope.Z;
+                            if (controllerConfig.Motion.InvertZAxis) 
+                                gyroZ *= -1;
                             gyroscope = new Vector3(gyroscope.X, gyroZ, gyroscope.Y);
 
                             _leftMotionInput.Update(accelerometer, gyroscope, (ulong)PerformanceCounter.ElapsedNanoseconds / 1000, controllerConfig.Motion.Sensitivity, (float)controllerConfig.Motion.GyroDeadzone);

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -296,7 +296,10 @@ namespace Ryujinx.Input.HLE
                             Vector3 gyroscope = _gamepad.GetMotionData(MotionInputId.Gyroscope);
 
                             accelerometer = new Vector3(accelerometer.X, -accelerometer.Z, accelerometer.Y);
-                            gyroscope = new Vector3(gyroscope.X, -gyroscope.Z, gyroscope.Y);
+
+                            var gyroZ = -gyroscope.Z;
+                            if (controllerConfig.Motion.InvertZAxis) gyroZ *= -1;
+                            gyroscope = new Vector3(gyroscope.X, gyroZ, gyroscope.Y);
 
                             _leftMotionInput.Update(accelerometer, gyroscope, (ulong)PerformanceCounter.ElapsedNanoseconds / 1000, controllerConfig.Motion.Sensitivity, (float)controllerConfig.Motion.GyroDeadzone);
 

--- a/src/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/src/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -184,7 +184,6 @@ namespace Ryujinx.Ui.Windows
             _rSl.Clicked += Button_Pressed;
             _rSr.Clicked += Button_Pressed;
             _enableCemuHook.Clicked += CemuHookCheckButtonPressed;
-            _enableMotionInvertZ.Clicked += InvertMotionZPressed;
 
             // Setup current values.
             UpdateInputDeviceList();
@@ -205,11 +204,6 @@ namespace Ryujinx.Ui.Windows
         private void CemuHookCheckButtonPressed(object sender, EventArgs e)
         {
             UpdateCemuHookSpecificFieldsVisibility();
-        }
-
-        private void InvertMotionZPressed(object sender, EventArgs e)
-        {
-            
         }
 
         private void HandleOnGamepadDisconnected(string id)

--- a/src/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/src/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -45,6 +45,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] Adjustment _gyroDeadzone;
         [GUI] CheckButton _enableMotion;
         [GUI] CheckButton _enableCemuHook;
+        [GUI] CheckButton _enableMotionInvertZ;
         [GUI] CheckButton _mirrorInput;
         [GUI] Entry _dsuServerHost;
         [GUI] Entry _dsuServerPort;
@@ -183,6 +184,7 @@ namespace Ryujinx.Ui.Windows
             _rSl.Clicked += Button_Pressed;
             _rSr.Clicked += Button_Pressed;
             _enableCemuHook.Clicked += CemuHookCheckButtonPressed;
+            _enableMotionInvertZ.Clicked += InvertMotionZPressed;
 
             // Setup current values.
             UpdateInputDeviceList();
@@ -203,6 +205,11 @@ namespace Ryujinx.Ui.Windows
         private void CemuHookCheckButtonPressed(object sender, EventArgs e)
         {
             UpdateCemuHookSpecificFieldsVisibility();
+        }
+
+        private void InvertMotionZPressed(object sender, EventArgs e)
+        {
+            
         }
 
         private void HandleOnGamepadDisconnected(string id)
@@ -434,6 +441,7 @@ namespace Ryujinx.Ui.Windows
             _dsuServerHost.Buffer.Text = "";
             _dsuServerPort.Buffer.Text = "";
             _enableRumble.Active = false;
+            _enableMotionInvertZ.Active = false;
         }
 
         private void SetValues(InputConfig config)
@@ -526,6 +534,7 @@ namespace Ryujinx.Ui.Windows
                     _gyroDeadzone.Value = controllerConfig.Motion.GyroDeadzone;
                     _enableMotion.Active = controllerConfig.Motion.EnableMotion;
                     _enableCemuHook.Active = controllerConfig.Motion.MotionBackend == MotionInputBackendType.CemuHook;
+                    _enableMotionInvertZ.Active = controllerConfig.Motion.InvertZAxis;
 
                     // If both stick ranges are 0 (usually indicative of an outdated profile load) then both sticks will be set to 1.0.
                     if (_controllerRangeLeft.Value <= 0.0 && _controllerRangeRight.Value <= 0.0)
@@ -690,6 +699,7 @@ namespace Ryujinx.Ui.Windows
                         EnableMotion = _enableMotion.Active,
                         Sensitivity = (int)_sensitivity.Value,
                         GyroDeadzone = _gyroDeadzone.Value,
+                        InvertZAxis = _enableMotionInvertZ.Active
                     };
                 }
 

--- a/src/Ryujinx/Ui/Windows/ControllerWindow.glade
+++ b/src/Ryujinx/Ui/Windows/ControllerWindow.glade
@@ -1868,6 +1868,20 @@
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkCheckButton" id="_enableMotionInvertZ">
+                                        <property name="label" translatable="yes">Invert Z axis (Horizontal)</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkCheckButton" id="_enableCemuHook">
                                         <property name="label" translatable="yes">Use CemuHook compatible motion</property>
                                         <property name="visible">True</property>
@@ -1878,7 +1892,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">2</property>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1921,7 +1935,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">3</property>
+                                        <property name="position">4</property>
                                       </packing>
                                     </child>
                                     <child>


### PR DESCRIPTION
Horizontal gyroscope motion can be broken for some people. I've seen previous PR that's related to this issue: #3284. That did not fix it for me so I decided to add option to allow users to change that behavior.

Added `InvertZAzis` field to MotionConfigController and option to change it in UI:
![image](https://github.com/Ryujinx/Ryujinx/assets/48125186/9d4175ed-c848-4687-ab2f-f4fd175522c6)

It still prefers fix from #3284 and uses `-gyroscope.Z` by default.