### PR TITLE
Avalonia: Add macOS check for Color Space Passthrough

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
@@ -147,6 +147,13 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool EnableTextureRecompression { get; set; }
         public bool EnableMacroHLE { get; set; }
         public bool EnableColorSpacePassthrough { get; set; }
+        public static bool ColorSpacePassthroughAvailable
+        {
+            get
+            {
+                return OperatingSystem.IsMacOS();
+            }
+        }
         public bool EnableFileLog { get; set; }
         public bool EnableStub { get; set; }
         public bool EnableInfo { get; set; }

--- a/src/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
@@ -147,13 +147,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool EnableTextureRecompression { get; set; }
         public bool EnableMacroHLE { get; set; }
         public bool EnableColorSpacePassthrough { get; set; }
-        public static bool ColorSpacePassthroughAvailable
-        {
-            get
-            {
-                return OperatingSystem.IsMacOS();
-            }
-        }
+        public bool ColorSpacePassthroughAvailable => IsMacOS;
         public bool EnableFileLog { get; set; }
         public bool EnableStub { get; set; }
         public bool EnableInfo { get; set; }

--- a/src/Ryujinx.Ava/UI/Views/Settings/SettingsGraphicsView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Settings/SettingsGraphicsView.axaml
@@ -73,6 +73,7 @@
                             <TextBlock Text="{locale:Locale SettingsEnableMacroHLE}" />
                         </CheckBox>
                         <CheckBox IsChecked="{Binding EnableColorSpacePassthrough}"
+                                  IsVisible="{Binding ColorSpacePassthroughAvailable}"
                             ToolTip.Tip="{locale:Locale SettingsEnableColorSpacePassthroughTooltip}">
                             <TextBlock Text="{locale:Locale SettingsEnableColorSpacePassthrough}" />
                         </CheckBox>


### PR DESCRIPTION
### Description
Gates the new color space passthrough option behind a check for whether the user is on macOS.
### Motivation/Context
Users have reported being confused about what this option does and/or why it doesn't work. When the option was added, it was unclear whether other operating systems and Vulkan drivers might support the passthrough color space. It seems clear since that macOS and MoltenVK are the only combination for which passthrough is currently supported, implemented and exposed.
### Discussion
Initially, I explored a check for whether the passthrough color space is actually supported. However, this would involve a significant amount of added plumbing, since Ryujinx normally does not check for available color spaces until after a `VulkanRenderer` has already been initialized with a window, surface, and swapchain. For now, it seems sufficient to simply check for macOS, and revisit this check when other operating systems support color space intermingling the way macOS does.