### PR TITLE
Horizon: Migrate usb and psc services

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Ins/IReceiverManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ins/IReceiverManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Ins
-{
-    [Service("ins:r")]
-    class IReceiverManager : IpcService
-    {
-        public IReceiverManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Ins/ISenderManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ins/ISenderManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Ins
-{
-    [Service("ins:s")]
-    class ISenderManager : IpcService
-    {
-        public ISenderManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Ovln/IReceiverService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ovln/IReceiverService.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Ovln
-{
-    [Service("ovln:rcv")]
-    class IReceiverService : IpcService
-    {
-        public IReceiverService(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Ovln/ISenderService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ovln/ISenderService.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Ovln
-{
-    [Service("ovln:snd")]
-    class ISenderService : IpcService
-    {
-        public ISenderService(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Psc/IPmControl.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Psc/IPmControl.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Psc
-{
-    [Service("psc:c")]
-    class IPmControl : IpcService
-    {
-        public IPmControl(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Psc/IPmService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Psc/IPmService.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Psc
-{
-    [Service("psc:m")]
-    class IPmService : IpcService
-    {
-        public IPmService(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Psc/IPmUnknown.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Psc/IPmUnknown.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Psc
-{
-    [Service("psc:l")] // 9.0.0+
-    class IPmUnknown : IpcService
-    {
-        public IPmUnknown(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Srepo/ISrepoService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Srepo/ISrepoService.cs
@@ -1,9 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Srepo
-{
-    [Service("srepo:a")] // 5.0.0+
-    [Service("srepo:u")] // 5.0.0+
-    class ISrepoService : IpcService
-    {
-        public ISrepoService(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IClientRootSession.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IClientRootSession.cs
@@ -1,9 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:hs")]
-    [Service("usb:hs:a")] // 7.0.0+
-    class IClientRootSession : IpcService
-    {
-        public IClientRootSession(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IDsService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IDsService.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:ds")]
-    class IDsService : IpcService
-    {
-        public IDsService(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IPdCradleManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IPdCradleManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:pd:c")]
-    class IPdCradleManager : IpcService
-    {
-        public IPdCradleManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IPdManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IPdManager.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:pd")]
-    class IPdManager : IpcService
-    {
-        public IPdManager(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IPmService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IPmService.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:pm")]
-    class IPmService : IpcService
-    {
-        public IPmService(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IUnknown1.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IUnknown1.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:qdb")] // 7.0.0+
-    class IUnknown1 : IpcService
-    {
-        public IUnknown1(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.HLE/HOS/Services/Usb/IUnknown2.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Usb/IUnknown2.cs
@@ -1,8 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Usb
-{
-    [Service("usb:obsv")] // 8.0.0+
-    class IUnknown2 : IpcService
-    {
-        public IUnknown2(ServiceCtx context) { }
-    }
-}

--- a/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
+++ b/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
@@ -93,7 +93,7 @@ namespace Ryujinx.Horizon.Generators.Hipc
                 generator.LeaveScope();
                 generator.LeaveScope();
 
-                context.AddSource($"{className}.g.cs", generator.ToString());
+                context.AddSource($"{GetNamespaceName(commandInterface.ClassDeclarationSyntax)}.{className}.g.cs", generator.ToString());
             }
         }
 

--- a/src/Ryujinx.Horizon/Hshl/HshlIpcServer.cs
+++ b/src/Ryujinx.Horizon/Hshl/HshlIpcServer.cs
@@ -1,0 +1,47 @@
+﻿using Ryujinx.Horizon.Hshl.Ipc;
+using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+
+namespace Ryujinx.Horizon.Hshl
+{
+    class HshlIpcServer
+    {
+        private const int HshlMaxSessionsCount = 10;
+        private const int TotalMaxSessionsCount = HshlMaxSessionsCount * 2;
+
+        private const int PointerBufferSize = 0;
+        private const int MaxDomains = 0;
+        private const int MaxDomainObjects = 0;
+        private const int MaxPortsCount = 2;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+#pragma warning disable IDE0055 // Disable formatting
+            _serverManager.RegisterObjectForServer(new SetterManager(), ServiceName.Encode("hshl:set"), HshlMaxSessionsCount); // 11.0.0+
+            _serverManager.RegisterObjectForServer(new Manager(),       ServiceName.Encode("hshl:sys"), HshlMaxSessionsCount); // 11.0.0+
+#pragma warning restore IDE0055
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Hshl/HshlMain.cs
+++ b/src/Ryujinx.Horizon/Hshl/HshlMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Hshl
+{
+    class HshlMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            HshlIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Hshl/Ipc/Manager.cs
+++ b/src/Ryujinx.Horizon/Hshl/Ipc/Manager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Hshl;
+
+namespace Ryujinx.Horizon.Hshl.Ipc
+{
+    partial class Manager : IManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Hshl/Ipc/SetterManager.cs
+++ b/src/Ryujinx.Horizon/Hshl/Ipc/SetterManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Hshl;
+
+namespace Ryujinx.Horizon.Hshl.Ipc
+{
+    partial class SetterManager : ISetterManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Ins/InsIpcServer.cs
+++ b/src/Ryujinx.Horizon/Ins/InsIpcServer.cs
@@ -1,0 +1,47 @@
+﻿using Ryujinx.Horizon.Ins.Ipc;
+using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+
+namespace Ryujinx.Horizon.Ins
+{
+    class InsIpcServer
+    {
+        private const int InsMaxSessionsCount = 8;
+        private const int TotalMaxSessionsCount = InsMaxSessionsCount * 2;
+
+        private const int PointerBufferSize = 0x200;
+        private const int MaxDomains = 0;
+        private const int MaxDomainObjects = 0;
+        private const int MaxPortsCount = 2;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+#pragma warning disable IDE0055 // Disable formatting
+            _serverManager.RegisterObjectForServer(new ReceiverManager(), ServiceName.Encode("ins:r"), InsMaxSessionsCount); // 9.0.0+
+            _serverManager.RegisterObjectForServer(new SenderManager(),   ServiceName.Encode("ins:s"), InsMaxSessionsCount); // 9.0.0+
+#pragma warning restore IDE0055
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Ins/InsMain.cs
+++ b/src/Ryujinx.Horizon/Ins/InsMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Ins
+{
+    class InsMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            InsIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Ins/Ipc/ReceiverManager.cs
+++ b/src/Ryujinx.Horizon/Ins/Ipc/ReceiverManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Ins;
+
+namespace Ryujinx.Horizon.Ins.Ipc
+{
+    partial class ReceiverManager : IReceiverManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Ins/Ipc/SenderManager.cs
+++ b/src/Ryujinx.Horizon/Ins/Ipc/SenderManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Ins;
+
+namespace Ryujinx.Horizon.Ins.Ipc
+{
+    partial class SenderManager : ISenderManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Ovln/Ipc/ReceiverService.cs
+++ b/src/Ryujinx.Horizon/Ovln/Ipc/ReceiverService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Ovln;
+
+namespace Ryujinx.Horizon.Ovln.Ipc
+{
+    partial class ReceiverService : IReceiverService
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Ovln/Ipc/SenderService.cs
+++ b/src/Ryujinx.Horizon/Ovln/Ipc/SenderService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Ovln;
+
+namespace Ryujinx.Horizon.Ovln.Ipc
+{
+    partial class SenderService : ISenderService
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Ovln/OvlnIpcServer.cs
+++ b/src/Ryujinx.Horizon/Ovln/OvlnIpcServer.cs
@@ -1,0 +1,48 @@
+﻿using Ryujinx.Horizon.Ovln.Ipc;
+using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+
+namespace Ryujinx.Horizon.Ovln
+{
+    class OvlnIpcServer
+    {
+        private const int OvlnRcvMaxSessionsCount = 2;
+        private const int OvlnSndMaxSessionsCount = 20;
+        private const int TotalMaxSessionsCount = OvlnRcvMaxSessionsCount + OvlnSndMaxSessionsCount;
+
+        private const int PointerBufferSize = 0;
+        private const int MaxDomains = 21;
+        private const int MaxDomainObjects = 60;
+        private const int MaxPortsCount = 2;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+#pragma warning disable IDE0055 // Disable formatting
+            _serverManager.RegisterObjectForServer(new ReceiverService(), ServiceName.Encode("ovln:rcv"), OvlnRcvMaxSessionsCount); // 8.0.0+
+            _serverManager.RegisterObjectForServer(new SenderService(),   ServiceName.Encode("ovln:snd"), OvlnSndMaxSessionsCount); // 8.0.0+
+#pragma warning restore IDE0055
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Ovln/OvlnMain.cs
+++ b/src/Ryujinx.Horizon/Ovln/OvlnMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Ovln
+{
+    class OvlnMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            OvlnIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Psc/Ipc/PmControl.cs
+++ b/src/Ryujinx.Horizon/Psc/Ipc/PmControl.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Psc;
+
+namespace Ryujinx.Horizon.Psc.Ipc
+{
+    partial class PmControl : IPmControl
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Psc/Ipc/PmService.cs
+++ b/src/Ryujinx.Horizon/Psc/Ipc/PmService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Psc;
+
+namespace Ryujinx.Horizon.Psc.Ipc
+{
+    partial class PmService : IPmService
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Psc/Ipc/PmStateLock.cs
+++ b/src/Ryujinx.Horizon/Psc/Ipc/PmStateLock.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Psc;
+
+namespace Ryujinx.Horizon.Psc.Ipc
+{
+    partial class PmStateLock : IPmStateLock
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Psc/PscIpcServer.cs
+++ b/src/Ryujinx.Horizon/Psc/PscIpcServer.cs
@@ -1,0 +1,50 @@
+﻿using Ryujinx.Horizon.Psc.Ipc;
+using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+
+namespace Ryujinx.Horizon.Psc
+{
+    class PscIpcServer
+    {
+        private const int PscCMaxSessionsCount = 1;
+        private const int PscMMaxSessionsCount = 50;
+        private const int PscLMaxSessionsCount = 5;
+        private const int TotalMaxSessionsCount = PscCMaxSessionsCount + PscMMaxSessionsCount + PscLMaxSessionsCount;
+
+        private const int PointerBufferSize = 0;
+        private const int MaxDomains = 0;
+        private const int MaxDomainObjects = 0;
+        private const int MaxPortsCount = 3;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+#pragma warning disable IDE0055 // Disable formatting
+            _serverManager.RegisterObjectForServer(new PmControl(),   ServiceName.Encode("psc:c"), PscCMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new PmService(),   ServiceName.Encode("psc:m"), PscMMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new PmStateLock(), ServiceName.Encode("psc:l"), PscLMaxSessionsCount); // 9.0.0+
+#pragma warning restore IDE0055
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Psc/PscMain.cs
+++ b/src/Ryujinx.Horizon/Psc/PscMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Psc
+{
+    class PscMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            PscIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Hshl/IManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Hshl/IManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Hshl
+{
+    interface IManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Hshl/ISetterManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Hshl/ISetterManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Hshl
+{
+    interface ISetterManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Ins/IReceiverManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Ins/IReceiverManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Ins
+{
+    interface IReceiverManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Ins/ISenderManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Ins/ISenderManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Ins
+{
+    interface ISenderManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Ovln/IReceiverService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Ovln/IReceiverService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Ovln
+{
+    interface IReceiverService : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Ovln/ISenderService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Ovln/ISenderService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Ovln
+{
+    interface ISenderService : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Psc/IPmControl.cs
+++ b/src/Ryujinx.Horizon/Sdk/Psc/IPmControl.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Psc
+{
+    interface IPmControl : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Psc/IPmService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Psc/IPmService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Psc
+{
+    interface IPmService : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Psc/IPmStateLock.cs
+++ b/src/Ryujinx.Horizon/Sdk/Psc/IPmStateLock.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Psc
+{
+    interface IPmStateLock : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Srepo/ISrepoService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Srepo/ISrepoService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Srepo
+{
+    interface ISrepoService : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IClientRootSession.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IClientRootSession.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IClientRootSession : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IDsRootSession.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IDsRootSession.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IDsRootSession : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IPdCradleManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IPdCradleManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IPdCradleManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IPdManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IPdManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IPdManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IPdManufactureManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IPdManufactureManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IPdManufactureManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IPmObserverService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IPmObserverService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IPmObserverService : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IPmService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IPmService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IPmService : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Sdk/Usb/IQdbManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Usb/IQdbManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Sf;
+
+namespace Ryujinx.Horizon.Sdk.Usb
+{
+    interface IQdbManager : IServiceObject
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/ServiceTable.cs
+++ b/src/Ryujinx.Horizon/ServiceTable.cs
@@ -1,9 +1,15 @@
 using Ryujinx.Horizon.Bcat;
+using Ryujinx.Horizon.Hshl;
+using Ryujinx.Horizon.Ins;
 using Ryujinx.Horizon.Lbl;
 using Ryujinx.Horizon.LogManager;
 using Ryujinx.Horizon.MmNv;
 using Ryujinx.Horizon.Ngc;
+using Ryujinx.Horizon.Ovln;
 using Ryujinx.Horizon.Prepo;
+using Ryujinx.Horizon.Psc;
+using Ryujinx.Horizon.Srepo;
+using Ryujinx.Horizon.Usb;
 using Ryujinx.Horizon.Wlan;
 using System.Collections.Generic;
 using System.Threading;
@@ -27,12 +33,18 @@ namespace Ryujinx.Horizon
             }
 
             RegisterService<BcatMain>();
+            RegisterService<HshlMain>();
+            RegisterService<InsMain>();
             RegisterService<LblMain>();
             RegisterService<LmMain>();
             RegisterService<MmNvMain>();
-            RegisterService<PrepoMain>();
-            RegisterService<WlanMain>();
             RegisterService<NgcMain>();
+            RegisterService<OvlnMain>();
+            RegisterService<PrepoMain>();
+            RegisterService<PscMain>();
+            RegisterService<SrepoMain>();
+            RegisterService<UsbMain>();
+            RegisterService<WlanMain>();
 
             _totalServices = entries.Count;
 

--- a/src/Ryujinx.Horizon/Srepo/Ipc/SrepoService.cs
+++ b/src/Ryujinx.Horizon/Srepo/Ipc/SrepoService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Srepo;
+
+namespace Ryujinx.Horizon.Srepo.Ipc
+{
+    partial class SrepoService : ISrepoService
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Srepo/SrepoIpcServer.cs
+++ b/src/Ryujinx.Horizon/Srepo/SrepoIpcServer.cs
@@ -1,0 +1,46 @@
+﻿using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+using Ryujinx.Horizon.Srepo.Ipc;
+
+namespace Ryujinx.Horizon.Srepo
+{
+    class SrepoIpcServer
+    {
+        private const int SrepoAMaxSessionsCount = 2;
+        private const int SrepoUMaxSessionsCount = 30;
+        private const int TotalMaxSessionsCount = SrepoAMaxSessionsCount + SrepoUMaxSessionsCount;
+
+        private const int PointerBufferSize = 0x80;
+        private const int MaxDomains = 32;
+        private const int MaxDomainObjects = 192;
+        private const int MaxPortsCount = 2;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+            _serverManager.RegisterObjectForServer(new SrepoService(), ServiceName.Encode("srepo:a"), SrepoAMaxSessionsCount); // 5.0.0+
+            _serverManager.RegisterObjectForServer(new SrepoService(), ServiceName.Encode("srepo:u"), SrepoUMaxSessionsCount); // 5.0.0+
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Srepo/SrepoMain.cs
+++ b/src/Ryujinx.Horizon/Srepo/SrepoMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Srepo
+{
+    class SrepoMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            SrepoIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/ClientRootSession.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/ClientRootSession.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class ClientRootSession : IClientRootSession
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/DsRootSession.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/DsRootSession.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class DsRootSession : IDsRootSession
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/PdCradleManager.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/PdCradleManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class PdCradleManager : IPdCradleManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/PdManager.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/PdManager.cs
@@ -1,0 +1,9 @@
+﻿using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class PdManager : IPdManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/PdManufactureManager.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/PdManufactureManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class PdManufactureManager : IPdManufactureManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/PmObserverService.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/PmObserverService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class PmObserverService : IPmObserverService
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/PmService.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/PmService.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class PmService : IPmService
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/Ipc/QdbManager.cs
+++ b/src/Ryujinx.Horizon/Usb/Ipc/QdbManager.cs
@@ -1,0 +1,8 @@
+﻿using Ryujinx.Horizon.Sdk.Usb;
+
+namespace Ryujinx.Horizon.Usb.Ipc
+{
+    partial class QdbManager : IQdbManager
+    {
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/UsbIpcServer.cs
+++ b/src/Ryujinx.Horizon/Usb/UsbIpcServer.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Horizon.Usb
         private const int UsbPdMMaxSessionsCount = 1;
         private const int UsbPmMaxSessionsCount = 5;
         private const int UsbQdbMaxSessionsCount = 4;
-        private const int TotalMaxSessionsCount = UsbDsMaxSessionsCount+ UsbHsMaxSessionsCount + UsbHsAMaxSessionsCount + UsbObsvMaxSessionsCount
+        private const int TotalMaxSessionsCount = UsbDsMaxSessionsCount + UsbHsMaxSessionsCount + UsbHsAMaxSessionsCount + UsbObsvMaxSessionsCount
             + UsbPdMaxSessionsCount + UsbPdCMaxSessionsCount + UsbPdMMaxSessionsCount + UsbPmMaxSessionsCount + UsbQdbMaxSessionsCount;
 
         private const int PointerBufferSize = 0;

--- a/src/Ryujinx.Horizon/Usb/UsbIpcServer.cs
+++ b/src/Ryujinx.Horizon/Usb/UsbIpcServer.cs
@@ -15,8 +15,16 @@ namespace Ryujinx.Horizon.Usb
         private const int UsbPdMMaxSessionsCount = 1;
         private const int UsbPmMaxSessionsCount = 5;
         private const int UsbQdbMaxSessionsCount = 4;
-        private const int TotalMaxSessionsCount = UsbDsMaxSessionsCount + UsbHsMaxSessionsCount + UsbHsAMaxSessionsCount + UsbObsvMaxSessionsCount
-            + UsbPdMaxSessionsCount + UsbPdCMaxSessionsCount + UsbPdMMaxSessionsCount + UsbPmMaxSessionsCount + UsbQdbMaxSessionsCount;
+        private const int TotalMaxSessionsCount =
+            UsbDsMaxSessionsCount +
+            UsbHsMaxSessionsCount +
+            UsbHsAMaxSessionsCount +
+            UsbObsvMaxSessionsCount +
+            UsbPdMaxSessionsCount +
+            UsbPdCMaxSessionsCount +
+            UsbPdMMaxSessionsCount +
+            UsbPmMaxSessionsCount +
+            UsbQdbMaxSessionsCount;
 
         private const int PointerBufferSize = 0;
         private const int MaxDomains = 0;

--- a/src/Ryujinx.Horizon/Usb/UsbIpcServer.cs
+++ b/src/Ryujinx.Horizon/Usb/UsbIpcServer.cs
@@ -1,0 +1,63 @@
+﻿using Ryujinx.Horizon.Sdk.Sf.Hipc;
+using Ryujinx.Horizon.Sdk.Sm;
+using Ryujinx.Horizon.Usb.Ipc;
+
+namespace Ryujinx.Horizon.Usb
+{
+    class UsbIpcServer
+    {
+        private const int UsbDsMaxSessionsCount = 4;
+        private const int UsbHsMaxSessionsCount = 20;
+        private const int UsbHsAMaxSessionsCount = 3;
+        private const int UsbObsvMaxSessionsCount = 2;
+        private const int UsbPdMaxSessionsCount = 6;
+        private const int UsbPdCMaxSessionsCount = 4;
+        private const int UsbPdMMaxSessionsCount = 1;
+        private const int UsbPmMaxSessionsCount = 5;
+        private const int UsbQdbMaxSessionsCount = 4;
+        private const int TotalMaxSessionsCount = UsbDsMaxSessionsCount+ UsbHsMaxSessionsCount + UsbHsAMaxSessionsCount + UsbObsvMaxSessionsCount
+            + UsbPdMaxSessionsCount + UsbPdCMaxSessionsCount + UsbPdMMaxSessionsCount + UsbPmMaxSessionsCount + UsbQdbMaxSessionsCount;
+
+        private const int PointerBufferSize = 0;
+        private const int MaxDomains = 0;
+        private const int MaxDomainObjects = 0;
+        private const int MaxPortsCount = 9;
+
+        private static readonly ManagerOptions _options = new(PointerBufferSize, MaxDomains, MaxDomainObjects, false);
+
+        private SmApi _sm;
+        private ServerManager _serverManager;
+
+        public void Initialize()
+        {
+            HeapAllocator allocator = new();
+
+            _sm = new SmApi();
+            _sm.Initialize().AbortOnFailure();
+
+            _serverManager = new ServerManager(allocator, _sm, MaxPortsCount, _options, TotalMaxSessionsCount);
+
+#pragma warning disable IDE0055 // Disable formatting
+            _serverManager.RegisterObjectForServer(new DsRootSession(),        ServiceName.Encode("usb:ds"),   UsbDsMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new ClientRootSession(),    ServiceName.Encode("usb:hs"),   UsbHsMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new ClientRootSession(),    ServiceName.Encode("usb:hs:a"), UsbHsAMaxSessionsCount);  // 7.0.0+
+            _serverManager.RegisterObjectForServer(new PmObserverService(),    ServiceName.Encode("usb:obsv"), UsbObsvMaxSessionsCount); // 8.0.0+
+            _serverManager.RegisterObjectForServer(new PdManager(),            ServiceName.Encode("usb:pd"),   UsbPdMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new PdCradleManager(),      ServiceName.Encode("usb:pd:c"), UsbPdCMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new PdManufactureManager(), ServiceName.Encode("usb:pd:m"), UsbPdMMaxSessionsCount);  // 1.0.0
+            _serverManager.RegisterObjectForServer(new PmService(),            ServiceName.Encode("usb:pm"),   UsbPmMaxSessionsCount);
+            _serverManager.RegisterObjectForServer(new QdbManager(),           ServiceName.Encode("usb:qdb"),  UsbQdbMaxSessionsCount);  // 7.0.0+
+#pragma warning restore IDE0055
+        }
+
+        public void ServiceRequests()
+        {
+            _serverManager.ServiceRequests();
+        }
+
+        public void Shutdown()
+        {
+            _serverManager.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Horizon/Usb/UsbMain.cs
+++ b/src/Ryujinx.Horizon/Usb/UsbMain.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Horizon.Usb
+{
+    class UsbMain : IService
+    {
+        public static void Main(ServiceTable serviceTable)
+        {
+            UsbIpcServer ipcServer = new();
+
+            ipcServer.Initialize();
+
+            serviceTable.SignalServiceReady();
+
+            ipcServer.ServiceRequests();
+            ipcServer.Shutdown();
+        }
+    }
+}


### PR DESCRIPTION
This PR migrate `usb` and `psc` services (not `time`) to Horizon project and update them to reflect latest Switch firmware.
Everything is checked by RE.

There was an issue in the code generator when 2 IPC interfaces got the same name. It's now fixed too.