### PR TITLE
Change minimum OS to macOS 12 in Info.plist

### DIFF
--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -43,7 +43,7 @@
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
     <key>LSMinimumSystemVersion</key>
-    <string>11.0</string>
+    <string>12.0</string>
     <key>UTExportedTypeDeclarations</key>
     <array>
       <dict>


### PR DESCRIPTION
This should prevent the app from opening on macOS 11 and lower, informing the user that their OS is unsupported.

This should prevent (at least some) people from filing bug reports for unsupported OS versions. 

Important: I don't know for certain if macOS 12 is actually technically the lowest supported version. I have just seen it mentioned [here](https://github.com/Ryujinx/Ryujinx/issues/5918#issuecomment-1809349501) and in several other posts on Discord. This should be confirmed before the PR is merged. 

Testing: 
Try to open the app on macOS 11 or lower and confirm that the "Unable to open" dialog appears. 