### PR TITLE
Fix AddSessionObj NRE regression

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -191,6 +191,9 @@ namespace Ryujinx.HLE.HOS.Services
                 AddPort(serverPortHandle, SmObjectFactory);
             }
 
+            _wakeEvent = new KEvent(_context);
+            Result result = _selfProcess.HandleTable.GenerateHandle(_wakeEvent.ReadableEvent, out _wakeHandle);
+
             InitDone.Set();
 
             ulong messagePtr = _selfThread.TlsAddress;
@@ -200,9 +203,6 @@ namespace Ryujinx.HLE.HOS.Services
             _selfProcess.CpuMemory.Write(messagePtr + 0x4, 2 << 10);
             _selfProcess.CpuMemory.Write(messagePtr + 0x8, heapAddr | ((ulong)PointerBufferSize << 48));
             int replyTargetHandle = 0;
-
-            _wakeEvent = new KEvent(_context);
-            Result result = _selfProcess.HandleTable.GenerateHandle(_wakeEvent.ReadableEvent, out _wakeHandle);
 
             while (true)
             {


### PR DESCRIPTION
Fixes a regression caused by #5855. It is possible that `AddSessionObj` is called from another thread before the service thread had a chance to create the `_wakeEvent` object, in which case it would throw a `NullReferenceException`. This fixes de issue by moving the event creation before `InitDone.Set();`. Since `AddSessionObj` waits for the `InitDone` event, it won't try to access it before it has been created.

Fixes #5874.