### PR TITLE
Extend bindless elimination to see through Phis with the same results

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5791;
+        private const uint CodeGenVersion = 5957;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";


### PR DESCRIPTION
This extends bindless elimination to also work on cases where the handle is "materialized" on multiple places in the code. It was not able to reason about that before because a Phi was on the way, so it was not able to find the handle comining operation.

Basically, this code:
```glsl
handle = fp_c2.data[24].z | fp_c2.data[88].x;
if (someCond) {
    handle = fp_c2.data[24].z | fp_c2.data[88].x;
}
texture(handle, vec2(x, y));
```
Because `handle` has two assignment, and may have different values depending on the path it takes, it was not able to find the handle value. But the value is actually the same regardless of the path it takes, since constant buffers can't be modified inside the shader, and they both access the same values from the constant buffer, and perform the same operation.

To fix this I extended the code to also match this case and pick the first value.

Fixes some shadow issues on Super Mario RPG.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/52e10b48-55e2-45ff-aaa3-6bec6148fab3)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/77725b98-9e85-4ffd-abc3-bef9171fe37d)
Fixes #5946.