### PR TITLE
GPU: Add HLE macros for popular NVN macros

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/DeviceStateWithShadow.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/DeviceStateWithShadow.cs
@@ -33,6 +33,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
         public ref TState State => ref _state.State;
 
         /// <summary>
+        /// Current shadow state.
+        /// </summary>
+        public ref TState ShadowState => ref _shadowState.State;
+
+        /// <summary>
         /// Creates a new instance of the device state, with shadow state.
         /// </summary>
         /// <param name="callbacks">Optional that will be called if a register specified by name is read or written</param>

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -1,7 +1,10 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.Common.Memory;
 using Ryujinx.Graphics.Device;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.GPFifo;
+using Ryujinx.Graphics.Gpu.Engine.Threed;
+using Ryujinx.Graphics.Gpu.Engine.Types;
 using System;
 using System.Collections.Generic;
 
@@ -15,8 +18,17 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         private const int ColorLayerCountOffset = 0x818;
         private const int ColorStructSize = 0x40;
         private const int ZetaLayerCountOffset = 0x1230;
+        private const int UniformBufferBindVertexOffset = 0x2410;
+        private const int FirstVertexOffset = 0x1434;
 
         private const int IndirectIndexedDataEntrySize = 0x14;
+
+        private const int LogicOpOffset = 0x19c4;
+        private const int ShaderIdScratchOffset = 0x3470;
+        private const int ShaderAddressScratchOffset = 0x3488;
+        private const int UpdateConstantBufferAddressesBase = 0x34a8;
+        private const int UpdateConstantBufferSizesBase = 0x34bc;
+        private const int UpdateConstantBufferAddressCbu = 0x3460;
 
         private readonly GPFifoProcessor _processor;
         private readonly MacroHLEFunctionName _functionName;
@@ -49,6 +61,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         {
             switch (_functionName)
             {
+                case MacroHLEFunctionName.BindShaderProgram:
+                    BindShaderProgram(state, arg0);
+                    break;
                 case MacroHLEFunctionName.ClearColor:
                     ClearColor(state, arg0);
                     break;
@@ -57,6 +72,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                     break;
                 case MacroHLEFunctionName.DrawArraysInstanced:
                     DrawArraysInstanced(state, arg0);
+                    break;
+                case MacroHLEFunctionName.DrawElements:
+                    DrawElements(state, arg0);
                     break;
                 case MacroHLEFunctionName.DrawElementsInstanced:
                     DrawElementsInstanced(state, arg0);
@@ -67,12 +85,168 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                 case MacroHLEFunctionName.MultiDrawElementsIndirectCount:
                     MultiDrawElementsIndirectCount(state, arg0);
                     break;
+                case MacroHLEFunctionName.UpdateBlendState:
+                    UpdateBlendState(state, arg0);
+                    break;
+                case MacroHLEFunctionName.UpdateColorMasks:
+                    UpdateColorMasks(state, arg0);
+                    break;
+                case MacroHLEFunctionName.UpdateUniformBufferState:
+                    UpdateUniformBufferState(state, arg0);
+                    break;
+                case MacroHLEFunctionName.UpdateUniformBufferStateCbu:
+                    UpdateUniformBufferStateCbu(state, arg0);
+                    break;
+                case MacroHLEFunctionName.UpdateUniformBufferStateCbuV2:
+                    UpdateUniformBufferStateCbuV2(state, arg0);
+                    break;
                 default:
                     throw new NotImplementedException(_functionName.ToString());
             }
 
             // It should be empty at this point, but clear it just to be safe.
             Fifo.Clear();
+        }
+
+        /// <summary>
+        /// Binds a shader program with the index in arg0.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void BindShaderProgram(IDeviceState state, int arg0)
+        {
+            int scratchOffset = ShaderIdScratchOffset + arg0 * 4;
+
+            int lastId = state.Read(scratchOffset);
+            int id = FetchParam().Word;
+            int offset = FetchParam().Word;
+
+            if (lastId == id)
+            {
+                FetchParam();
+                FetchParam();
+
+                return;
+            }
+
+            _processor.ThreedClass.SetShaderOffset(arg0, (uint)offset);
+
+            int addrMask = unchecked((int)0xfffc0fff) << 2;
+
+            state.Write(scratchOffset & addrMask, id);
+            state.Write((ShaderAddressScratchOffset + arg0 * 4) & addrMask, offset);
+
+            int stage = FetchParam().Word;
+            uint cbAddress = (uint)FetchParam().Word;
+
+            _processor.ThreedClass.UpdateUniformBufferState(65536, cbAddress >> 24, cbAddress << 8);
+
+            int stageOffset = (stage & 0x7f) << 3;
+
+            state.Write((UniformBufferBindVertexOffset + stageOffset * 4) & addrMask, 17);
+        }
+
+        /// <summary>
+        /// Updates uniform buffer state for update or bind.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void UpdateUniformBufferState(IDeviceState state, int arg0)
+        {
+            uint address = (uint)state.Read(UpdateConstantBufferAddressesBase + arg0 * 4);
+            int size = state.Read(UpdateConstantBufferSizesBase + arg0 * 4);
+
+            _processor.ThreedClass.UpdateUniformBufferState(size, address >> 24, address << 8);
+        }
+
+        /// <summary>
+        /// Updates uniform buffer state for update.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void UpdateUniformBufferStateCbu(IDeviceState state, int arg0)
+        {
+            uint address = (uint)state.Read(UpdateConstantBufferAddressCbu);
+
+            UniformBufferState ubState = new()
+            {
+                Address = new()
+                {
+                    High = address >> 24,
+                    Low = address << 8
+                },
+                Size = 24320,
+                Offset = arg0 << 2
+            };
+
+            _processor.ThreedClass.UpdateUniformBufferState(ubState);
+        }
+
+        /// <summary>
+        /// Updates uniform buffer state for update.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void UpdateUniformBufferStateCbuV2(IDeviceState state, int arg0)
+        {
+            uint address = (uint)state.Read(UpdateConstantBufferAddressCbu);
+
+            UniformBufferState ubState = new()
+            {
+                Address = new()
+                {
+                    High = address >> 24,
+                    Low = address << 8
+                },
+                Size = 28672,
+                Offset = arg0 << 2
+            };
+
+            _processor.ThreedClass.UpdateUniformBufferState(ubState);
+        }
+
+        /// <summary>
+        /// Updates blend enable using the given argument.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void UpdateBlendState(IDeviceState state, int arg0)
+        {
+            state.Write(LogicOpOffset, 0);
+
+            Array8<Boolean32> enable = new();
+
+            for (int i = 0; i < 8; i++)
+            {
+                enable[i] = new Boolean32((uint)(arg0 >> (i + 8)) & 1);
+            }
+
+            _processor.ThreedClass.UpdateBlendEnable(ref enable);
+        }
+
+        /// <summary>
+        /// Updates color masks using the given argument and three pushed arguments.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void UpdateColorMasks(IDeviceState state, int arg0)
+        {
+            Array8<RtColorMask> masks = new();
+
+            int index = 0;
+
+            for (int i = 0; i < 4; i++)
+            {
+                masks[index++] = new RtColorMask((uint)arg0 & 0x1fff);
+                masks[index++] = new RtColorMask(((uint)arg0 >> 16) & 0x1fff);
+
+                if (i != 3)
+                {
+                    arg0 = FetchParam().Word;
+                }
+            }
+
+            _processor.ThreedClass.UpdateColorMasks(ref masks);
         }
 
         /// <summary>
@@ -127,6 +301,36 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                 firstVertex.Word,
                 firstInstance.Word,
                 indexed: false);
+        }
+
+        /// <summary>
+        /// Performs a indexed draw.
+        /// </summary>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void DrawElements(IDeviceState state, int arg0)
+        {
+            var topology = (PrimitiveTopology)arg0;
+
+            var indexAddressHigh = FetchParam();
+            var indexAddressLow = FetchParam();
+            var indexType = FetchParam();
+            var firstIndex = 0;
+            var indexCount = FetchParam();
+
+            _processor.ThreedClass.UpdateIndexBuffer(
+                (uint)indexAddressHigh.Word,
+                (uint)indexAddressLow.Word,
+                (IndexType)indexType.Word);
+
+            _processor.ThreedClass.Draw(
+                topology,
+                indexCount.Word,
+                1,
+                firstIndex,
+                state.Read(FirstVertexOffset),
+                0,
+                indexed: true);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -131,6 +131,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
             _processor.ThreedClass.SetShaderOffset(arg0, (uint)offset);
 
+            // Removes overflow on the method address into the increment portion.
+            // Present in the original macro.
             int addrMask = unchecked((int)0xfffc0fff) << 2;
 
             state.Write(scratchOffset & addrMask, id);

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLEFunctionName.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLEFunctionName.cs
@@ -6,11 +6,19 @@
     enum MacroHLEFunctionName
     {
         None,
+        BindShaderProgram,
         ClearColor,
         ClearDepthStencil,
         DrawArraysInstanced,
+        DrawElements,
         DrawElementsInstanced,
         DrawElementsIndirect,
         MultiDrawElementsIndirectCount,
+
+        UpdateBlendState,
+        UpdateColorMasks,
+        UpdateUniformBufferState,
+        UpdateUniformBufferStateCbu,
+        UpdateUniformBufferStateCbuV2
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
@@ -69,7 +69,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <returns>True if the host supports the HLE macro, false otherwise</returns>
         private static bool IsMacroHLESupported(Capabilities caps, MacroHLEFunctionName name)
         {
-            if (name == MacroHLEFunctionName.BindShaderProgram || 
+            if (name == MacroHLEFunctionName.BindShaderProgram ||
                 name == MacroHLEFunctionName.ClearColor ||
                 name == MacroHLEFunctionName.ClearDepthStencil ||
                 name == MacroHLEFunctionName.DrawArraysInstanced ||

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
@@ -69,24 +69,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <returns>True if the host supports the HLE macro, false otherwise</returns>
         private static bool IsMacroHLESupported(Capabilities caps, MacroHLEFunctionName name)
         {
-            if (name == MacroHLEFunctionName.BindShaderProgram ||
-                name == MacroHLEFunctionName.ClearColor ||
-                name == MacroHLEFunctionName.ClearDepthStencil ||
-                name == MacroHLEFunctionName.DrawArraysInstanced ||
-                name == MacroHLEFunctionName.DrawElements ||
-                name == MacroHLEFunctionName.DrawElementsInstanced ||
-                name == MacroHLEFunctionName.DrawElementsIndirect ||
-                name == MacroHLEFunctionName.UpdateBlendState ||
-                name == MacroHLEFunctionName.UpdateColorMasks ||
-                name == MacroHLEFunctionName.UpdateUniformBufferState ||
-                name == MacroHLEFunctionName.UpdateUniformBufferStateCbu ||
-                name == MacroHLEFunctionName.UpdateUniformBufferStateCbuV2)
-            {
-                return true;
-            }
-            else if (name == MacroHLEFunctionName.MultiDrawElementsIndirectCount)
+            if (name == MacroHLEFunctionName.MultiDrawElementsIndirectCount)
             {
                 return caps.SupportsIndirectParameters;
+            }
+            else if (name != MacroHLEFunctionName.None)
+            {
+                return true;
             }
 
             return false;

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
@@ -46,12 +46,19 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
         private static readonly TableEntry[] _table = new TableEntry[]
         {
+            new(MacroHLEFunctionName.BindShaderProgram, new Hash128(0x5d5efb912369f60b, 0x69131ed5019f08ef), 0x68),
             new(MacroHLEFunctionName.ClearColor, new Hash128(0xA9FB28D1DC43645A, 0xB177E5D2EAE67FB0), 0x28),
             new(MacroHLEFunctionName.ClearDepthStencil, new Hash128(0x1B96CB77D4879F4F, 0x8557032FE0C965FB), 0x24),
             new(MacroHLEFunctionName.DrawArraysInstanced, new Hash128(0x197FB416269DBC26, 0x34288C01DDA82202), 0x48),
+            new(MacroHLEFunctionName.DrawElements, new Hash128(0x3D7F32AE6C2702A7, 0x9353C9F41C1A244D), 0x20),
             new(MacroHLEFunctionName.DrawElementsInstanced, new Hash128(0x1A501FD3D54EC8E0, 0x6CF570CF79DA74D6), 0x5c),
             new(MacroHLEFunctionName.DrawElementsIndirect, new Hash128(0x86A3E8E903AF8F45, 0xD35BBA07C23860A4), 0x7c),
             new(MacroHLEFunctionName.MultiDrawElementsIndirectCount, new Hash128(0x890AF57ED3FB1C37, 0x35D0C95C61F5386F), 0x19C),
+            new(MacroHLEFunctionName.UpdateBlendState, new Hash128(0x40F6D4E7B08D7640, 0x82167BEEAECB959F), 0x28),
+            new(MacroHLEFunctionName.UpdateColorMasks, new Hash128(0x9EE32420B8441DFD, 0x6E7724759A57333E), 0x24),
+            new(MacroHLEFunctionName.UpdateUniformBufferState, new Hash128(0x8EE66706049CB0B0, 0x51C1CF906EC86F7C), 0x20),
+            new(MacroHLEFunctionName.UpdateUniformBufferStateCbu, new Hash128(0xA4592676A3E581A0, 0xA39E77FE19FE04AC), 0x18),
+            new(MacroHLEFunctionName.UpdateUniformBufferStateCbuV2, new Hash128(0x392FA750489983D4, 0x35BACE455155D2C3), 0x18)
         };
 
         /// <summary>
@@ -62,11 +69,18 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <returns>True if the host supports the HLE macro, false otherwise</returns>
         private static bool IsMacroHLESupported(Capabilities caps, MacroHLEFunctionName name)
         {
-            if (name == MacroHLEFunctionName.ClearColor ||
+            if (name == MacroHLEFunctionName.BindShaderProgram || 
+                name == MacroHLEFunctionName.ClearColor ||
                 name == MacroHLEFunctionName.ClearDepthStencil ||
                 name == MacroHLEFunctionName.DrawArraysInstanced ||
+                name == MacroHLEFunctionName.DrawElements ||
                 name == MacroHLEFunctionName.DrawElementsInstanced ||
-                name == MacroHLEFunctionName.DrawElementsIndirect)
+                name == MacroHLEFunctionName.DrawElementsIndirect ||
+                name == MacroHLEFunctionName.UpdateBlendState ||
+                name == MacroHLEFunctionName.UpdateColorMasks ||
+                name == MacroHLEFunctionName.UpdateUniformBufferState ||
+                name == MacroHLEFunctionName.UpdateUniformBufferStateCbu ||
+                name == MacroHLEFunctionName.UpdateUniformBufferStateCbuV2)
             {
                 return true;
             }

--- a/src/Ryujinx.Graphics.Gpu/Engine/SetMmeShadowRamControlMode.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/SetMmeShadowRamControlMode.cs
@@ -13,17 +13,17 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
     static class SetMmeShadowRamControlModeExtensions
     {
-        public static bool Track(this SetMmeShadowRamControlMode mode)
+        public static bool IsTrack(this SetMmeShadowRamControlMode mode)
         {
             return mode == SetMmeShadowRamControlMode.MethodTrack || mode == SetMmeShadowRamControlMode.MethodTrackWithFilter;
         }
 
-        public static bool Passthrough(this SetMmeShadowRamControlMode mode)
+        public static bool IsPassthrough(this SetMmeShadowRamControlMode mode)
         {
             return mode == SetMmeShadowRamControlMode.MethodPassthrough;
         }
 
-        public static bool Replay(this SetMmeShadowRamControlMode mode)
+        public static bool IsReplay(this SetMmeShadowRamControlMode mode)
         {
             return mode == SetMmeShadowRamControlMode.MethodReplay;
         }

--- a/src/Ryujinx.Graphics.Gpu/Engine/SetMmeShadowRamControlMode.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/SetMmeShadowRamControlMode.cs
@@ -10,4 +10,22 @@ namespace Ryujinx.Graphics.Gpu.Engine
         MethodPassthrough = 2,
         MethodReplay = 3,
     }
+
+    static class SetMmeShadowRamControlModeExtensions
+    {
+        public static bool Track(this SetMmeShadowRamControlMode mode)
+        {
+            return mode == SetMmeShadowRamControlMode.MethodTrack || mode == SetMmeShadowRamControlMode.MethodTrackWithFilter;
+        }
+
+        public static bool Passthrough(this SetMmeShadowRamControlMode mode)
+        {
+            return mode == SetMmeShadowRamControlMode.MethodPassthrough;
+        }
+
+        public static bool Replay(this SetMmeShadowRamControlMode mode)
+        {
+            return mode == SetMmeShadowRamControlMode.MethodReplay;
+        }
+    }
 }

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -17,9 +17,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
     class StateUpdater
     {
         public const int ShaderStateIndex = 26;
+        public const int RtColorMaskIndex = 14;
         public const int RasterizerStateIndex = 15;
         public const int ScissorStateIndex = 16;
         public const int VertexBufferStateIndex = 0;
+        public const int BlendStateIndex = 2;
         public const int IndexBufferStateIndex = 23;
         public const int PrimitiveRestartStateIndex = 12;
         public const int RenderTargetStateIndex = 27;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -250,27 +250,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     Unsafe.As<T, Vector256<uint>>(ref rhs)
                 );
             }
-            else if (Vector128.IsHardwareAccelerated)
+            else
             {
                 ref var lhsVec = ref Unsafe.As<T, Vector128<uint>>(ref lhs);
                 ref var rhsVec = ref Unsafe.As<T, Vector128<uint>>(ref rhs);
 
                 return Vector128.EqualsAll(lhsVec, rhsVec) &&
                     Vector128.EqualsAll(Unsafe.Add(ref lhsVec, 1), Unsafe.Add(ref rhsVec, 1));
-            }
-            else
-            {
-                ref var lhsInt = ref Unsafe.As<T, uint>(ref lhs);
-                ref var rhsInt = ref Unsafe.As<T, uint>(ref rhs);
-
-                return lhsInt == rhsInt &&
-                    Unsafe.Add(ref lhsInt, 1) == Unsafe.Add(ref rhsInt, 1) &&
-                    Unsafe.Add(ref lhsInt, 2) == Unsafe.Add(ref rhsInt, 2) &&
-                    Unsafe.Add(ref lhsInt, 3) == Unsafe.Add(ref rhsInt, 3) &&
-                    Unsafe.Add(ref lhsInt, 4) == Unsafe.Add(ref rhsInt, 4) &&
-                    Unsafe.Add(ref lhsInt, 5) == Unsafe.Add(ref rhsInt, 5) &&
-                    Unsafe.Add(ref lhsInt, 6) == Unsafe.Add(ref rhsInt, 6) &&
-                    Unsafe.Add(ref lhsInt, 7) == Unsafe.Add(ref rhsInt, 7);
             }
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -269,7 +269,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             var shadow = ShadowMode;
             ref var state = ref _state.State.BlendEnable;
 
-            if (shadow.Replay())
+            if (shadow.IsReplay())
             {
                 enable = _state.ShadowState.BlendEnable;
             }
@@ -281,7 +281,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _stateUpdater.ForceDirty(StateUpdater.BlendStateIndex);
             }
 
-            if (shadow.Track())
+            if (shadow.IsTrack())
             {
                 _state.ShadowState.BlendEnable = enable;
             }
@@ -296,7 +296,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             var shadow = ShadowMode;
             ref var state = ref _state.State.RtColorMask;
 
-            if (shadow.Replay())
+            if (shadow.IsReplay())
             {
                 masks = _state.ShadowState.RtColorMask;
             }
@@ -308,7 +308,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _stateUpdater.ForceDirty(StateUpdater.RtColorMaskIndex);
             }
 
-            if (shadow.Track())
+            if (shadow.IsTrack())
             {
                 _state.ShadowState.RtColorMask = masks;
             }
@@ -317,15 +317,15 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// <summary>
         /// Updates index buffer state for an indexed draw. Respects current shadow mode.
         /// </summary>
-        /// <param name="addrHigh">High part of the binding</param>
-        /// <param name="addrLow">Low part of the binding</param>
+        /// <param name="addrHigh">High part of the address</param>
+        /// <param name="addrLow">Low part of the address</param>
         /// <param name="type">Type of the binding</param>
         public void UpdateIndexBuffer(uint addrHigh, uint addrLow, IndexType type)
         {
             var shadow = ShadowMode;
             ref var state = ref _state.State.IndexBufferState;
 
-            if (shadow.Replay())
+            if (shadow.IsReplay())
             {
                 ref var shadowState = ref _state.ShadowState.IndexBufferState;
                 addrHigh = shadowState.Address.High;
@@ -342,7 +342,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _stateUpdater.ForceDirty(StateUpdater.IndexBufferStateIndex);
             }
 
-            if (shadow.Track())
+            if (shadow.IsTrack())
             {
                 ref var shadowState = ref _state.ShadowState.IndexBufferState;
                 shadowState.Address.High = addrHigh;
@@ -355,14 +355,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Updates uniform buffer state for update or bind. Respects current shadow mode.
         /// </summary>
         /// <param name="size">Size of the binding</param>
-        /// <param name="addrHigh">High part of the binding</param>
-        /// <param name="addrLow">Low part of the binding</param>
+        /// <param name="addrHigh">High part of the addrsss</param>
+        /// <param name="addrLow">Low part of the address</param>
         public void UpdateUniformBufferState(int size, uint addrHigh, uint addrLow)
         {
             var shadow = ShadowMode;
             ref var state = ref _state.State.UniformBufferState;
 
-            if (shadow.Replay())
+            if (shadow.IsReplay())
             {
                 ref var shadowState = ref _state.ShadowState.UniformBufferState;
                 size = shadowState.Size;
@@ -374,7 +374,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             state.Address.High = addrHigh;
             state.Address.Low = addrLow;
 
-            if (shadow.Track())
+            if (shadow.IsTrack())
             {
                 ref var shadowState = ref _state.ShadowState.UniformBufferState;
                 shadowState.Size = size;
@@ -393,7 +393,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             var shadow = ShadowMode;
             ref var shaderState = ref _state.State.ShaderState[index];
 
-            if (shadow.Replay())
+            if (shadow.IsReplay())
             {
                 offset = _state.ShadowState.ShaderState[index].Offset;
             }
@@ -405,7 +405,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _stateUpdater.ForceDirty(StateUpdater.ShaderStateIndex);
             }
 
-            if (shadow.Track())
+            if (shadow.IsTrack())
             {
                 _state.ShadowState.ShaderState[index].Offset = offset;
             }
@@ -420,14 +420,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             var shadow = ShadowMode;
             ref var state = ref _state.State.UniformBufferState;
 
-            if (shadow.Replay())
+            if (shadow.IsReplay())
             {
                 ubState = _state.ShadowState.UniformBufferState;
             }
 
             state = ubState;
 
-            if (shadow.Track())
+            if (shadow.IsTrack())
             {
                 _state.ShadowState.UniformBufferState = ubState;
             }

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -1,12 +1,15 @@
-﻿using Ryujinx.Graphics.Device;
+﻿using Ryujinx.Common.Memory;
+using Ryujinx.Graphics.Device;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.GPFifo;
 using Ryujinx.Graphics.Gpu.Engine.InlineToMemory;
 using Ryujinx.Graphics.Gpu.Engine.Threed.Blender;
+using Ryujinx.Graphics.Gpu.Engine.Types;
 using Ryujinx.Graphics.Gpu.Synchronization;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 
 namespace Ryujinx.Graphics.Gpu.Engine.Threed
 {
@@ -25,6 +28,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         private readonly SemaphoreUpdater _semaphoreUpdater;
         private readonly ConstantBufferUpdater _cbUpdater;
         private readonly StateUpdater _stateUpdater;
+
+        private SetMmeShadowRamControlMode ShadowMode => _state.State.SetMmeShadowRamControlMode;
 
         /// <summary>
         /// Creates a new instance of the 3D engine class.
@@ -226,6 +231,220 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public void ConstantBufferUpdate(ReadOnlySpan<int> data)
         {
             _cbUpdater.Update(data);
+        }
+
+        /// <summary>
+        /// Test if two 32 byte structs are equal. 
+        /// </summary>
+        /// <typeparam name="T">Type of the 32-byte struct</typeparam>
+        /// <param name="lhs">First struct</param>
+        /// <param name="rhs">Second struct</param>
+        /// <returns>True if equal, false otherwise</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool UnsafeEquals32Byte<T>(ref T lhs, ref T rhs) where T : unmanaged
+        {
+            if (Vector256.IsHardwareAccelerated)
+            {
+                return Vector256.EqualsAll(
+                    Unsafe.As<T, Vector256<uint>>(ref lhs),
+                    Unsafe.As<T, Vector256<uint>>(ref rhs)
+                );
+            }
+            else if (Vector128.IsHardwareAccelerated)
+            {
+                ref var lhsVec = ref Unsafe.As<T, Vector128<uint>>(ref lhs);
+                ref var rhsVec = ref Unsafe.As<T, Vector128<uint>>(ref rhs);
+
+                return Vector128.EqualsAll(lhsVec, rhsVec) &&
+                    Vector128.EqualsAll(Unsafe.Add(ref lhsVec, 1), Unsafe.Add(ref rhsVec, 1));
+            }
+            else
+            {
+                ref var lhsInt = ref Unsafe.As<T, uint>(ref lhs);
+                ref var rhsInt = ref Unsafe.As<T, uint>(ref rhs);
+
+                return lhsInt == rhsInt &&
+                    Unsafe.Add(ref lhsInt, 1) == Unsafe.Add(ref rhsInt, 1) &&
+                    Unsafe.Add(ref lhsInt, 2) == Unsafe.Add(ref rhsInt, 2) &&
+                    Unsafe.Add(ref lhsInt, 3) == Unsafe.Add(ref rhsInt, 3) &&
+                    Unsafe.Add(ref lhsInt, 4) == Unsafe.Add(ref rhsInt, 4) &&
+                    Unsafe.Add(ref lhsInt, 5) == Unsafe.Add(ref rhsInt, 5) &&
+                    Unsafe.Add(ref lhsInt, 6) == Unsafe.Add(ref rhsInt, 6) &&
+                    Unsafe.Add(ref lhsInt, 7) == Unsafe.Add(ref rhsInt, 7);
+            }
+        }
+
+        /// <summary>
+        /// Updates blend enable. Respects current shadow mode.
+        /// </summary>
+        /// <param name="masks">Blend enable</param>
+        public void UpdateBlendEnable(ref Array8<Boolean32> enable)
+        {
+            var shadow = ShadowMode;
+            ref var state = ref _state.State.BlendEnable;
+
+            if (shadow.Replay())
+            {
+                enable = _state.ShadowState.BlendEnable;
+            }
+
+            if (!UnsafeEquals32Byte(ref enable, ref state))
+            {
+                state = enable;
+
+                _stateUpdater.ForceDirty(StateUpdater.BlendStateIndex);
+            }
+
+            if (shadow.Track())
+            {
+                _state.ShadowState.BlendEnable = enable;
+            }
+        }
+
+        /// <summary>
+        /// Updates color masks. Respects current shadow mode.
+        /// </summary>
+        /// <param name="masks">Color masks</param>
+        public void UpdateColorMasks(ref Array8<RtColorMask> masks)
+        {
+            var shadow = ShadowMode;
+            ref var state = ref _state.State.RtColorMask;
+
+            if (shadow.Replay())
+            {
+                masks = _state.ShadowState.RtColorMask;
+            }
+
+            if (!UnsafeEquals32Byte(ref masks, ref state))
+            {
+                state = masks;
+
+                _stateUpdater.ForceDirty(StateUpdater.RtColorMaskIndex);
+            }
+
+            if (shadow.Track())
+            {
+                _state.ShadowState.RtColorMask = masks;
+            }
+        }
+
+        /// <summary>
+        /// Updates index buffer state for an indexed draw. Respects current shadow mode.
+        /// </summary>
+        /// <param name="addrHigh">High part of the binding</param>
+        /// <param name="addrLow">Low part of the binding</param>
+        /// <param name="type">Type of the binding</param>
+        public void UpdateIndexBuffer(uint addrHigh, uint addrLow, IndexType type)
+        {
+            var shadow = ShadowMode;
+            ref var state = ref _state.State.IndexBufferState;
+
+            if (shadow.Replay())
+            {
+                ref var shadowState = ref _state.ShadowState.IndexBufferState;
+                addrHigh = shadowState.Address.High;
+                addrLow = shadowState.Address.Low;
+                type = shadowState.Type;
+            }
+
+            if (state.Address.High != addrHigh || state.Address.Low != addrLow || state.Type != type)
+            {
+                state.Address.High = addrHigh;
+                state.Address.Low = addrLow;
+                state.Type = type;
+
+                _stateUpdater.ForceDirty(StateUpdater.IndexBufferStateIndex);
+            }
+
+            if (shadow.Track())
+            {
+                ref var shadowState = ref _state.ShadowState.IndexBufferState;
+                shadowState.Address.High = addrHigh;
+                shadowState.Address.Low = addrLow;
+                shadowState.Type = type;
+            }
+        }
+
+        /// <summary>
+        /// Updates uniform buffer state for update or bind. Respects current shadow mode.
+        /// </summary>
+        /// <param name="size">Size of the binding</param>
+        /// <param name="addrHigh">High part of the binding</param>
+        /// <param name="addrLow">Low part of the binding</param>
+        public void UpdateUniformBufferState(int size, uint addrHigh, uint addrLow)
+        {
+            var shadow = ShadowMode;
+            ref var state = ref _state.State.UniformBufferState;
+
+            if (shadow.Replay())
+            {
+                ref var shadowState = ref _state.ShadowState.UniformBufferState;
+                size = shadowState.Size;
+                addrHigh = shadowState.Address.High;
+                addrLow = shadowState.Address.Low;
+            }
+
+            state.Size = size;
+            state.Address.High = addrHigh;
+            state.Address.Low = addrLow;
+
+            if (shadow.Track())
+            {
+                ref var shadowState = ref _state.ShadowState.UniformBufferState;
+                shadowState.Size = size;
+                shadowState.Address.High = addrHigh;
+                shadowState.Address.Low = addrLow;
+            }
+        }
+
+        /// <summary>
+        /// Updates a shader offset. Respects current shadow mode.
+        /// </summary>
+        /// <param name="index">Index of the shader to update</param>
+        /// <param name="offset">Offset to update with</param>
+        public void SetShaderOffset(int index, uint offset)
+        {
+            var shadow = ShadowMode;
+            ref var shaderState = ref _state.State.ShaderState[index];
+
+            if (shadow.Replay())
+            {
+                offset = _state.ShadowState.ShaderState[index].Offset;
+            }
+
+            if (shaderState.Offset != offset)
+            {
+                shaderState.Offset = offset;
+
+                _stateUpdater.ForceDirty(StateUpdater.ShaderStateIndex);
+            }
+
+            if (shadow.Track())
+            {
+                _state.ShadowState.ShaderState[index].Offset = offset;
+            }
+        }
+
+        /// <summary>
+        /// Updates uniform buffer state for update. Respects current shadow mode.
+        /// </summary>
+        /// <param name="ubState">Uniform buffer state</param>
+        public void UpdateUniformBufferState(UniformBufferState ubState)
+        {
+            var shadow = ShadowMode;
+            ref var state = ref _state.State.UniformBufferState;
+
+            if (shadow.Replay())
+            {
+                ubState = _state.ShadowState.UniformBufferState;
+            }
+
+            state = ubState;
+
+            if (shadow.Track())
+            {
+                _state.ShadowState.UniformBufferState = ubState;
+            }
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -590,9 +590,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
     /// </summary>
     struct RtColorMask
     {
-#pragma warning disable CS0649 // Field is never assigned to
         public uint Packed;
-#pragma warning restore CS0649
+
+        public RtColorMask(uint packed)
+        {
+            Packed = packed;
+        }
 
         /// <summary>
         /// Unpacks red channel enable.

--- a/src/Ryujinx.Graphics.Gpu/Engine/Types/Boolean32.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Types/Boolean32.cs
@@ -5,9 +5,12 @@
     /// </summary>
     readonly struct Boolean32
     {
-#pragma warning disable CS0649 // Field is never assigned to
         private readonly uint _value;
-#pragma warning restore CS0649
+
+        public Boolean32(uint value)
+        {
+            _value = value;
+        }
 
         public static implicit operator bool(Boolean32 value)
         {


### PR DESCRIPTION
We have a Macro JIT that emits CIL that the .NET runtime can convert directly into a method, which allows these methods to perform much faster than the interpreter. However, NativeAOT is not able to use Reflection.Emit, so the current Macro JIT does not work with it. NativeAOT has faster boot and load times, and is required for certain platforms. Also, it might be generally beneficial to make popular macros faster anyways, which it did end up being.

Initially, I tried to make a faster interpreter for macros by abusing C# generics to generate slim methods for instructions that only do what they need, but the cost of an interface method call for each instruction proved to be comparable to just doing everything via a ton of switch statements. I instead used this as a base for something that converts them to readable code strings that helped me implement HLE versions of them.

I identified the following macros, in order of most expensive to least: (I made the names up)
- **UpdateUniformBufferState**
  - Sets Address and Size in the UniformBufferState. Offset is not changed.
  - This is used an order of magnitude more than anything else.
- **BindShaderProgram**
  - Sets the shader offset at the given index (arg0) to arg2
  - Tends to happen before each draw, but has a fast path where it exits early if the shader ID (arg1) matches the one in scratch memory.
  - Binds uniform buffer 1 for the stage (arg3) to an address (arg4), with size 65536.
  - Typically called once per stage per draw.
- **UpdateUniformBufferStateCbu**
  - Sets Address and Offset in the UniformBufferState. Size is set to a hardcoded 24320.
  - Offset is only used by the constant buffer updater, hence the name.
  - This is used in older games, such as SMO v1.0.
- **UpdateUniformBufferStateCbuV2**
  - Same as above, but the size is 28672.
  - This is used in newer games, such as TOTK and Pokemon S/V.
- **UpdateColorMasks**
  - Updates color masks, 8 ushorts packed into 4 int arguments.
  - Typically done before each draw. 8 fields means 8 redundancy checks and shadows, much faster with HLE.
- **UpdateBlendState**
  - Updates blend state, 8 booleans packed into an integer argument.
  - Typically done before each draw.
- **DrawElements**
  - Sets index buffer state and draws. Most of the other draws are covered by HLE macro, this isn't too different.
  - It does use the existing vertex buffer first element, which is a bit odd.
  
These have been implemented via methods in ThreedClass.cs that update the state directly, all at once. This avoids some checks for writing values individually (redundancy, dirty flags), but does mean they need to implement shadowing themselves.

### Benefits

Main benefit is when running under NativeAOT. Emmaus's testing branch for nativeaot under .NET 8 showed a significant reduction to performance due to disabling Macro JIT and PGO (profile guided optimization).

Macro interpreter, NativeAOT on .NET8:
![image](https://github.com/Ryujinx/Ryujinx/assets/6294155/199648ed-1efb-4c1d-bd5f-99412dc7b719)

New Macro HLE methods, interpreter fallback, NativeAOT on .NET8:
![image-1](https://github.com/Ryujinx/Ryujinx/assets/6294155/9d2952a7-bd62-4b56-8aad-b4bb22a15656)

For reference, .NET8 on master is 90fps. The remaining difference is likely due to PGO. Profile guided optimization allows the .NET JIT to write fast paths into code when it goes through tiered compilation (based on how it has been used so far, a "profile"), but this is obviously not possible when compiling ahead of time. This might be improvable by reducing calls to virtual methods, but that's outside the scope of this PR.

In other news, .NET 7 JIT goes from around **84 to 88 fps** in that scene here, so there is notable benefit over leaving them up to the JIT. If you're limited by the Vulkan driver, you won't see a difference.

This also identifies DrawElements coming from NVN, which allows a small optimization for draw call parameters that might help Pokemon a little (removes constant buffer binding, though i haven't checked if this works).

### Other

The method `UnsafeEquals32Byte` is in an odd place. It's the most optimal way to check for struct equality in a very hot method, and it's only used in ThreedClass, though there might be a better static class to place it in somewhere.

These methods were selected based on what ended up used the most by Super Mario Odyssey, but other games may use other macros heavily, and some macros may be more complicated than others. Could probably come back to this for other macros in other games if it will end up making a difference.

Finally, it would be good to test a variety of games. All of them use all of these methods, so hopefully nothing breaks inadvertantly.