### PR TITLE
Create Desktop Shortcut fixes

### DIFF
--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
@@ -12,6 +12,11 @@
         Click="ToggleFavorite_Click"
         Header="{locale:Locale GameListContextMenuToggleFavorite}"
         ToolTip.Tip="{locale:Locale GameListContextMenuToggleFavoriteToolTip}" />
+	<MenuItem
+		Click="CreateApplicationShortcut_Click"
+		Header="{locale:Locale GameListContextMenuCreateShortcut}"
+        IsEnabled="{Binding CreateShortcutEnabled}"
+		ToolTip.Tip="{locale:Locale GameListContextMenuCreateShortcutToolTip}" />
     <Separator />
     <MenuItem
         Click="OpenUserSaveDirectory_Click"
@@ -82,9 +87,4 @@
             Header="{locale:Locale GameListContextMenuExtractDataLogo}"
             ToolTip.Tip="{locale:Locale GameListContextMenuExtractDataLogoToolTip}" />
     </MenuItem>
-	<MenuItem
-		Click="CreateApplicationShortcut_Click"
-		Header="{locale:Locale GameListContextMenuCreateShortcut}"
-        IsEnabled="{Binding CreateShortcutEnabled}"
-		ToolTip.Tip="{locale:Locale GameListContextMenuCreateShortcutToolTip}" />
 </MenuFlyout>

--- a/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.Ui.Common.Helper
             graphic.DrawImage(image, 0, 0, 128, 128);
             SaveBitmapAsIcon(bitmap, iconPath);
 
-            var shortcut = Shortcut.CreateShortcut(basePath, GetArgsString(basePath, applicationFilePath), iconPath, 0);
+            var shortcut = Shortcut.CreateShortcut(basePath, GetArgsString(applicationFilePath), iconPath, 0);
             shortcut.StringData.NameString = cleanedAppName;
             shortcut.WriteToFile(Path.Combine(desktopPath, cleanedAppName + ".lnk"));
         }
@@ -46,7 +46,7 @@ namespace Ryujinx.Ui.Common.Helper
             image.SaveAsPng(iconPath);
 
             using StreamWriter outputFile = new(Path.Combine(desktopPath, cleanedAppName + ".desktop"));
-            outputFile.Write(desktopFile, cleanedAppName, iconPath, GetArgsString(basePath, applicationFilePath));
+            outputFile.Write(desktopFile, cleanedAppName, iconPath, $"{basePath} {GetArgsString(applicationFilePath)}");
         }
 
         [SupportedOSPlatform("macos")]
@@ -69,7 +69,7 @@ namespace Ryujinx.Ui.Common.Helper
             using StreamWriter scriptFile = new(scriptPath);
 
             scriptFile.WriteLine("#!/bin/sh");
-            scriptFile.WriteLine(GetArgsString(basePath, appFilePath));
+            scriptFile.WriteLine($"{basePath} {GetArgsString(appFilePath)}");
 
             // Set execute permission
             FileInfo fileInfo = new(scriptPath);
@@ -125,7 +125,7 @@ namespace Ryujinx.Ui.Common.Helper
             throw new NotImplementedException("Shortcut support has not been implemented yet for this OS.");
         }
 
-        private static string GetArgsString(string basePath, string appFilePath)
+        private static string GetArgsString(string appFilePath)
         {
             // args are first defined as a list, for easier adjustments in the future
             var argsList = new List<string>();
@@ -137,7 +137,6 @@ namespace Ryujinx.Ui.Common.Helper
             }
 
             argsList.Add($"\"{appFilePath}\"");
-            argsList.Add($"--fullscreen");
 
             return String.Join(" ", argsList);
         }

--- a/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
@@ -55,7 +55,7 @@ namespace Ryujinx.Ui.Common.Helper
             string basePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
             var plistFile = EmbeddedResources.ReadAllText("Ryujinx.Ui.Common/shortcut-template.plist");
             // Macos .App folder
-            string contentFolderPath = Path.Combine(desktopPath, cleanedAppName + ".app", "Contents");
+            string contentFolderPath = Path.Combine("/Applications", cleanedAppName + ".app", "Contents");
             string scriptFolderPath = Path.Combine(contentFolderPath, "MacOS");
 
             if (!Directory.Exists(scriptFolderPath))

--- a/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Ui.Common.Helper
         [SupportedOSPlatform("macos")]
         private static void CreateShortcutMacos(string appFilePath, byte[] iconData, string desktopPath, string cleanedAppName)
         {
-            string basePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AppDomain.CurrentDomain.FriendlyName);
+            string basePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
             var plistFile = EmbeddedResources.ReadAllText("Ryujinx.Ui.Common/shortcut-template.plist");
             // Macos .App folder
             string contentFolderPath = Path.Combine(desktopPath, cleanedAppName + ".app", "Contents");

--- a/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/ShortcutHelper.cs
@@ -128,10 +128,7 @@ namespace Ryujinx.Ui.Common.Helper
         private static string GetArgsString(string basePath, string appFilePath)
         {
             // args are first defined as a list, for easier adjustments in the future
-            var argsList = new List<string>
-            {
-                basePath,
-            };
+            var argsList = new List<string>();
 
             if (!string.IsNullOrEmpty(CommandLineState.BaseDirPathArg))
             {
@@ -140,7 +137,7 @@ namespace Ryujinx.Ui.Common.Helper
             }
 
             argsList.Add($"\"{appFilePath}\"");
-
+            argsList.Add($"--fullscreen");
 
             return String.Join(" ", argsList);
         }

--- a/src/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/src/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -211,6 +211,8 @@ namespace Ryujinx.Ui.Widgets
             _manageSubMenu.Append(_openPtcDirMenuItem);
             _manageSubMenu.Append(_openShaderCacheDirMenuItem);
 
+            Add(_createShortcutMenuItem);
+            Add(new SeparatorMenuItem());
             Add(_openSaveUserDirMenuItem);
             Add(_openSaveDeviceDirMenuItem);
             Add(_openSaveBcatDirMenuItem);
@@ -223,7 +225,6 @@ namespace Ryujinx.Ui.Widgets
             Add(new SeparatorMenuItem());
             Add(_manageCacheMenuItem);
             Add(_extractMenuItem);
-            Add(_createShortcutMenuItem);
 
             ShowAll();
         }


### PR DESCRIPTION
This pull request aims to fix current issues with the Create Shortcut functionality, specifically this will close #5839 #5827.
This will also add the `--fullscreen` arg to the shortcuts so by default launching games with shortcuts automatically open Ryujinx in fullscreen mode.

I will need some testing with the MacOS issue (#5827), as I do not currently have a Mac to test with myself. Perhaps @nickoanastassiu could help with this?