### PR TITLE
Disable DMA GPU copy for block linear to linear copies

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -283,7 +283,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 // but only if we are doing a complete copy,
                 // and not for block linear to linear copies, since those are typically accessed from the CPU.
 
-                if (completeSource && completeDest && (!dstLinear || srcLinear == dstLinear))
+                if (completeSource && completeDest && (srcLinear || !dstLinear))
                 {
                     var target = memoryManager.Physical.TextureCache.FindTexture(
                         memoryManager,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -279,7 +279,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
 
-                if (completeSource && completeDest)
+                // Try to set the texture data directly,
+                // but only if we are doing a complete copy,
+                // and not for block linear to linear copies, since those are typically accessed from the CPU.
+
+                if (completeSource && completeDest && (!dstLinear || srcLinear == dstLinear))
                 {
                     var target = memoryManager.Physical.TextureCache.FindTexture(
                         memoryManager,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -283,7 +283,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 // but only if we are doing a complete copy,
                 // and not for block linear to linear copies, since those are typically accessed from the CPU.
 
-                if (completeSource && completeDest && (srcLinear || !dstLinear))
+                if (completeSource && completeDest && !(dstLinear && !srcLinear))
                 {
                     var target = memoryManager.Physical.TextureCache.FindTexture(
                         memoryManager,


### PR DESCRIPTION
We have a fast path where we can avoid some layout conversion operations by setting texture data directly to the destination texture on DMA copy. However, this can also trigger for block linear to linear textures. Typically, block linear to linear copies are used when the target texture will be read from CPU, and in those cases setting the data on the target texture is not worth it (since it will need to be flushed again later). This change disables the GPU path for this case, doing the copy on CPU instead.

Also has the advantage of avoiding flush related bugs, it seems to fix #5889 (this game triggers this case frequently).
Also includes #5926 since it affects that game too.