### PR TITLE
misc: Default to Vulkan if available or running on macOS

### DIFF
--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationLoadResult.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationLoadResult.cs
@@ -1,9 +1,0 @@
-namespace Ryujinx.Ui.Common.Configuration
-{
-    public enum ConfigurationLoadResult
-    {
-        Success = 0,
-        NotLoaded = 1,
-        MigratedFromPreVulkan = 1 << 8,
-    }
-}

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -908,7 +908,7 @@ namespace Ryujinx.Ui.Common.Configuration
             };
         }
 
-        public ConfigurationLoadResult Load(ConfigurationFileFormat configurationFileFormat, string configurationFilePath)
+        public void Load(ConfigurationFileFormat configurationFileFormat, string configurationFilePath)
         {
             bool configurationFileUpdated = false;
 
@@ -917,11 +917,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Unsupported configuration version {configurationFileFormat.Version}, loading default.");
 
                 LoadDefault();
-
-                return ConfigurationLoadResult.NotLoaded;
             }
-
-            ConfigurationLoadResult result = ConfigurationLoadResult.Success;
 
             if (configurationFileFormat.Version < 2)
             {
@@ -1337,8 +1333,6 @@ namespace Ryujinx.Ui.Common.Configuration
 
                 configurationFileFormat.GraphicsBackend = GraphicsBackend.OpenGl;
 
-                result |= ConfigurationLoadResult.MigratedFromPreVulkan;
-
                 configurationFileUpdated = true;
             }
 
@@ -1536,8 +1530,6 @@ namespace Ryujinx.Ui.Common.Configuration
 
                 Ryujinx.Common.Logging.Logger.Notice.Print(LogClass.Application, $"Configuration file updated to version {ConfigurationFileFormat.CurrentVersion}");
             }
-
-            return result;
         }
 
         private static GraphicsBackend DefaultGraphicsBackend()

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -11,6 +11,7 @@ using Ryujinx.Ui.Common.Helper;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
+using Ryujinx.Graphics.Vulkan;
 
 namespace Ryujinx.Ui.Common.Configuration
 {
@@ -763,7 +764,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Graphics.ResScaleCustom.Value = 1.0f;
             Graphics.MaxAnisotropy.Value = -1.0f;
             Graphics.AspectRatio.Value = AspectRatio.Fixed16x9;
-            Graphics.GraphicsBackend.Value = OperatingSystem.IsMacOS() ? GraphicsBackend.Vulkan : GraphicsBackend.OpenGl;
+            Graphics.GraphicsBackend.Value = DefaultGraphicsBackend();
             Graphics.PreferredGpu.Value = "";
             Graphics.ShadersDumpPath.Value = "";
             Logger.EnableDebug.Value = false;
@@ -1537,6 +1538,18 @@ namespace Ryujinx.Ui.Common.Configuration
             }
 
             return result;
+        }
+
+        private static GraphicsBackend DefaultGraphicsBackend()
+        {
+            // Any system running macOS or returning any amount of valid Vulkan devices should default to Vulkan.
+            // Checks for if the Vulkan version and featureset is compatible should be performed within VulkanRenderer.
+            if (OperatingSystem.IsMacOS() || VulkanRenderer.GetPhysicalDevices().Length > 0)
+            {
+                return GraphicsBackend.Vulkan;
+            }
+
+            return GraphicsBackend.OpenGl;
         }
 
         private static void LogValueChange<T>(ReactiveEventArgs<T> eventArgs, string valueName)

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -5,13 +5,13 @@ using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Keyboard;
 using Ryujinx.Common.Configuration.Multiplayer;
 using Ryujinx.Common.Logging;
+using Ryujinx.Graphics.Vulkan;
 using Ryujinx.Ui.Common.Configuration.System;
 using Ryujinx.Ui.Common.Configuration.Ui;
 using Ryujinx.Ui.Common.Helper;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
-using Ryujinx.Graphics.Vulkan;
 
 namespace Ryujinx.Ui.Common.Configuration
 {

--- a/src/Ryujinx.Ui.Common/Ryujinx.Ui.Common.csproj
+++ b/src/Ryujinx.Ui.Common/Ryujinx.Ui.Common.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
     <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj" />
+    <ProjectReference Include="..\Ryujinx.Graphics.Vulkan\Ryujinx.Graphics.Vulkan.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -177,8 +177,6 @@ namespace Ryujinx
                     ? appDataConfigurationPath
                     : null;
 
-            bool showVulkanPrompt = false;
-
             if (ConfigurationPath == null)
             {
                 // No configuration, we load the default values and save it to disk
@@ -187,24 +185,16 @@ namespace Ryujinx
                 ConfigurationState.Instance.LoadDefault();
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
 
-                showVulkanPrompt = true;
             }
             else
             {
                 if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
                 {
                     ConfigurationLoadResult result = ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
-
-                    if ((result & ConfigurationLoadResult.MigratedFromPreVulkan) != 0)
-                    {
-                        showVulkanPrompt = true;
-                    }
                 }
                 else
                 {
                     ConfigurationState.Instance.LoadDefault();
-
-                    showVulkanPrompt = true;
 
                     Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.\nFailed config location {ConfigurationPath}");
                 }
@@ -216,12 +206,10 @@ namespace Ryujinx
                 if (CommandLineState.OverrideGraphicsBackend.ToLower() == "opengl")
                 {
                     ConfigurationState.Instance.Graphics.GraphicsBackend.Value = GraphicsBackend.OpenGl;
-                    showVulkanPrompt = false;
                 }
                 else if (CommandLineState.OverrideGraphicsBackend.ToLower() == "vulkan")
                 {
                     ConfigurationState.Instance.Graphics.GraphicsBackend.Value = GraphicsBackend.Vulkan;
-                    showVulkanPrompt = false;
                 }
             }
 
@@ -341,35 +329,6 @@ namespace Ryujinx
                 {
                     Logger.Error?.Print(LogClass.Application, $"Updater Error: {task.Exception}");
                 }, TaskContinuationOptions.OnlyOnFaulted);
-            }
-
-            if (showVulkanPrompt)
-            {
-                var buttonTexts = new Dictionary<int, string>()
-                {
-                    { 0, "Yes (Vulkan)" },
-                    { 1, "No (OpenGL)" },
-                };
-
-                ResponseType response = GtkDialog.CreateCustomDialog(
-                    "Ryujinx - Default graphics backend",
-                    "Use Vulkan as default graphics backend?",
-                    "Ryujinx now supports the Vulkan API. " +
-                    "Vulkan greatly improves shader compilation performance, " +
-                    "and fixes some graphical glitches; however, since it is a new feature, " +
-                    "you may experience some issues that did not occur with OpenGL.\n\n" +
-                    "Note that you will also lose any existing shader cache the first time you start a game " +
-                    "on version 1.1.200 onwards, because Vulkan required changes to the shader cache that makes it incompatible with previous versions.\n\n" +
-                    "Would you like to set Vulkan as the default graphics backend? " +
-                    "You can change this at any time on the settings window.",
-                    buttonTexts,
-                    MessageType.Question);
-
-                ConfigurationState.Instance.Graphics.GraphicsBackend.Value = response == 0
-                    ? GraphicsBackend.Vulkan
-                    : GraphicsBackend.OpenGl;
-
-                ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
             }
 
             Application.Run();

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -184,7 +184,6 @@ namespace Ryujinx
 
                 ConfigurationState.Instance.LoadDefault();
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
-
             }
             else
             {

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -189,7 +189,7 @@ namespace Ryujinx
             {
                 if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
                 {
-                    ConfigurationLoadResult result = ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
+                    ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
                 }
                 else
                 {


### PR DESCRIPTION
MessageBox asking users to choose on fresh installation has been removed in favour of Vulkan if any of two conditions are met:
- The `VulkanRenderer.GetPhysicalDevices()` method returns any valid devices. There are already checks within said method for version and featureset.
- The system is running macOS, where Vulkan was already the only target.

Due to the maturity of the Vulkan backend I think this is a better default experience than the current wall of text popup for new users.