### PR TITLE
HLE: Fix Mii crc generation and minor issues

### DIFF
--- a/src/Ryujinx.Common/Memory/StructArrayHelpers.cs
+++ b/src/Ryujinx.Common/Memory/StructArrayHelpers.cs
@@ -756,6 +756,18 @@ namespace Ryujinx.Common.Memory
         public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, Length);
     }
 
+    public struct Array96<T> : IArray<T> where T : unmanaged
+    {
+        T _e0;
+        Array64<T> _other;
+        Array31<T> _other2;
+        public readonly int Length => 96;
+        public ref T this[int index] => ref AsSpan()[index];
+
+        [Pure]
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, Length);
+    }
+
     public struct Array127<T> : IArray<T> where T : unmanaged
     {
         T _e0;

--- a/src/Ryujinx.HLE/HOS/Services/Mii/DatabaseImpl.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/DatabaseImpl.cs
@@ -290,7 +290,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii
         {
             coreData = new CoreData();
 
-            if (charInfo.IsValid())
+            if (!charInfo.IsValid())
             {
                 return ResultCode.InvalidCharInfo;
             }

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/CoreData.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/CoreData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ryujinx.Common.Memory;
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Ryujinx.HLE.HOS.Services.Mii.Types.RandomMiiConstants;
@@ -10,9 +11,9 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
     {
         public const int Size = 0x30;
 
-        private byte _storage;
+        private Array48<byte> _storage;
 
-        public Span<byte> Storage => MemoryMarshal.CreateSpan(ref _storage, Size);
+        public Span<byte> Storage => _storage.AsSpan();
 
         [StructLayout(LayoutKind.Sequential, Pack = 4, Size = 0x18)]
         public struct ElementInfo

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/Nickname.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/Nickname.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ryujinx.Common.Memory;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -10,12 +11,12 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
         public const int CharCount = 10;
         private const int SizeConst = (CharCount + 1) * 2;
 
-        private byte _storage;
+        private Array22<byte> _storage;
 
         public static Nickname Default => FromString("no name");
         public static Nickname Question => FromString("???");
 
-        public Span<byte> Raw => MemoryMarshal.CreateSpan(ref _storage, SizeConst);
+        public Span<byte> Raw => _storage.AsSpan();
 
         private ReadOnlySpan<ushort> Characters => MemoryMarshal.Cast<byte, ushort>(Raw);
 

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/StoreData.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/StoreData.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
 
         private ushort CalculateDataCrc()
         {
-            return Helper.CalculateCrc16(AsSpanWithoutDeviceCrc(), 0, true);
+            return Helper.CalculateCrc16(AsSpanWithoutCrcs(), 0, true);
         }
 
         private ushort CalculateDeviceCrc()
@@ -71,7 +71,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
 
             ushort deviceIdCrc16 = Helper.CalculateCrc16(SpanHelpers.AsByteSpan(ref deviceId), 0, false);
 
-            return Helper.CalculateCrc16(AsSpan(), deviceIdCrc16, true);
+            return Helper.CalculateCrc16(AsSpanWithoutDeviceCrc(), deviceIdCrc16, true);
         }
 
         private ReadOnlySpan<byte> AsSpan()
@@ -82,6 +82,11 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
         private ReadOnlySpan<byte> AsSpanWithoutDeviceCrc()
         {
             return AsSpan()[..(Size - 2)];
+        }
+
+        private ReadOnlySpan<byte> AsSpanWithoutCrcs()
+        {
+            return AsSpan()[..(Size - 4)];
         }
 
         public static StoreData BuildDefault(UtilityImpl utilImpl, uint index)

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/Ver3StoreData.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/Ver3StoreData.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Ryujinx.Common.Memory;
+using Ryujinx.Common.Utilities;
+using System;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Mii.Types
@@ -8,9 +10,10 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
     {
         public const int Size = 0x60;
 
-        private byte _storage;
+        private Array64<byte> _storage;
+        private Array32<byte> _storage2;
 
-        public Span<byte> Storage => MemoryMarshal.CreateSpan(ref _storage, Size);
+        public Span<byte> Storage => SpanHelpers.CreateSpan(ref MemoryMarshal.GetReference(_storage.AsSpan()), Size);
 
         // TODO: define all getters/setters
     }

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/Ver3StoreData.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/Ver3StoreData.cs
@@ -10,10 +10,9 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
     {
         public const int Size = 0x60;
 
-        private Array64<byte> _storage;
-        private Array32<byte> _storage2;
+        private Array96<byte> _storage;
 
-        public Span<byte> Storage => SpanHelpers.CreateSpan(ref MemoryMarshal.GetReference(_storage.AsSpan()), Size);
+        public Span<byte> Storage => _storage.AsSpan();
 
         // TODO: define all getters/setters
     }


### PR DESCRIPTION
Validating CRCs for data and device involves calculating the crc of all data including the crc being checked, which should then be 0.

The crc should be _generated_ on all data _before_ the crc in the struct. It shouldn't include the crcs themselves.

This fixes all generated miis (eg. default) having invalid crcs. This does not affect mii maker normally, as that generates its own StoreData crcs.

Also includes some miscellaneous fixes:
- Use Array<> instead of a byte storage field for CoreData, Nickname and Ver3StoreData
  - This was observed causing core data to become all 0s, and nickname to only display the first character in debug mode. This probably depends on if the struct is copied, I imagine it doesn't think the undefined space in the struct holds any data.
  - Ver3StoreData was not tested to have an issue, but it has been changed just in case.
  - This leaves me a bit worried for other places in the codebase that do this. I recommend searching for `MemoryMarshal.CreateSpan(ref ` to see similar examples.
- Flipped comparison that always errored on `ConvertCharInfoToCoreData`.

Does not fix MK8D crash. I have more info on it, though:

Loading a save file with a mii saved from Ryujinx _or_ the switch does work if the mii doesn't currently exist in the database (deleted in mii maker). In this case, it tries to GetIndex for the player mii, and all the data seems intact.

If the saved mii does exist in the database retrieved via the `Get` method (matching createid), then the GetIndex call instead has a mii that is all 0s, indicating that the mii was blanked out for some reason. It crashes later on, probably because it tries to draw a null mii for the menu.