### PR TITLE
macOS: Use user-friendly macOS version string

### DIFF
--- a/src/Ryujinx.Common/SystemInfo/MacOSSystemInfo.cs
+++ b/src/Ryujinx.Common/SystemInfo/MacOSSystemInfo.cs
@@ -14,6 +14,8 @@ namespace Ryujinx.Common.SystemInfo
         {
             string cpuName = GetCpuidCpuName();
 
+            OsDescription = $"macOS {Environment.OSVersion.Version} ({RuntimeInformation.OSArchitecture})";
+
             if (cpuName == null && SysctlByName("machdep.cpu.brand_string", out cpuName) != 0)
             {
                 cpuName = "Unknown";

--- a/src/Ryujinx.Common/SystemInfo/MacOSSystemInfo.cs
+++ b/src/Ryujinx.Common/SystemInfo/MacOSSystemInfo.cs
@@ -12,9 +12,14 @@ namespace Ryujinx.Common.SystemInfo
     {
         internal MacOSSystemInfo()
         {
-            string cpuName = GetCpuidCpuName();
+            if (SysctlByName("kern.osversion", out string buildRevision) != 0)
+            {
+                buildRevision = "Unknown Build";
+            }
 
-            OsDescription = $"macOS {Environment.OSVersion.Version} ({RuntimeInformation.OSArchitecture})";
+            OsDescription = $"macOS {Environment.OSVersion.Version} ({buildRevision}) ({RuntimeInformation.OSArchitecture})";
+
+            string cpuName = GetCpuidCpuName();
 
             if (cpuName == null && SysctlByName("machdep.cpu.brand_string", out cpuName) != 0)
             {


### PR DESCRIPTION
### Description
Logs currently output the Darwin kernel version string. While correct, this is a version string that is never exposed to the user. It would be more useful to output the user-facing macOS version string (i.e. macOS 14.0 for Sonoma, versus Darwin 23.0). This will make debugging at a glance much easier, as most Mac developers do not hold the kernel versioning system in their heads simultaneously with macOS release versions.

It is fairly remote that the much more verbose version string will contain pertinent information that the common version string does not.

Before: <img width="1048" alt="Screenshot 2023-10-22 at 4 54 40 PM" src="https://github.com/Ryujinx/Ryujinx/assets/6864788/c3c62db0-c5c3-4104-8ab4-43b3a92a75ca">
After: 
<img width="817" alt="Screenshot 2023-10-24 at 6 58 14 AM" src="https://github.com/Ryujinx/Ryujinx/assets/6864788/9d9081a3-a2ac-4f41-a624-c2d56fc22bd9">
(screenshot reflects changes from [639d641](https://github.com/Ryujinx/Ryujinx/commit/639d64115915f040d82f367959b9b7b2284cd68d))
