### PR TITLE
Update to Silk.NET 2.18.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,9 +39,9 @@
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
+    <PackageVersion Include="Silk.NET.Vulkan" Version="2.18.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.18.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.18.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageVersion Include="SPB" Version="0.0.4-build28" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,8 +37,8 @@
     <PackageVersion Include="Ryujinx.GtkSharp" Version="3.24.24.59-ryujinx" />
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.28.1-build28" />
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
-    <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="Silk.NET.Shaderc" Version="2.18.0" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.18.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.18.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.18.0" />

--- a/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
+++ b/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" />
-    <PackageReference Include="shaderc.net" />
+    <PackageReference Include="Silk.NET.Shaderc" />
     <PackageReference Include="Silk.NET.Vulkan" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" />

--- a/src/Ryujinx.Graphics.Vulkan/Shader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Shader.cs
@@ -1,7 +1,7 @@
 ﻿using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Shader;
-using shaderc;
+using Silk.NET.Shaderc;
 using Silk.NET.Vulkan;
 using System;
 using System.Runtime.InteropServices;
@@ -11,10 +11,6 @@ namespace Ryujinx.Graphics.Vulkan
 {
     class Shader : IDisposable
     {
-        // The shaderc.net dependency's Options constructor and dispose are not thread safe.
-        // Take this lock when using them.
-        private static readonly object _shaderOptionsLock = new();
-
         private static readonly IntPtr _ptrMainEntryPointName = Marshal.StringToHGlobalAnsi("main");
 
         private readonly Vk _api;
@@ -73,38 +69,33 @@ namespace Ryujinx.Graphics.Vulkan
 
         private unsafe static byte[] GlslToSpirv(string glsl, ShaderStage stage)
         {
-            Options options;
+            var api = Shaderc.GetApi();
+            var compiler = api.CompilerInitialize();
+            var options = api.CompileOptionsInitialize();
 
-            lock (_shaderOptionsLock)
+            api.CompileOptionsSetSourceLanguage(options, SourceLanguage.Glsl);
+            api.CompileOptionsSetTargetSpirv(options, SpirvVersion.Shaderc15);
+            api.CompileOptionsSetTargetEnv(options, TargetEnv.Vulkan, Vk.Version12);
+
+            var scr = api.CompileIntoSpv(compiler, glsl, (nuint)glsl.Length, GetShaderCShaderStage(stage), "Ryu", "main", options);
+
+            var status = api.ResultGetCompilationStatus(scr);
+
+            if (status != CompilationStatus.Success)
             {
-                options = new Options(false)
-                {
-                    SourceLanguage = SourceLanguage.Glsl,
-                    TargetSpirVVersion = new SpirVVersion(1, 5),
-                };
-            }
-
-            options.SetTargetEnvironment(TargetEnvironment.Vulkan, EnvironmentVersion.Vulkan_1_2);
-            Compiler compiler = new(options);
-            var scr = compiler.Compile(glsl, "Ryu", GetShaderCShaderStage(stage));
-
-            lock (_shaderOptionsLock)
-            {
-                options.Dispose();
-            }
-
-            if (scr.Status != Status.Success)
-            {
-                Logger.Error?.Print(LogClass.Gpu, $"Shader compilation error: {scr.Status} {scr.ErrorMessage}");
+                Logger.Error?.Print(LogClass.Gpu, $"Shader compilation error: {status} {api.ResultGetErrorMessageS(scr)}");
 
                 return null;
             }
 
-            var spirvBytes = new Span<byte>((void*)scr.CodePointer, (int)scr.CodeLength);
+            var spirvBytes = new Span<byte>(api.ResultGetBytes(scr), (int)api.ResultGetLength(scr));
 
-            byte[] code = new byte[(scr.CodeLength + 3) & ~3];
+            byte[] code = new byte[(spirvBytes.Length + 3) & ~3];
 
-            spirvBytes.CopyTo(code.AsSpan()[..(int)scr.CodeLength]);
+            spirvBytes.CopyTo(code.AsSpan()[..spirvBytes.Length]);
+
+            api.CompilerRelease(compiler);
+            api.CompileOptionsRelease(options);
 
             return code;
         }


### PR DESCRIPTION
As the title says. I also replaced the `shdaerc.net` dependency with `Silk.NET.Shaderc`.
I tested on macOS and it seems to work there too with our MoltenVK package.