### PR TITLE
Halve primitive ID when converting quads to triangles

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/src/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.Graphics.GAL
         public readonly bool SupportsMismatchingViewFormat;
         public readonly bool SupportsCubemapView;
         public readonly bool SupportsNonConstantTextureOffset;
+        public readonly bool SupportsQuads;
         public readonly bool SupportsShaderBallot;
         public readonly bool SupportsShaderBarrierDivergence;
         public readonly bool SupportsShaderFloat64;
@@ -90,6 +91,7 @@ namespace Ryujinx.Graphics.GAL
             bool supportsMismatchingViewFormat,
             bool supportsCubemapView,
             bool supportsNonConstantTextureOffset,
+            bool supportsQuads,
             bool supportsShaderBallot,
             bool supportsShaderBarrierDivergence,
             bool supportsShaderFloat64,
@@ -141,6 +143,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsMismatchingViewFormat = supportsMismatchingViewFormat;
             SupportsCubemapView = supportsCubemapView;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
+            SupportsQuads = supportsQuads;
             SupportsShaderBallot = supportsShaderBallot;
             SupportsShaderBarrierDivergence = supportsShaderBarrierDivergence;
             SupportsShaderFloat64 = supportsShaderFloat64;

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheGpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheGpuAccessor.cs
@@ -18,6 +18,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private readonly ShaderSpecializationState _newSpecState;
         private readonly int _stageIndex;
         private readonly bool _isVulkan;
+        private readonly bool _hasGeometryShader;
+        private readonly bool _supportsQuads;
 
         /// <summary>
         /// Creates a new instance of the cached GPU state accessor for shader translation.
@@ -28,6 +30,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         /// <param name="oldSpecState">Shader specialization state of the cached shader</param>
         /// <param name="newSpecState">Shader specialization state of the recompiled shader</param>
         /// <param name="stageIndex">Shader stage index</param>
+        /// <param name="hasGeometryShader">Indicates if a geometry shader is present</param>
         public DiskCacheGpuAccessor(
             GpuContext context,
             ReadOnlyMemory<byte> data,
@@ -35,7 +38,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             ShaderSpecializationState oldSpecState,
             ShaderSpecializationState newSpecState,
             ResourceCounts counts,
-            int stageIndex) : base(context, counts, stageIndex)
+            int stageIndex,
+            bool hasGeometryShader) : base(context, counts, stageIndex)
         {
             _data = data;
             _cb1Data = cb1Data;
@@ -43,6 +47,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             _newSpecState = newSpecState;
             _stageIndex = stageIndex;
             _isVulkan = context.Capabilities.Api == TargetApi.Vulkan;
+            _hasGeometryShader = hasGeometryShader;
+            _supportsQuads = context.Capabilities.SupportsQuads;
 
             if (stageIndex == (int)ShaderStage.Geometry - 1)
             {
@@ -99,7 +105,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         /// <inheritdoc/>
         public GpuGraphicsState QueryGraphicsState()
         {
-            return _oldSpecState.GraphicsState.CreateShaderGraphicsState(!_isVulkan, _isVulkan || _oldSpecState.GraphicsState.YNegateEnabled);
+            return _oldSpecState.GraphicsState.CreateShaderGraphicsState(
+                !_isVulkan,
+                _supportsQuads,
+                _hasGeometryShader,
+                _isVulkan || _oldSpecState.GraphicsState.YNegateEnabled);
         }
 
         /// <inheritdoc/>

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5791;
+        private const uint CodeGenVersion = 5936;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -601,6 +601,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
 
             TargetApi api = _context.Capabilities.Api;
 
+            bool hasCachedGs = guestShaders[4].HasValue;
+
             for (int stageIndex = Constants.ShaderStages - 1; stageIndex >= 0; stageIndex--)
             {
                 if (guestShaders[stageIndex + 1].HasValue)
@@ -610,7 +612,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     byte[] guestCode = shader.Code;
                     byte[] cb1Data = shader.Cb1Data;
 
-                    DiskCacheGpuAccessor gpuAccessor = new(_context, guestCode, cb1Data, specState, newSpecState, counts, stageIndex);
+                    DiskCacheGpuAccessor gpuAccessor = new(_context, guestCode, cb1Data, specState, newSpecState, counts, stageIndex, hasCachedGs);
                     TranslatorContext currentStage = DecodeGraphicsShader(gpuAccessor, api, DefaultFlags, 0);
 
                     if (nextStage != null)
@@ -623,7 +625,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                         byte[] guestCodeA = guestShaders[0].Value.Code;
                         byte[] cb1DataA = guestShaders[0].Value.Cb1Data;
 
-                        DiskCacheGpuAccessor gpuAccessorA = new(_context, guestCodeA, cb1DataA, specState, newSpecState, counts, 0);
+                        DiskCacheGpuAccessor gpuAccessorA = new(_context, guestCodeA, cb1DataA, specState, newSpecState, counts, 0, hasCachedGs);
                         translatorContexts[0] = DecodeGraphicsShader(gpuAccessorA, api, DefaultFlags | TranslationFlags.VertexA, 0);
                     }
 
@@ -711,7 +713,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             GuestCodeAndCbData shader = guestShaders[0].Value;
             ResourceCounts counts = new();
             ShaderSpecializationState newSpecState = new(ref specState.ComputeState);
-            DiskCacheGpuAccessor gpuAccessor = new(_context, shader.Code, shader.Cb1Data, specState, newSpecState, counts, 0);
+            DiskCacheGpuAccessor gpuAccessor = new(_context, shader.Code, shader.Cb1Data, specState, newSpecState, counts, 0, false);
             gpuAccessor.InitializeReservedCounts(tfEnabled: false, vertexAsCompute: false);
 
             TranslatorContext translatorContext = DecodeComputeShader(gpuAccessor, _context.Capabilities.Api, 0);

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -17,6 +17,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         private readonly int _stageIndex;
         private readonly bool _compute;
         private readonly bool _isVulkan;
+        private readonly bool _hasGeometryShader;
+        private readonly bool _supportsQuads;
 
         /// <summary>
         /// Creates a new instance of the GPU state accessor for graphics shader translation.
@@ -25,12 +27,20 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="channel">GPU channel</param>
         /// <param name="state">Current GPU state</param>
         /// <param name="stageIndex">Graphics shader stage index (0 = Vertex, 4 = Fragment)</param>
-        public GpuAccessor(GpuContext context, GpuChannel channel, GpuAccessorState state, int stageIndex) : base(context, state.ResourceCounts, stageIndex)
+        /// <param name="hasGeometryShader">Indicates if a geometry shader is present</param>
+        public GpuAccessor(
+            GpuContext context,
+            GpuChannel channel,
+            GpuAccessorState state,
+            int stageIndex,
+            bool hasGeometryShader) : base(context, state.ResourceCounts, stageIndex)
         {
-            _isVulkan = context.Capabilities.Api == TargetApi.Vulkan;
             _channel = channel;
             _state = state;
             _stageIndex = stageIndex;
+            _isVulkan = context.Capabilities.Api == TargetApi.Vulkan;
+            _hasGeometryShader = hasGeometryShader;
+            _supportsQuads = context.Capabilities.SupportsQuads;
 
             if (stageIndex == (int)ShaderStage.Geometry - 1)
             {
@@ -104,7 +114,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <inheritdoc/>
         public GpuGraphicsState QueryGraphicsState()
         {
-            return _state.GraphicsState.CreateShaderGraphicsState(!_isVulkan, _isVulkan || _state.GraphicsState.YNegateEnabled);
+            return _state.GraphicsState.CreateShaderGraphicsState(
+                !_isVulkan,
+                _supportsQuads,
+                _hasGeometryShader,
+                _isVulkan || _state.GraphicsState.YNegateEnabled);
         }
 
         /// <inheritdoc/>

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuChannelGraphicsState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuChannelGraphicsState.cs
@@ -106,8 +106,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// Creates a new graphics state from this state that can be used for shader generation.
         /// </summary>
         /// <param name="hostSupportsAlphaTest">Indicates if the host API supports alpha test operations</param>
+        /// <param name="hostSupportsQuads">Indicates if the host API supports quad primitives</param>
+        /// <param name="hasGeometryShader">Indicates if a geometry shader is used</param>
+        /// <param name="originUpperLeft">If true, indicates that the fragment origin is the upper left corner of the viewport, otherwise it is the lower left corner</param>
         /// <returns>GPU graphics state that can be used for shader translation</returns>
-        public readonly GpuGraphicsState CreateShaderGraphicsState(bool hostSupportsAlphaTest, bool originUpperLeft)
+        public readonly GpuGraphicsState CreateShaderGraphicsState(bool hostSupportsAlphaTest, bool hostSupportsQuads, bool hasGeometryShader, bool originUpperLeft)
         {
             AlphaTestOp alphaTestOp;
 
@@ -130,6 +133,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 };
             }
 
+            bool isQuad = Topology == PrimitiveTopology.Quads || Topology == PrimitiveTopology.QuadStrip;
+            bool halvePrimitiveId = !hostSupportsQuads && !hasGeometryShader && isQuad;
+
             return new GpuGraphicsState(
                 EarlyZForce,
                 ConvertToInputTopology(Topology, TessellationMode),
@@ -149,7 +155,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 in FragmentOutputTypes,
                 DualSourceBlendEnable,
                 YNegateEnabled,
-                originUpperLeft);
+                originUpperLeft,
+                halvePrimitiveId);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -334,7 +334,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                 if (gpuVa != 0)
                 {
-                    GpuAccessor gpuAccessor = new(_context, channel, gpuAccessorState, stageIndex);
+                    GpuAccessor gpuAccessor = new(_context, channel, gpuAccessorState, stageIndex, addresses.Geometry != 0);
                     TranslatorContext currentStage = DecodeGraphicsShader(gpuAccessor, api, DefaultFlags, gpuVa);
 
                     if (nextStage != null)

--- a/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -160,6 +160,7 @@ namespace Ryujinx.Graphics.OpenGL
                 supportsCubemapView: true,
                 supportsNonConstantTextureOffset: HwCapabilities.SupportsNonConstantTextureOffset,
                 supportsScaledVertexFormats: true,
+                supportsQuads: HwCapabilities.SupportsQuads,
                 supportsShaderBallot: HwCapabilities.SupportsShaderBallot,
                 supportsShaderBarrierDivergence: !(intelWindows || intelUnix),
                 supportsShaderFloat64: true,

--- a/src/Ryujinx.Graphics.Shader/GpuGraphicsState.cs
+++ b/src/Ryujinx.Graphics.Shader/GpuGraphicsState.cs
@@ -103,6 +103,11 @@ namespace Ryujinx.Graphics.Shader
         public readonly bool OriginUpperLeft;
 
         /// <summary>
+        /// Indicates that the primitive ID values on the shader should be halved due to quad to triangles conversion.
+        /// </summary>
+        public readonly bool HalvePrimitiveId;
+
+        /// <summary>
         /// Creates a new GPU graphics state.
         /// </summary>
         /// <param name="earlyZForce">Early Z force enable</param>
@@ -124,6 +129,7 @@ namespace Ryujinx.Graphics.Shader
         /// <param name="dualSourceBlendEnable">Indicates whether dual source blend is enabled</param>
         /// <param name="yNegateEnabled">Indicates if negation of the viewport Y axis is enabled</param>
         /// <param name="originUpperLeft">If true, indicates that the fragment origin is the upper left corner of the viewport, otherwise it is the lower left corner</param>
+        /// <param name="halvePrimitiveId">Indicates that the primitive ID values on the shader should be halved due to quad to triangles conversion</param>
         public GpuGraphicsState(
             bool earlyZForce,
             InputTopology topology,
@@ -143,7 +149,8 @@ namespace Ryujinx.Graphics.Shader
             in Array8<AttributeType> fragmentOutputTypes,
             bool dualSourceBlendEnable,
             bool yNegateEnabled,
-            bool originUpperLeft)
+            bool originUpperLeft,
+            bool halvePrimitiveId)
         {
             EarlyZForce = earlyZForce;
             Topology = topology;
@@ -164,6 +171,7 @@ namespace Ryujinx.Graphics.Shader
             DualSourceBlendEnable = dualSourceBlendEnable;
             YNegateEnabled = yNegateEnabled;
             OriginUpperLeft = originUpperLeft;
+            HalvePrimitiveId = halvePrimitiveId;
         }
     }
 }

--- a/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -147,6 +147,7 @@ namespace Ryujinx.Graphics.Shader
                 default,
                 false,
                 false,
+                false,
                 false);
         }
 

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
@@ -84,6 +84,10 @@ namespace Ryujinx.Graphics.Shader.Instructions
                                 value = context.IConvertU32ToFP32(value);
                             }
                         }
+                        else if (offset == AttributeConsts.PrimitiveId && context.TranslatorContext.Definitions.HalvePrimitiveId)
+                        {
+                            value = context.ShiftRightS32(value, Const(1));
+                        }
 
                         context.Copy(Register(rd), value);
                     }
@@ -186,6 +190,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
                             res = context.FPSubtract(viewportHeight, res);
                         }
                     }
+                }
+                else if (op.Imm10 == AttributeConsts.PrimitiveId && context.TranslatorContext.Definitions.HalvePrimitiveId)
+                {
+                    // If quads are used, but the host does not support them, they need to be converted to triangles.
+                    // Since each quad becomes 2 triangles, we need to compensate here and divide primitive ID by 2.
+                    res = context.ShiftRightS32(res, Const(1));
                 }
                 else if (op.Imm10 == AttributeConsts.FrontFacing && context.TranslatorContext.GpuAccessor.QueryHostHasFrontFacingBug())
                 {

--- a/src/Ryujinx.Graphics.Shader/Translation/ShaderDefinitions.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ShaderDefinitions.cs
@@ -45,6 +45,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         public bool YNegateEnabled => _graphicsState.YNegateEnabled;
         public bool OriginUpperLeft => _graphicsState.OriginUpperLeft;
 
+        public bool HalvePrimitiveId => _graphicsState.HalvePrimitiveId;
+
         public ImapPixelType[] ImapTypes { get; }
         public bool IaIndexing { get; private set; }
         public bool OaIndexing { get; private set; }

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -602,6 +602,7 @@ namespace Ryujinx.Graphics.Vulkan
                 supportsCubemapView: !IsAmdGcn,
                 supportsNonConstantTextureOffset: false,
                 supportsScaledVertexFormats: FormatCapabilities.SupportsScaledVertexFormats(),
+                supportsQuads: false,
                 supportsShaderBallot: false,
                 supportsShaderBarrierDivergence: Vendor != Vendor.Intel,
                 supportsShaderFloat64: Capabilities.SupportsShaderFloat64,


### PR DESCRIPTION
When the API or driver does not have native native support for quad primitives, we convert them to triangles. Because we convert each quad to 2 triangles, when we render quads, we have twice as many primitives than the game submitted. For this reason, the value for `gl_PrimitiveID` which is the index of the primitive on the shader is incorrect, and it is also double of what it should be.

To fix this issue, this change divides the ID by 2 if the primitive type is `Quads` or `QuadStrip`, the host does not support quads, and there is no geometry shader (as geometry shader must always generate new primitives, and they can't output quads).

I'm not aware of any visible improvements from this change on its own, **but when combined with #3001**, it fixes rendering on Castle Crashers Remastered.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/81275de5-4260-40af-a8a3-253bf750c480)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/06be9e21-fbe5-4636-8bb8-5f0981f8c618)