### PR TITLE
Ava UI: Fix temporary volume not being set after unmute

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -1085,10 +1085,11 @@ namespace Ryujinx.Ava
                         case KeyboardHotkeyState.ToggleMute:
                             if (Device.IsAudioMuted())
                             {
-                                Device.SetVolume(ConfigurationState.Instance.System.AudioVolume);
+                                Device.SetVolume(_viewModel.VolumeBeforeMute);
                             }
                             else
                             {
+                                _viewModel.VolumeBeforeMute = Device.GetVolume();
                                 Device.SetVolume(0);
                             }
 

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -90,6 +90,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         private string _pauseKey = "F5";
         private string _screenshotKey = "F8";
         private float _volume;
+        private float _volumeBeforeMute;
         private string _backendText;
 
         private bool _canUpdate = true;
@@ -550,6 +551,17 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 OnPropertyChanged(nameof(VolumeStatusText));
                 OnPropertyChanged(nameof(VolumeMuted));
+                OnPropertyChanged();
+            }
+        }
+
+        public float VolumeBeforeMute
+        {
+            get => _volumeBeforeMute;
+            set
+            {
+                _volumeBeforeMute = value;
+
                 OnPropertyChanged();
             }
         }

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -436,10 +436,11 @@ namespace Ryujinx.Ava.UI.Windows
             {
                 if (!volumeSplitButton.IsChecked)
                 {
-                    ViewModel.AppHost.Device.SetVolume(ConfigurationState.Instance.System.AudioVolume);
+                    ViewModel.AppHost.Device.SetVolume(ViewModel.VolumeBeforeMute);
                 }
                 else
                 {
+                    ViewModel.VolumeBeforeMute = ViewModel.AppHost.Device.GetVolume();
                     ViewModel.AppHost.Device.SetVolume(0);
                 }
 


### PR DESCRIPTION
Fixes #5745 

Both the mute button and the mute keybind (F2) now respect the temporary value set via the in-bar flyout slider after unmuting.

cc: @MutantAura 