### PR TITLE
Replace ReaderWriterLock with ReaderWriterLockSlim

### DIFF
--- a/src/Ryujinx.Common/ReactiveObject.cs
+++ b/src/Ryujinx.Common/ReactiveObject.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.Common
 {
     public class ReactiveObject<T>
     {
-        private readonly ReaderWriterLock _readerWriterLock = new();
+        private readonly ReaderWriterLockSlim _readerWriterLock = new();
         private bool _isInitialized;
         private T _value;
 
@@ -15,15 +15,15 @@ namespace Ryujinx.Common
         {
             get
             {
-                _readerWriterLock.AcquireReaderLock(Timeout.Infinite);
+                _readerWriterLock.EnterReadLock();
                 T value = _value;
-                _readerWriterLock.ReleaseReaderLock();
+                _readerWriterLock.ExitReadLock();
 
                 return value;
             }
             set
             {
-                _readerWriterLock.AcquireWriterLock(Timeout.Infinite);
+                _readerWriterLock.EnterWriteLock();
 
                 T oldValue = _value;
 
@@ -32,7 +32,7 @@ namespace Ryujinx.Common
                 _isInitialized = true;
                 _value = value;
 
-                _readerWriterLock.ReleaseWriterLock();
+                _readerWriterLock.ExitWriteLock();
 
                 if (!oldIsInitialized || oldValue == null || !oldValue.Equals(_value))
                 {

--- a/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -550,9 +550,11 @@ namespace Ryujinx.Graphics.Vulkan
         {
             bool wasInReadLock = _flushLock.IsReadLockHeld;
 
-            // Try to get into a write lock if not already.
+            // Try to get into a read lock if not already.
             if (!wasInReadLock)
+            {
                 _flushLock.EnterReadLock();
+            }
 
             try
             {
@@ -585,7 +587,9 @@ namespace Ryujinx.Graphics.Vulkan
                     {
                         _flushLock.ExitWriteLock();
                         if (wasInReadLock)
+                        {
                             _flushLock.EnterReadLock(); // Re-enter read lock if we were originally in it.
+                        }
                     }
                 }
             }
@@ -593,7 +597,9 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 // If we catch an exception, ensure we have the appropriate locks restored.
                 if (wasInReadLock && !_flushLock.IsReadLockHeld)
+                {
                     _flushLock.EnterReadLock();
+                }
 
                 throw;
             }

--- a/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.Graphics.Vulkan
         private int _flushTemp;
         private int _lastFlushWrite = -1;
 
-        private readonly ReaderWriterLock _flushLock;
+        private readonly ReaderWriterLockSlim _flushLock;
         private FenceHolder _flushFence;
         private int _flushWaiting;
 
@@ -85,7 +85,7 @@ namespace Ryujinx.Graphics.Vulkan
             _currentType = currentType;
             DesiredType = currentType;
 
-            _flushLock = new ReaderWriterLock();
+            _flushLock = new ReaderWriterLockSlim();
             _useMirrors = gd.IsTBDR;
         }
 
@@ -106,7 +106,7 @@ namespace Ryujinx.Graphics.Vulkan
             _currentType = currentType;
             DesiredType = currentType;
 
-            _flushLock = new ReaderWriterLock();
+            _flushLock = new ReaderWriterLockSlim();
         }
 
         public bool TryBackingSwap(ref CommandBufferScoped? cbs)
@@ -116,7 +116,7 @@ namespace Ryujinx.Graphics.Vulkan
                 // Only swap if the buffer is not used in any queued command buffer.
                 bool isRented = _buffer.HasRentedCommandBufferDependency(_gd.CommandBufferPool);
 
-                if (!isRented && _gd.CommandBufferPool.OwnedByCurrentThread && !_flushLock.IsReaderLockHeld && (_pendingData == null || cbs != null))
+                if (!isRented && _gd.CommandBufferPool.OwnedByCurrentThread && !_flushLock.IsReadLockHeld && (_pendingData == null || cbs != null))
                 {
                     var currentAllocation = _allocationAuto;
                     var currentBuffer = _buffer;
@@ -131,7 +131,7 @@ namespace Ryujinx.Graphics.Vulkan
                             ClearMirrors(cbs.Value, 0, Size);
                         }
 
-                        _flushLock.AcquireWriterLock(Timeout.Infinite);
+                        _flushLock.EnterWriteLock();
 
                         ClearFlushFence();
 
@@ -185,7 +185,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                         _gd.PipelineInternal.SwapBuffer(currentBuffer, _buffer);
 
-                        _flushLock.ReleaseWriterLock();
+                        _flushLock.ExitWriteLock();
                     }
 
                     _swapQueued = false;
@@ -548,42 +548,60 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void WaitForFlushFence()
         {
-            // Assumes the _flushLock is held as reader, returns in same state.
+            bool wasInReadLock = _flushLock.IsReadLockHeld;
 
-            if (_flushFence != null)
+            // Try to get into a write lock if not already.
+            if (!wasInReadLock)
+                _flushLock.EnterReadLock();
+
+            try
             {
-                // If storage has changed, make sure the fence has been reached so that the data is in place.
-
-                var cookie = _flushLock.UpgradeToWriterLock(Timeout.Infinite);
-
                 if (_flushFence != null)
                 {
-                    var fence = _flushFence;
-                    Interlocked.Increment(ref _flushWaiting);
+                    _flushLock.ExitReadLock();
+                    _flushLock.EnterWriteLock();
 
-                    // Don't wait in the lock.
-
-                    var restoreCookie = _flushLock.ReleaseLock();
-
-                    fence.Wait();
-
-                    _flushLock.RestoreLock(ref restoreCookie);
-
-                    if (Interlocked.Decrement(ref _flushWaiting) == 0)
+                    try
                     {
-                        fence.Put();
+                        if (_flushFence != null)
+                        {
+                            var fence = _flushFence;
+                            Interlocked.Increment(ref _flushWaiting);
+
+                            // Don't wait inside the write lock.
+                            _flushLock.ExitWriteLock();
+                            fence.Wait();
+                            _flushLock.EnterWriteLock();
+
+                            if (Interlocked.Decrement(ref _flushWaiting) == 0)
+                            {
+                                fence.Put();
+                            }
+
+                            _flushFence = null;
+                        }
                     }
-
-                    _flushFence = null;
+                    finally
+                    {
+                        _flushLock.ExitWriteLock();
+                        if (wasInReadLock)
+                            _flushLock.EnterReadLock(); // Re-enter read lock if we were originally in it.
+                    }
                 }
+            }
+            catch
+            {
+                // If we catch an exception, ensure we have the appropriate locks restored.
+                if (wasInReadLock && !_flushLock.IsReadLockHeld)
+                    _flushLock.EnterReadLock();
 
-                _flushLock.DowngradeFromWriterLock(ref cookie);
+                throw;
             }
         }
 
         public PinnedSpan<byte> GetData(int offset, int size)
         {
-            _flushLock.AcquireReaderLock(Timeout.Infinite);
+            _flushLock.EnterReadLock();
 
             WaitForFlushFence();
 
@@ -603,7 +621,7 @@ namespace Ryujinx.Graphics.Vulkan
                 // Need to be careful here, the buffer can't be unmapped while the data is being used.
                 _buffer.IncrementReferenceCount();
 
-                _flushLock.ReleaseReaderLock();
+                _flushLock.ExitReadLock();
 
                 return PinnedSpan<byte>.UnsafeFromSpan(result, _buffer.DecrementReferenceCount);
             }
@@ -621,7 +639,7 @@ namespace Ryujinx.Graphics.Vulkan
                 result = resource.GetFlushBuffer().GetBufferData(resource.GetPool(), this, offset, size);
             }
 
-            _flushLock.ReleaseReaderLock();
+            _flushLock.ExitReadLock();
 
             // Flush buffer is pinned until the next GetBufferData on the thread, which is fine for current uses.
             return PinnedSpan<byte>.UnsafeFromSpan(result);
@@ -1073,11 +1091,11 @@ namespace Ryujinx.Graphics.Vulkan
                 _allocationAuto.Dispose();
             }
 
-            _flushLock.AcquireWriterLock(Timeout.Infinite);
+            _flushLock.EnterWriteLock();
 
             ClearFlushFence();
 
-            _flushLock.ReleaseWriterLock();
+            _flushLock.ExitWriteLock();
         }
     }
 }


### PR DESCRIPTION
Replaces Use of ReaderWriterLock with ReaderWriterLockSlim, ReaderWriterLock is now deprecated in favor of ReaderWriterLockSlim. In cases of many readers and few writer it is preferred and in other cases a simple lock should be used. UpgradeableReadLock also is a thread blocking state so was replaced with simple switching between reading and writing. 

Supersedes #5493