### PR TITLE
Symbols.cs Get function return value fix

### DIFF
--- a/src/ARMeilleure/Diagnostics/Symbols.cs
+++ b/src/ARMeilleure/Diagnostics/Symbols.cs
@@ -34,7 +34,6 @@ namespace ARMeilleure.Diagnostics
 
         public static string Get(ulong address)
         {
-
             if (_symbols.TryGetValue(address, out string result))
             {
                 return result;
@@ -57,7 +56,8 @@ namespace ARMeilleure.Diagnostics
                             resultBuilder.Append($"+{rem}");
                         }
 
-                        _symbols.TryAdd(address, resultBuilder.ToString());
+                        result = resultBuilder.ToString();
+                        _symbols.TryAdd(address, result);
 
                         return result;
                     }


### PR DESCRIPTION
Fixes a regression from #5664 that causes the wrong value to be returned in the Get function for Symbols.cs when a result does not currently exist for an address.