### PR TITLE
Fix macOS Path on .NET 8

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Common.Configuration
             string appDataPath;
             if (OperatingSystem.IsMacOS())
             {
-                appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Application Support");
+                appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support");
             }
             else
             {


### PR DESCRIPTION
Post .NET 8 has changed `SpecialFolder.Personal` to point to `~/Documents` which resulted in Ryujinx creating/looking for its folder in a user's document directory, rather than actually in Application Support.

Fixes #5940