### PR TITLE
Fix NRE on shader gather operations with depth compare on macOS

### DIFF
--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -766,7 +766,10 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 flags |= offset == TexOffset.Ptp ? TextureFlags.Offsets : TextureFlags.Offset;
             }
 
-            sourcesList.Add(Const((int)component));
+            if (!hasDepthCompare)
+            {
+                sourcesList.Add(Const((int)component));
+            }
 
             Operand[] sources = sourcesList.ToArray();
             Operand[] dests = new Operand[BitOperations.PopCount((uint)componentMask)];


### PR DESCRIPTION
I believe this is a regression from #5792 (though the issue technically already existed before that, but I think we did not hit it because there was no need to "rewrite" any gather with depth compare before). The problem is that emit stage always adds the gather component to the operands, however gathers with depth compare don't have a "component" since it is supposed to be used with a depth texture. This causes the source array size to be too large and the last operand is null, causing NRE later on. Fixed by not adding the component operand when not needed. Maybe it is a good idea to resize the sources array if it's too large to avoid potential issues of this nature in the future.

Should fix this crash on macOS (Luigi's Mansion 3): https://github.com/Ryujinx/Ryujinx-Games-List/issues/207#issuecomment-1773935299