### PR TITLE
Enable copy dependency between RGBA8 and RGBA32 formats

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
@@ -651,9 +651,35 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if the format is valid, false otherwise</returns>
         public static bool TryGetTextureFormat(uint encoded, bool isSrgb, out FormatInfo format)
         {
-            encoded |= (isSrgb ? 1u << 19 : 0u);
+            bool isPacked = (encoded & 0x80000000u) != 0;
+            if (isPacked)
+            {
+                encoded &= ~0x80000000u;
+            }
 
-            return _textureFormats.TryGetValue((TextureFormat)encoded, out format);
+            encoded |= isSrgb ? 1u << 19 : 0u;
+
+            bool found = _textureFormats.TryGetValue((TextureFormat)encoded, out format);
+
+            if (found && isPacked)
+            {
+                // If the packed flag is set, then the components of the pixel are tightly packed into the
+                // GPU registers on the shader.
+                // We can get the same behaviour by aliasing the texture as a format with the same amount of
+                // bytes per pixel, but only a single or the lowest possible number of components.
+
+                format = format.BytesPerPixel switch
+                {
+                    1 => new FormatInfo(Format.R8Unorm, 1, 1, 1, 1),
+                    2 => new FormatInfo(Format.R16Unorm, 1, 1, 2, 1),
+                    4 => new FormatInfo(Format.R32Float, 1, 1, 4, 1),
+                    8 => new FormatInfo(Format.R32G32Float, 1, 1, 8, 2),
+                    16 => new FormatInfo(Format.R32G32B32A32Float, 1, 1, 16, 4),
+                    _ => format,
+                };
+            }
+
+            return found;
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
@@ -661,7 +661,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             bool found = _textureFormats.TryGetValue((TextureFormat)encoded, out format);
 
-            if (found && isPacked)
+            if (found && isPacked && !format.Format.IsDepthOrStencil())
             {
                 // If the packed flag is set, then the components of the pixel are tightly packed into the
                 // GPU registers on the shader.

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -718,7 +718,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 (lhsFormat, rhsFormat) = (rhsFormat, lhsFormat);
             }
 
-            return lhsFormat.Format == Format.R8Unorm && rhsFormat.Format == Format.R8G8B8A8Unorm;
+            return (lhsFormat.Format == Format.R8G8B8A8Unorm && rhsFormat.Format == Format.R32G32B32A32Float) ||
+                   (lhsFormat.Format == Format.R8Unorm && rhsFormat.Format == Format.R8G8B8A8Unorm);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -2,6 +2,8 @@ using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Texture;
 using System;
+using System.Diagnostics;
+using System.Numerics;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -339,7 +341,20 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (lhs.FormatInfo.BytesPerPixel != rhs.FormatInfo.BytesPerPixel && IsIncompatibleFormatAliasingAllowed(lhs.FormatInfo, rhs.FormatInfo))
             {
-                alignedWidthMatches = lhsSize.Width * lhs.FormatInfo.BytesPerPixel == rhsSize.Width * rhs.FormatInfo.BytesPerPixel;
+                // If the formats are incompatible, but the texture strides match,
+                // we might allow them to be copy compatible depending on the format.
+                // The strides are aligned because the format with higher bytes per pixel
+                // might need a bit of padding at the end due to one width not being a multiple of the other.
+
+                Debug.Assert((1 << BitOperations.Log2((uint)lhs.FormatInfo.BytesPerPixel)) == lhs.FormatInfo.BytesPerPixel);
+                Debug.Assert((1 << BitOperations.Log2((uint)rhs.FormatInfo.BytesPerPixel)) == rhs.FormatInfo.BytesPerPixel);
+
+                int alignment = Math.Max(lhs.FormatInfo.BytesPerPixel, rhs.FormatInfo.BytesPerPixel);
+
+                int lhsStride = BitUtils.AlignUp(lhsSize.Width * lhs.FormatInfo.BytesPerPixel, alignment);
+                int rhsStride = BitUtils.AlignUp(rhsSize.Width * rhs.FormatInfo.BytesPerPixel, alignment);
+
+                alignedWidthMatches = lhsStride == rhsStride;
             }
 
             TextureViewCompatibility result = TextureViewCompatibility.Full;

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -430,7 +430,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (!FormatTable.TryGetTextureFormat(format, srgb, out FormatInfo formatInfo))
             {
-                if (gpuVa != 0 && (int)format > 0)
+                if (gpuVa != 0)
                 {
                     Logger.Error?.Print(LogClass.Gpu, $"Invalid texture format 0x{format:X} (sRGB: {srgb}).");
                 }

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -430,7 +430,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (!FormatTable.TryGetTextureFormat(format, srgb, out FormatInfo formatInfo))
             {
-                if (gpuVa != 0)
+                if (gpuVa != 0 && format != 0)
                 {
                     Logger.Error?.Print(LogClass.Gpu, $"Invalid texture format 0x{format:X} (sRGB: {srgb}).");
                 }


### PR DESCRIPTION
A few OpenGL games do a image store using a texture that has 1/4 of the width and 4x the amount of bytes per pixel (effectively storing 4 pixels in one invocation). Then later, the texture is accessed using the "true" format. This does not work right now because the formats are incompatible, one texture uses a RGBA32 format, and the other RGBA8. A while ago, I enabled copy between incompatible formats since the game Mario + Rabbids Sparks of Hope does something similar (but the formats are R8 and RGBA8 instead). This change enables copy dependency between RGBA32 and RGBA8 formats.

Fixing this reveals another bug, which is why I did not include this fix on the Mario + Rabbids targeted change back then. The format of the input texture that the shader samples for the image store was also wrong. It was using a RGBA8 format, which is the "default" format that the emulator uses right now when the format is invalid. I did not realize that the format was "invalid" back then because it was not logging any error.

The reason for the log not printing is this code:
```cs
if (gpuVa != 0 && (int)format > 0)
{
    Logger.Error?.Print(LogClass.Gpu, $"Invalid texture format 0x{format:X} (sRGB: {srgb}).");
}
```
The `(int)format > 0` check means it won't print if the most significant bit is set, and this was the case for this format. I don't remember why this check was added, I believe it was to prevent log spam on some games with invalid formats.

When the most significant bit of the format is set, the components should be tightly packed on the registers in the shader. To emulate this behaviour without needing to change the shader, I made it instead return compatible formats that only have a single component (or 2/4 components for 8 and 16 bytes per pixel formats) which should ensure values are tightly packed.

This finally fixes cicadas not rendering when you catch them on Yo-kai Watch 1.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/315e14dd-e3d0-4346-a7af-2de7a1b4847d)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/a7505acc-f290-420d-b83d-a51bd0de9eb9)
Also improves rendering on Wet Steps, ~~but this game still has other rendering issues~~. There was also another issue, when comparing the widths for textures with different formats, it did not take into account the fact that they might not be a multiple of each other, and one of them having a little padding for this reason. I have fixed that as well, and the game seems to be rendering correctly now.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/c1ec9cbd-1844-4469-aefe-afbd8b4bc67a)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/eda0763c-eea8-4c17-903a-08bfc7927ada)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/54bb1d3c-1ab1-4335-b976-6cd1facbcc2d)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/6a9b1b40-2c36-4ba9-b4f0-671397d16738)
Other OpenGL games might also be positively impacted.