### PR TITLE
Decrement nvmap reference count on surface flinger prealloc

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -669,6 +669,12 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             lock (Core.Lock)
             {
+                // If we are replacing a buffer that has already been queued, make sure we release the references.
+                if (Core.Slots[slot].BufferState == BufferState.Queued)
+                {
+                    Core.Slots[slot].GraphicBuffer.Object.DecrementNvMapHandleRefCount(Core.Owner);
+                }
+
                 Core.Slots[slot].BufferState = BufferState.Free;
                 Core.Slots[slot].Fence = AndroidFence.NoFence;
                 Core.Slots[slot].RequestBufferCalled = false;


### PR DESCRIPTION
The game Sifu was calling `SetPreallocatedBuffer` and replacing buffers that have been queued. Because it is replaced before consumption, the nvmap reference count is never decremented, and this later causes the nvmap `Free` call to set the `NotYetFreed` flag. This prevents the memory attributes from being restored from `Uncached` to `None`, which in turn causes the `UnmapPhysicalMemory` to return an error, and ultimately the game crashes with `GuestProgramBrokeExecution`. This is fixed here by making sure the problematic case also decrements the reference count. The crash was somewhat random though.