### PR TITLE
Skip some invalid texture flushes

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -107,8 +107,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                             // Any texture that has been unmapped at any point or is partially unmapped
                             // should update their pool references after the remap completes.
 
-                            MultiRange unmapped = ((MemoryManager)sender).GetPhysicalRegions(e.Address, e.Size);
-
                             foreach (var texture in _partiallyMappedTextures)
                             {
                                 texture.UpdatePoolMappings();

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1659,6 +1659,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return;
             }
 
+            // If size is zero, we have nothing to flush.
+            // If the flush is stale, we should ignore it because the texture was unmapped since the modified
+            // flag was set, and flushing it is not safe anymore as the GPU might no longer own the memory.
+            if (size == 0 || Storage.FlushStale)
+            {
+                return;
+            }
+
             // There is a small gap here where the action is removed but _actionRegistered is still 1.
             // In this case it will skip registering the action, but here we are already handling it,
             // so there shouldn't be any issue as it's the same handler for all actions.


### PR DESCRIPTION
Flushing texture data after the texture has been unmapped from GPU memory is generally considered invalid/dangerous. That is because at this point, the GPU no longer owns it, and the CPU might be using the memory for something else, which means that flushing the texture may cause data corruption.

We already have something in place to prevent flushing after unmap, but it doesn't work for render targets, since after the render target is swapped out, it sets the modified flag again. This PR adds an additional flag to skip flush if the texture has been unmapped, and not bound/modified after the unmap.

This fixes memory corruption on Neptunia GameMaker R:Evolution (#5546), which now goes ingame (it was crashing before showing anything before):
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/61859f25-f74f-4039-9690-63672f571f21)

Testing is welcome to ensure nothing broke, especially on OpenGL games which does weird things with textures.