### PR TITLE
Fix JitCache.Unmap called with the same address freeing memory in use

### DIFF
--- a/src/ARMeilleure/Translation/Cache/JitUnwindWindows.cs
+++ b/src/ARMeilleure/Translation/Cache/JitUnwindWindows.cs
@@ -95,7 +95,7 @@ namespace ARMeilleure.Translation.Cache
         {
             int offset = (int)((long)controlPc - context.ToInt64());
 
-            if (!JitCache.TryFind(offset, out CacheEntry funcEntry))
+            if (!JitCache.TryFind(offset, out CacheEntry funcEntry, out _))
             {
                 return null; // Not found.
             }


### PR DESCRIPTION
`JitCache.Unmap` was not able to handle multiple unmaps of the same address properly. `TryFind` will return the nearest entry in the cache if it can't find one with the exact address that should be freed. This means that if `Unmap` is called more than once with the same function address, it will free the wrong region the second time. This could cause it to free code still in use which would crash the emulator.

This was causing crashes on games that uses the JIT service. One example is Super Mario 3D All-Stars. To reproduce, launch Super Mario 64 there, then stop emulation and try to launch another game. It will crash quickly. In debug mode, an assert would fire when trying to stop emulation.

This change makes the `Unmap` function more robust, now it checks if the entry offset matches the offset that should be freed before doing anything else. This fixes the issue mentioned above.