### PR TITLE
Use unique temporary variables for function call parameters on SPIR-V

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5750;
+        private const uint CodeGenVersion = 5757;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -44,7 +44,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
         public StructuredFunction CurrentFunction { get; set; }
         private readonly Dictionary<AstOperand, Instruction> _locals = new();
-        private readonly Dictionary<int, Instruction[]> _localForArgs = new();
         private readonly Dictionary<int, Instruction> _funcArgs = new();
         private readonly Dictionary<int, (StructuredFunction, Instruction)> _functions = new();
 
@@ -112,7 +111,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             IsMainFunction = isMainFunction;
             MayHaveReturned = false;
             _locals.Clear();
-            _localForArgs.Clear();
             _funcArgs.Clear();
         }
 
@@ -167,11 +165,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
         public void DeclareLocal(AstOperand local, Instruction spvLocal)
         {
             _locals.Add(local, spvLocal);
-        }
-
-        public void DeclareLocalForArgs(int funcIndex, Instruction[] spvLocals)
-        {
-            _localForArgs.Add(funcIndex, spvLocals);
         }
 
         public void DeclareArgument(int argIndex, Instruction spvLocal)
@@ -276,11 +269,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
         public Instruction GetLocalPointer(AstOperand local)
         {
             return _locals[local];
-        }
-
-        public Instruction[] GetLocalForArgsPointers(int funcIndex)
-        {
-            return _localForArgs[funcIndex];
         }
 
         public Instruction GetArgumentPointer(AstOperand funcArg)

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -41,28 +41,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             }
         }
 
-        public static void DeclareLocalForArgs(CodeGenContext context, List<StructuredFunction> functions)
-        {
-            for (int funcIndex = 0; funcIndex < functions.Count; funcIndex++)
-            {
-                StructuredFunction function = functions[funcIndex];
-                SpvInstruction[] locals = new SpvInstruction[function.InArguments.Length];
-
-                for (int i = 0; i < function.InArguments.Length; i++)
-                {
-                    var type = function.GetArgumentType(i);
-                    var localPointerType = context.TypePointer(StorageClass.Function, context.GetType(type));
-                    var spvLocal = context.Variable(localPointerType, StorageClass.Function);
-
-                    context.AddLocalVariable(spvLocal);
-
-                    locals[i] = spvLocal;
-                }
-
-                context.DeclareLocalForArgs(funcIndex, locals);
-            }
-        }
-
         public static void DeclareAll(CodeGenContext context, StructuredProgramInfo info)
         {
             DeclareConstantBuffers(context, context.Properties.ConstantBuffers.Values);

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -311,7 +311,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             var (function, spvFunc) = context.GetFunction(funcId.Value);
 
             var args = new SpvInstruction[operation.SourcesCount - 1];
-            var spvLocals = context.GetLocalForArgsPointers(funcId.Value);
 
             for (int i = 0; i < args.Length; i++)
             {
@@ -324,12 +323,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 else
                 {
                     var type = function.GetArgumentType(i);
-                    var value = context.Get(type, operand);
-                    var spvLocal = spvLocals[i];
 
-                    context.Store(spvLocal, value);
-
-                    args[i] = spvLocal;
+                    args[i] = context.Get(type, operand);
                 }
             }
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/SpirvGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/SpirvGenerator.cs
@@ -161,7 +161,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             context.EnterBlock(function.MainBlock);
 
             Declarations.DeclareLocals(context, function);
-            Declarations.DeclareLocalForArgs(context, info.Functions);
 
             Generate(context, function.MainBlock);
 

--- a/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -329,6 +329,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 attributeUsage,
                 definitions,
                 resourceManager,
+                Options.TargetLanguage,
                 Options.Flags.HasFlag(TranslationFlags.DebugMode));
 
             int geometryVerticesPerPrimitive = Definitions.OutputTopology switch


### PR DESCRIPTION
Currently the SPIR-V backend will copy each function call parameter to a temporary variable. Right now, it reserves one set of variables per function (one for each input parameter), and reuses them across calls to the same function. For some reason, this now confuses the AMD compiler on their latest drivers, with causes rendering issues that didn't exist before.

This PR changes how it works, now all function calls gets their own unique set of temporary variables without any reuse, which seems to fix the issue.

Example on Pokémon Scarlet.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/8ddd3f9e-ff99-4c96-901a-4a3302db1680)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/77b22fc8-1fde-4d5c-b330-d47b94ce4617)

Testing is welcome.
