### PR TITLE
infra: Reformat README.md & add new generic Mako workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,6 @@ root = true
 
 #### Core EditorConfig Options ####
 
-# Set default charset
-charset = utf-8
-
 # Indentation and spacing
 indent_size = 4
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,9 @@ root = true
 
 #### Core EditorConfig Options ####
 
+# Set default charset
+charset = utf-8
+
 # Indentation and spacing
 indent_size = 4
 indent_style = space
@@ -14,8 +17,8 @@ tab_width = 4
 end_of_line = lf
 insert_final_newline = true
 
-# JSON files
-[*.json]
+# Markdown, JSON, YAML, props and csproj files
+[*.{md,json,yml,props,csproj}]
 
 # Indentation and spacing
 indent_size = 2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
       - '!.github/**'
       - '!*.yml'
       - '!*.config'
-      - '!README.md'
+      - '!*.md'
       - '.github/workflows/*.yml'
 
 permissions:

--- a/.github/workflows/mako.yml
+++ b/.github/workflows/mako.yml
@@ -1,0 +1,45 @@
+name: Mako
+on:
+  discussion:
+    types: [created, edited, answered, unanswered, category_changed]
+  discussion_comment:
+    types: [created, edited]
+  gollum:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited, reopened, pinned, milestoned, demilestoned, assigned, unassigned, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review, assigned, unassigned]
+
+jobs:
+  tasks:
+    name: Run Ryujinx tasks
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
+        with:
+          # Ensure we pin the source origin as pull_request_target run under forks.
+          fetch-depth: 0
+          repository: Ryujinx/Ryujinx
+          ref: master
+
+      - name: Run Mako command
+        uses: Ryujinx/Ryujinx-Mako@master
+        with:
+          command: exec-ryujinx-tasks
+          args: --event-name "${{ github.event_name }}" --event-path "${{ github.event_path }}" -w "${{ github.workspace }}" "${{ github.repository }}" "${{ github.run_id }}"
+          app_id: ${{ secrets.MAKO_APP_ID }}
+          private_key: ${{ secrets.MAKO_PRIVATE_KEY }}
+          installation_id: ${{ secrets.MAKO_INSTALLATION_ID }}

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -21,27 +21,8 @@ jobs:
            repository: Ryujinx/Ryujinx
            ref: master
 
-      - name: Checkout Ryujinx-Mako
-        uses: actions/checkout@v4
-        with:
-            repository: Ryujinx/Ryujinx-Mako
-            ref: master
-            path: '.ryujinx-mako'
-
-      - name: Setup Ryujinx-Mako
-        uses: ./.ryujinx-mako/.github/actions/setup-mako
-
       - name: Update labels based on changes
         uses: actions/labeler@v4
         with:
           sync-labels: true
           dot: true
-
-      - name: Assign reviewers
-        run: |
-            poetry -n -C .ryujinx-mako run ryujinx-mako update-reviewers ${{ github.repository }} ${{ github.event.pull_request.number }} .github/reviewers.yml
-        shell: bash
-        env:
-            MAKO_APP_ID: ${{ secrets.MAKO_APP_ID }}
-            MAKO_PRIVATE_KEY: ${{ secrets.MAKO_PRIVATE_KEY }}
-            MAKO_INSTALLATION_ID: ${{ secrets.MAKO_INSTALLATION_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       - '*.yml'
       - '*.json'
       - '*.config'
-      - 'README.md'
+      - '*.md'
 
 concurrency: release
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-
 <h1 align="center">
   <br>
-  <a href="https://ryujinx.org/"><img src="https://i.imgur.com/WcCj6Rt.png" alt="Ryujinx" width="150"></a>
+  <a href="https://ryujinx.org/"><img src="https://raw.githubusercontent.com/Ryujinx/Ryujinx/master/distribution/misc/Logo.svg" alt="Ryujinx" width="150"></a>
   <br>
   <b>Ryujinx</b>
   <br>
   <sub><sup><b>(REE-YOU-JINX)</b></sup></sub>
   <br>
-
 </h1>
 
 <p align="center">
-       Ryujinx is an open-source Nintendo Switch emulator, created by gdkchan, written in C#.
-       This emulator aims at providing excellent accuracy and performance, a user-friendly interface and consistent builds.
-    It was written from scratch and development on the project began in September 2017. Ryujinx is available on Github under the <a href="https://github.com/Ryujinx/Ryujinx/blob/master/LICENSE.txt" target="_blank">MIT license</a>. <br />
-
+  Ryujinx is an open-source Nintendo Switch emulator, created by gdkchan, written in C#.
+  This emulator aims at providing excellent accuracy and performance, a user-friendly interface and consistent builds.
+  It was written from scratch and development on the project began in September 2017.
+  Ryujinx is available on Github under the <a href="https://github.com/Ryujinx/Ryujinx/blob/master/LICENSE.txt" target="_blank">MIT license</a>.
+  <br />
 </p>
+
 <p align="center">
     <a href="https://github.com/Ryujinx/Ryujinx/actions/workflows/release.yml">
         <img src="https://github.com/Ryujinx/Ryujinx/actions/workflows/release.yml/badge.svg"
@@ -34,87 +34,111 @@
     <img src="https://raw.githubusercontent.com/Ryujinx/Ryujinx-Website/master/public/assets/images/shell.png">
 </p>
 
-<h5 align="center">
-
-</h5>
-
 ## Compatibility
 
-As of April 2023, Ryujinx has been tested on approximately 4,050 titles; over 4,000 boot past menus and into gameplay, with roughly 3,400 of those being considered playable.
-You can check out the compatibility list [here](https://github.com/Ryujinx/Ryujinx-Games-List/issues). Anyone is free to submit a new game test or update an existing game test entry; simply follow the new issue template and testing guidelines, or post as a reply to the applicable game issue. Use the search function to see if a game has been tested already!
+As of April 2023, Ryujinx has been tested on approximately 4,050 titles;
+over 4,000 boot past menus and into gameplay, with roughly 3,400 of those being considered playable.
+
+You can check out the compatibility list [here](https://github.com/Ryujinx/Ryujinx-Games-List/issues).
+
+Anyone is free to submit a new game test or update an existing game test entry;
+simply follow the new issue template and testing guidelines, or post as a reply to the applicable game issue.
+Use the search function to see if a game has been tested already!
 
 ## Usage
 
-To run this emulator, your PC must be equipped with at least 8GiB of RAM; failing to meet this requirement may result in a poor gameplay experience or unexpected crashes.
+To run this emulator, your PC must be equipped with at least 8GiB of RAM;
+failing to meet this requirement may result in a poor gameplay experience or unexpected crashes.
 
 See our [Setup & Configuration Guide](https://github.com/Ryujinx/Ryujinx/wiki/Ryujinx-Setup-&-Configuration-Guide) on how to set up the emulator.
 
-For our Local Wireless and LAN builds, see our [Multiplayer: Local Play/Local Wireless Guide
+For our Local Wireless (LDN) builds, see our [Multiplayer: Local Play/Local Wireless Guide
 ](https://github.com/Ryujinx/Ryujinx/wiki/Multiplayer-(LDN-Local-Wireless)-Guide).
 
 Avalonia UI comes with translations for various languages. See [Crowdin](https://crwd.in/ryujinx) for more information.
 
 ## Latest build
 
-These builds are compiled automatically for each commit on the master branch. While we strive to ensure optimal stability and performance prior to pushing an update, our automated builds **may be unstable or completely broken.**
+These builds are compiled automatically for each commit on the master branch.
+While we strive to ensure optimal stability and performance prior to pushing an update, our automated builds **may be unstable or completely broken**.
 
 If you want to see details on updates to the emulator, you can visit our [Changelog](https://github.com/Ryujinx/Ryujinx/wiki/Changelog).
 
 The latest automatic build for Windows, macOS, and Linux can be found on the [Official Website](https://ryujinx.org/download).
 
+## Documentation
+
+If you are planning to contribute or just want to learn more about this project please read through our [documentation](docs/README.md).
 
 ## Building
 
 If you wish to build the emulator yourself, follow these steps:
 
 ### Step 1
-Install the X64 version of [.NET 8.0 (or higher) SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+
+Install the [.NET 8.0 (or higher) SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+Make sure your SDK version is higher or equal to the required version specified in [global.json](global.json). 
 
 ### Step 2
+
 Either use `git clone https://github.com/Ryujinx/Ryujinx` on the command line to clone the repository or use Code --> Download zip button to get the files.
 
 ### Step 3
 
-To build Ryujinx, open a command prompt inside the project directory. You can quickly access it on Windows by holding shift in File Explorer, then right clicking and selecting `Open command window here`. Then type the following command:
-`dotnet build -c Release -o build`
+To build Ryujinx, open a command prompt inside the project directory.
+You can quickly access it on Windows by holding shift in File Explorer, then right clicking and selecting `Open command window here`.
+Then type the following command: `dotnet build -c Release -o build`
 the built files will be found in the newly created build directory.
 
-Ryujinx system files are stored in the `Ryujinx` folder. This folder is located in the user folder, which can be accessed by clicking `Open Ryujinx Folder` under the File menu in the GUI.
-
+Ryujinx system files are stored in the `Ryujinx` folder.
+This folder is located in the user folder, which can be accessed by clicking `Open Ryujinx Folder` under the File menu in the GUI.
 
 ## Features
 
- - **Audio**
+- **Audio**
 
-   Audio output is entirely supported, audio input (microphone) isn't supported. We use C# wrappers for [OpenAL](https://openal-soft.org/), and [SDL2](https://www.libsdl.org/) & [libsoundio](http://libsound.io/) as fallbacks.
+  Audio output is entirely supported, audio input (microphone) isn't supported.
+  We use C# wrappers for [OpenAL](https://openal-soft.org/), and [SDL2](https://www.libsdl.org/) & [libsoundio](http://libsound.io/) as fallbacks.
 
 - **CPU**
 
-  The CPU emulator, ARMeilleure, emulates an ARMv8 CPU and currently has support for most 64-bit ARMv8 and some of the ARMv7 (and older) instructions, including partial 32-bit support. It translates the ARM code to a custom IR, performs a few optimizations, and turns that into x86 code.
-  There are three memory manager options available depending on the user's preference, leveraging both software-based (slower) and host-mapped modes (much faster). The fastest option (host, unchecked) is set by default.
-  Ryujinx also features an optional Profiled Persistent Translation Cache, which essentially caches translated functions so that they do not need to be translated every time the game loads. The net result is a significant reduction in load times (the amount of time between launching a game and arriving at the title screen) for nearly every game. NOTE: this feature is enabled by default in the Options menu > System tab. You must launch the game at least twice to the title screen or beyond before performance improvements are unlocked on the third launch! These improvements are permanent and do not require any extra launches going forward.
+  The CPU emulator, ARMeilleure, emulates an ARMv8 CPU and currently has support for most 64-bit ARMv8 and some of the ARMv7 (and older) instructions, including partial 32-bit support.
+  It translates the ARM code to a custom IR, performs a few optimizations, and turns that into x86 code.
+  There are three memory manager options available depending on the user's preference, leveraging both software-based (slower) and host-mapped modes (much faster).
+  The fastest option (host, unchecked) is set by default.
+  Ryujinx also features an optional Profiled Persistent Translation Cache, which essentially caches translated functions so that they do not need to be translated every time the game loads. 
+  The net result is a significant reduction in load times (the amount of time between launching a game and arriving at the title screen) for nearly every game.
+  NOTE: This feature is enabled by default in the Options menu > System tab.
+  You must launch the game at least twice to the title screen or beyond before performance improvements are unlocked on the third launch!
+  These improvements are permanent and do not require any extra launches going forward.
 
 - **GPU**
 
-  The GPU emulator emulates the Switch's Maxwell GPU using either the OpenGL (version 4.5 minimum), Vulkan, or Metal (via MoltenVK) APIs through a custom build of OpenTK or Silk.NET respectively. There are currently six graphics enhancements available to the end user in Ryujinx: Disk Shader Caching, Resolution Scaling, Anti-Aliasing, Scaling Filters (including FSR), Anisotropic Filtering and Aspect Ratio Adjustment. These enhancements can be adjusted or toggled as desired in the GUI.
+  The GPU emulator emulates the Switch's Maxwell GPU using either the OpenGL (version 4.5 minimum), Vulkan, or Metal (via MoltenVK) APIs through a custom build of OpenTK or Silk.NET respectively.
+  There are currently six graphics enhancements available to the end user in Ryujinx: Disk Shader Caching, Resolution Scaling, Anti-Aliasing, Scaling Filters (including FSR), Anisotropic Filtering and Aspect Ratio Adjustment.
+  These enhancements can be adjusted or toggled as desired in the GUI.
 
 - **Input**
 
-   We currently have support for keyboard, mouse, touch input, JoyCon input support, and nearly all controllers. Motion controls are natively supported in most cases; for dual-JoyCon motion support, DS4Windows or BetterJoy are currently required.
-   In all scenarios, you can set up everything inside the input configuration menu.
+  We currently have support for keyboard, mouse, touch input, JoyCon input support, and nearly all controllers.
+  Motion controls are natively supported in most cases; for dual-JoyCon motion support, DS4Windows or BetterJoy are currently required.
+  In all scenarios, you can set up everything inside the input configuration menu.
 
 - **DLC & Modifications**
 
-   Ryujinx is able to manage add-on content/downloadable content through the GUI. Mods (romfs, exefs, and runtime mods such as cheats) are also supported; the GUI contains a shortcut to open the respective mods folder for a particular game.
+  Ryujinx is able to manage add-on content/downloadable content through the GUI.
+  Mods (romfs, exefs, and runtime mods such as cheats) are also supported;
+  the GUI contains a shortcut to open the respective mods folder for a particular game.
 
 - **Configuration**
 
-   The emulator has settings for enabling or disabling some logging, remapping controllers, and more. You can configure all of them through the graphical interface or manually through the config file, `Config.json`, found in the user folder which can be accessed by clicking `Open Ryujinx Folder` under the File menu in the GUI.
-
+  The emulator has settings for enabling or disabling some logging, remapping controllers, and more.
+  You can configure all of them through the graphical interface or manually through the config file, `Config.json`, found in the user folder which can be accessed by clicking `Open Ryujinx Folder` under the File menu in the GUI.
 
 ## Contact
 
-If you have contributions, suggestions, need emulator support or just want to get in touch with the team, join our [Discord server](https://discord.com/invite/Ryujinx). You may also review our [FAQ](https://github.com/Ryujinx/Ryujinx/wiki/Frequently-Asked-Questions).
+If you have contributions, suggestions, need emulator support or just want to get in touch with the team, join our [Discord server](https://discord.com/invite/Ryujinx).
+You may also review our [FAQ](https://github.com/Ryujinx/Ryujinx/wiki/Frequently-Asked-Questions).
 
 ## Donations
 
@@ -134,9 +158,10 @@ All funds received through Patreon are considered a donation to support the proj
 
 ## License
 
-This software is licensed under the terms of the <a href="https://github.com/Ryujinx/Ryujinx/blob/master/LICENSE.txt" target="_blank">MIT license.</a></i><br />
+This software is licensed under the terms of the [MIT license](LICENSE.txt).
 This project makes use of code authored by the libvpx project, licensed under BSD and the ffmpeg project, licensed under LGPLv3.
 See [LICENSE.txt](LICENSE.txt) and [THIRDPARTY.md](distribution/legal/THIRDPARTY.md) for more details.
+
 ## Credits
 
 - [LibHac](https://github.com/Thealexbarney/LibHac) is used for our file-system.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
 
 ## Compatibility
 
-As of April 2023, Ryujinx has been tested on approximately 4,050 titles;
-over 4,000 boot past menus and into gameplay, with roughly 3,400 of those being considered playable.
+As of October 2023, Ryujinx has been tested on approximately 4,200 titles;
+over 4,150 boot past menus and into gameplay, with roughly 3,500 of those being considered playable.
 
 You can check out the compatibility list [here](https://github.com/Ryujinx/Ryujinx-Games-List/issues).
 


### PR DESCRIPTION
This PR includes a bunch of smaller changes and adds the new Mako workflow as previously announced in Ryujinx/Ryujinx-Mako#3.

The new Mako workflow:

- This workflow replaces the previous Ryujinx-Mako steps and should allow us to change Mako's behavior without changing any files here.
- It receives all the necessary information from the event that triggered the workflow, so we can execute the appropriate tasks for them. All of this is handled by the `exec-ryujinx-tasks` command.
  Currently only the `update-reviewers` task will be executed, since I want to make sure everything works before adding more stuff on top of it.
- Although there are a lot of events that trigger this workflow, most runs shouldn't take longer than ~30 seconds, so hopefully we don't run into any issues because of that.
- We should be able to use this workflow without any issues in our other projects as well.

Unrelated smaller adjustments:

- `.editorconfig` needed to be changed to account for the files where we indent with 2 spaces instead of 4.
- ~~The .NET SDK version in our current `global.json` is not able to compile Ryujinx anymore, so it was updated.~~
- Our `README.md` contained a bunch of small formatting/styling issues which I addressed.
  I also added a small section to link to our new documentation and fixed a few links, but didn't make any larger changes to the wording.
  Note: Most of these formatting changes don't affect the rendered markdown file.
  Currently we link to the MIT license twice for some reason, but I'm not sure if this is the right place to address that.

---

Depends on Ryujinx/Ryujinx-Mako#3