### PR TITLE
Fix TextureGroup.SignalModifying not being called

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1443,11 +1443,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (_modifiedStale || Group.HasCopyDependencies || Group.HasFlushBuffer)
             {
                 _modifiedStale = false;
-
-                if (bound || ModifiedSinceLastFlush || Group.HasCopyDependencies || Group.HasFlushBuffer)
-                {
-                    Group.SignalModifying(this, bound);
-                }
+                Group.SignalModifying(this, bound, bound || ModifiedSinceLastFlush || Group.HasCopyDependencies || Group.HasFlushBuffer);
             }
 
             _physicalMemory.TextureCache.Lift(this);

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -709,7 +709,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="texture">The texture that has been modified</param>
         /// <param name="bound">True if this texture is being bound, false if unbound</param>
-        public void SignalModifying(Texture texture, bool bound)
+        /// <param name="setModified">Indicates if the modified flag should be set</param>
+        public void SignalModifying(Texture texture, bool bound, bool setModified)
         {
             ModifiedSequence = _context.GetModifiedSequence();
 
@@ -721,7 +722,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     TextureGroupHandle group = _handles[baseHandle + i];
 
-                    group.SignalModifying(bound, _context);
+                    group.SignalModifying(bound, _context, setModified);
                 }
             });
         }

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -304,9 +304,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="bound">True if this handle is being bound, false if unbound</param>
         /// <param name="context">The GPU context to register a sync action on</param>
-        public void SignalModifying(bool bound, GpuContext context)
+        /// <param name="setModified">Indicates if the modified flag should be set</param>
+        public void SignalModifying(bool bound, GpuContext context, bool setModified)
         {
-            SignalModified(context);
+            if (setModified)
+            {
+                SignalModified(context);
+            }
+            else
+            {
+                RegisterSync(context);
+            }
 
             if (!bound && _syncActionRegistered && NextSyncCopies())
             {


### PR DESCRIPTION
Fixes a regression from #5909 that broke texture on some games.
There is some internal logic there that should run when the texture is unbound, even if we don't set the modified flag.