### PR TITLE
Fix SPIR-V call out arguments regression

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5764;
+        private const uint CodeGenVersion = 5767;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";


### PR DESCRIPTION
Fixes yet another regression from #5757. On the shader IR, out arguments are usually first added as destination operand, and then later it is moved to one of the source operands of the call (this is required since generally source operands are considered uses, and destination operands are considered assignments). The exception for that rule is some helper functions that the emulator generates, those adds the out argument as a source operand directly. While this was fine before, I did not account for that on #5757, which meant it will copy the out value into a temp (before the call), and the call would modify the temp value, while the actual out value would remain uninitialized.

This mainly affect games using shuffle instructions which does have one out parameter, so mostly UE4 games, but Marvel Ultimate Alliance 3 and maybe a few others were also affected.