### PR TITLE
Better handle instruction aborts when hitting unmapped memory

### DIFF
--- a/src/ARMeilleure/Decoders/Decoder.cs
+++ b/src/ARMeilleure/Decoders/Decoder.cs
@@ -38,7 +38,9 @@ namespace ARMeilleure.Decoders
                 {
                     block = new Block(blkAddress);
 
-                    if ((dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) || opsCount > instructionLimit || (visited.Count > 0 && !memory.IsMapped(blkAddress)))
+                    if ((dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) ||
+                        opsCount > instructionLimit ||
+                        (visited.Count > 0 && !memory.IsMapped(blkAddress)))
                     {
                         block.Exit = true;
                         block.EndAddress = blkAddress;

--- a/src/ARMeilleure/Decoders/Decoder.cs
+++ b/src/ARMeilleure/Decoders/Decoder.cs
@@ -38,7 +38,7 @@ namespace ARMeilleure.Decoders
                 {
                     block = new Block(blkAddress);
 
-                    if ((dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
+                    if ((dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) || opsCount > instructionLimit || (visited.Count > 0 && !memory.IsMapped(blkAddress)))
                     {
                         block.Exit = true;
                         block.EndAddress = blkAddress;


### PR DESCRIPTION
At the advice of @gdkchan, adjusted ARMeilleure to better handle unmapped memory. It now actually performs a read when beginning decoding code. This will trip the invalid access handler when execution jumps directly into unmapped memory. This allows for a proper stack trace and register dump, instead of just an exception being thrown.