### PR TITLE
Fix games freezing after initializing LDN 1021 times

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/IUserLocalCommunicationService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/IUserLocalCommunicationService.cs
@@ -1028,7 +1028,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
             SetState(NetworkState.None);
 
-            NetworkClient?.DisconnectAndStop();
+            NetworkClient?.Dispose();
             NetworkClient = null;
 
             return ResultCode.Success;
@@ -1079,7 +1079,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
                     }
                     else
                     {
-                        // NOTE: Service returns differents ResultCode here related to the nifm ResultCode.
+                        // NOTE: Service returns different ResultCode here related to the nifm ResultCode.
                         resultCode = ResultCode.DeviceDisabled;
                         _nifmResultCode = resultCode;
                     }
@@ -1091,14 +1091,13 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public void Dispose()
         {
-            if (NetworkClient != null)
-            {
-                _station?.Dispose();
-                _accessPoint?.Dispose();
+            _station?.Dispose();
+            _station = null;
 
-                NetworkClient.DisconnectAndStop();
-            }
+            _accessPoint?.Dispose();
+            _accessPoint = null;
 
+            NetworkClient?.Dispose();
             NetworkClient = null;
         }
     }


### PR DESCRIPTION
This PR fixes an odd issue where games would suddenly freeze after LDN was initialized 1021 times (or after spending about 20 minutes playing Pokémon Sword/Shield).

Since the `stateChangeEvent` handles were never closed before, the handle table was eventually running out of space which resulted in the game freezing for some reason. I was sure this issue would manifest as a crash, since at least in LDN we handle that case like that, but it seems in other places we might not be doing that or there is something else going on that I don't really understand yet. 

---

Fixes #5778