### PR TITLE
Allow skipping draws with broken pipeline variants on Vulkan

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -749,12 +749,15 @@ namespace Ryujinx.Graphics.Vulkan
             _vertexBufferUpdater.Commit(Cbs);
         }
 
+
+#pragma warning disable CA1822 // Mark member as static
         public void SetAlphaTest(bool enable, float reference, CompareOp op)
         {
             // This is currently handled using shader specialization, as Vulkan does not support alpha test.
             // In the future, we may want to use this to write the reference value into the support buffer,
             // to avoid creating one version of the shader per reference value used.
         }
+#pragma warning restore CA1822
 
         public void SetBlendState(AdvancedBlendDescriptor blend)
         {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -749,7 +749,6 @@ namespace Ryujinx.Graphics.Vulkan
             _vertexBufferUpdater.Commit(Cbs);
         }
 
-
 #pragma warning disable CA1822 // Mark member as static
         public void SetAlphaTest(bool enable, float reference, CompareOp op)
         {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -246,7 +246,10 @@ namespace Ryujinx.Graphics.Vulkan
 
             SignalCommandBufferChange();
 
-            DynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
+            if (Pipeline != null && Pbp == PipelineBindPoint.Graphics)
+            {
+                DynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
+            }
         }
 
         public void FlushCommandsImpl()

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -312,7 +312,6 @@ namespace Ryujinx.Graphics.Vulkan
         }
 
         public NativeArray<PipelineShaderStageCreateInfo> Stages;
-        public NativeArray<PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT> StageRequiredSubgroupSizes;
         public PipelineLayout PipelineLayout;
         public SpecData SpecializationData;
 
@@ -321,16 +320,6 @@ namespace Ryujinx.Graphics.Vulkan
         public void Initialize()
         {
             Stages = new NativeArray<PipelineShaderStageCreateInfo>(Constants.MaxShaderStages);
-            StageRequiredSubgroupSizes = new NativeArray<PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>(Constants.MaxShaderStages);
-
-            for (int index = 0; index < Constants.MaxShaderStages; index++)
-            {
-                StageRequiredSubgroupSizes[index] = new PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
-                {
-                    SType = StructureType.PipelineShaderStageRequiredSubgroupSizeCreateInfoExt,
-                    RequiredSubgroupSize = RequiredSubgroupSize,
-                };
-            }
 
             AdvancedBlendSrcPreMultiplied = true;
             AdvancedBlendDstPreMultiplied = true;
@@ -630,7 +619,14 @@ namespace Ryujinx.Graphics.Vulkan
                     BasePipelineIndex = -1,
                 };
 
-                gd.Api.CreateGraphicsPipelines(device, cache, 1, &pipelineCreateInfo, null, &pipelineHandle).ThrowOnError();
+                Result result = gd.Api.CreateGraphicsPipelines(device, cache, 1, &pipelineCreateInfo, null, &pipelineHandle);
+
+                if (result.IsError())
+                {
+                    program.AddGraphicsPipeline(ref Internal, null);
+
+                    return null;
+                }
 
                 // Restore previous blend enable values if we changed it.
                 while (blendEnables != 0)
@@ -708,7 +704,6 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly void Dispose()
         {
             Stages.Dispose();
-            StageRequiredSubgroupSizes.Dispose();
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -386,7 +386,8 @@ namespace Ryujinx.Graphics.Vulkan
             Device device,
             ShaderCollection program,
             PipelineCache cache,
-            RenderPass renderPass)
+            RenderPass renderPass,
+            bool throwOnError = false)
         {
             if (program.TryGetGraphicsPipeline(ref Internal, out var pipeline))
             {
@@ -621,7 +622,11 @@ namespace Ryujinx.Graphics.Vulkan
 
                 Result result = gd.Api.CreateGraphicsPipelines(device, cache, 1, &pipelineCreateInfo, null, &pipelineHandle);
 
-                if (result.IsError())
+                if (throwOnError)
+                {
+                    result.ThrowOnError();
+                }
+                else if (result.IsError())
                 {
                     program.AddGraphicsPipeline(ref Internal, null);
 

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -511,7 +511,7 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     foreach (Auto<DisposablePipeline> pipeline in _graphicsPipelineCache.Values)
                     {
-                        pipeline.Dispose();
+                        pipeline?.Dispose();
                     }
                 }
 

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -374,7 +374,7 @@ namespace Ryujinx.Graphics.Vulkan
             pipeline.StagesCount = (uint)_shaders.Length;
             pipeline.PipelineLayout = PipelineLayout;
 
-            pipeline.CreateGraphicsPipeline(_gd, _device, this, (_gd.Pipeline as PipelineBase).PipelineCache, renderPass.Value);
+            pipeline.CreateGraphicsPipeline(_gd, _device, this, (_gd.Pipeline as PipelineBase).PipelineCache, renderPass.Value, throwOnError: true);
             pipeline.Dispose();
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/VulkanException.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanException.cs
@@ -6,10 +6,16 @@ namespace Ryujinx.Graphics.Vulkan
 {
     static class ResultExtensions
     {
+        public static bool IsError(this Result result)
+        {
+            // Only negative result codes are errors.
+            return result < Result.Success;
+        }
+
         public static void ThrowOnError(this Result result)
         {
             // Only negative result codes are errors.
-            if ((int)result < (int)Result.Success)
+            if (result.IsError())
             {
                 throw new VulkanException(result);
             }


### PR DESCRIPTION
Currently we skip draws when the background compilation of the shaders on Vulkan failed. This is detected with the result code from the pipeline creation call. If an is error returned, we assume that the host failed to compile the shader that the emulator gave. While this generally works, there is an odd situation on macOS with MoltenVK where *some* pipeline variants may compile successfully, and others may fail. This means that the emulator can still crash in some cases due to shader compilation failures.

This PR allows draws to be skipped when *any* pipeline variant creation fails, not just the background one. This is only done for graphics shaders since compute generally doesn't have pipeline variants (since the only pipeline state on compute is the shader itself). This also includes minor improvements to try preventing any performance regression from additional checks. The `!_program.IsLinked` has been moved to `CreatePipeline` to avoid checking it all the time. `RecreatePipelineIfNeeded` has been split in two, one for graphics and other for compute. Most of what it was doing is not really necessary for compute (like updating dynamic state, vertex/index/transform feedback buffers).

Fixes #5790, although it does not fix the underlying issue (the compilation error). The only error that the compiler produces here is "Compiler encountered an internal error.", which does not really give much indication of what is wrong. I was able to track down the specific pipeline state that makes it produce that error, it was `ColorBlendAttachmentState`, on the background pipeline it was disabled, on the new one it is enabled. There is a single color attachment with VkFormat B10G11R11UfloatPack32.
<img width="1392" alt="Captura de Tela 2023-10-15 às 00 20 09" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/045240a2-b388-4ce3-bca4-cbf676ee3f6e">
Does not render 100% due to the skipped draw, but it is better than the game crashing.

Testing is welcome, also to ensure that nothing broke on platforms other than macOS.