### PR TITLE
Enable copy between MS and non-MS textures with different height

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -374,6 +374,13 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 return stride == rhs.Stride ? TextureViewCompatibility.CopyOnly : TextureViewCompatibility.LayoutIncompatible;
             }
+            else if (lhs.Target.IsMultisample() != rhs.Target.IsMultisample() && alignedWidthMatches && lhsAlignedSize.Height == rhsAlignedSize.Height)
+            {
+                // Copy between multisample and non-multisample textures with mismatching size is allowed,
+                // as long aligned size matches.
+
+                return TextureViewCompatibility.CopyOnly;
+            }
             else
             {
                 return TextureViewCompatibility.LayoutIncompatible;


### PR DESCRIPTION
This change allows Perky Little Things to render again. The game uses 8x multisampling on a 1920x1088 texture (really 1920x1080), later it tries to sample it as a 7680x2160 texture. While sampling multisampled textures as non-multisampled is already supported, this case was not working because the height doesn't match (1088 * 2 = 2076). This change enables copy compatibility for this specific case (as long the *aligned* height matches, at least).

![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/0190e127-05b4-417b-9361-03a9d3ab6dfc)

According to Muffin it's a regression from #4662, but I'm not sure how that is possible.