### PR TITLE
Extend bindless elimination to see through shuffle

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5957;
+        private const uint CodeGenVersion = 5958;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -29,7 +29,16 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                 if (texOp.Inst == Instruction.TextureSample || texOp.Inst.IsTextureQuery())
                 {
-                    Operand bindlessHandle = Utils.FindLastOperation(texOp.GetSource(0), block);
+                    Operand bindlessHandle = texOp.GetSource(0);
+
+                    // In some cases the compiler uses a shuffle operation to get the handle,
+                    // for some textureGrad implementations. In those cases, we can skip the shuffle.
+                    if (bindlessHandle.AsgOp is Operation shuffleOp && shuffleOp.Inst == Instruction.Shuffle)
+                    {
+                        bindlessHandle = shuffleOp.GetSource(0);
+                    }
+
+                    bindlessHandle = Utils.FindLastOperation(bindlessHandle, block);
 
                     // Some instructions do not encode an accurate sampler type:
                     // - Most instructions uses the same type for 1D and Buffer.


### PR DESCRIPTION
This shows up in some compiler generated patterns in the code, which I believe are used for some sort of `textureGrad` implementation.  The shuffle shouldn't really make a difference if all invocations access the handle from the same place (like from a constant buffer, without indexing). This change allows bindless elimination to "see through" the shuffle operation.

This pattern generally shows up on games using `SAM` and `RAM` shader instructions (which are currently printed on the log as not implemented).

Fixes missing cubemap reflections on Detective Pikachu.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/65a14437-a876-4c76-bd38-4b0f586706c4)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/c7fb08a2-58e1-4294-870b-9af7bd12745f)
Fixes #5901.