### PR TITLE
UI: Change default hide cursor mode to OnIdle

### DIFF
--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -784,7 +784,7 @@ namespace Ryujinx.Ui.Common.Configuration
             EnableDiscordIntegration.Value = true;
             CheckUpdatesOnStart.Value = true;
             ShowConfirmExit.Value = true;
-            HideCursor.Value = HideCursorMode.Never;
+            HideCursor.Value = HideCursorMode.OnIdle;
             Graphics.EnableVsync.Value = true;
             Graphics.EnableShaderCache.Value = true;
             Graphics.EnableTextureRecompression.Value = false;


### PR DESCRIPTION
### Description

Changes the default hide cursor mode to hide on idle instead of never.

### Motivation/Context

It seems like having the cursor hide on idle is generally a more sensible default than never hiding the cursor, given that the on idle hide does not take effect if you are not both in-game *and* the cursor is over the game window. If both these conditions are true, it seems like most people would want the cursor to disappear, at least by default.

This is the behavior at least on macOS and Avalonia. I have not tested the behavior of this setting extensively on GTK or on other platforms, and if the behavior differs significantly that could possibly be an issue.