### PR TITLE
Vulkan: Use templates for descriptor updates

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                     else
                     {
-                        // TODO: current normal impl likes to skip these if null?
+                        // NOTE: Current non-templated path skips these if null, we just send a 0 handle.
 
                         entries[entryI++] = new DescriptorUpdateTemplateEntry()
                         {
@@ -108,7 +108,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                     else
                     {
-                        // TODO: current normal impl likes to skip these if null?
+                        // NOTE: Current non-templated path skips these if null, we just send a 0 handle.
 
                         entries[entryI++] = new DescriptorUpdateTemplateEntry()
                         {

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -1,0 +1,153 @@
+﻿using Ryujinx.Graphics.GAL;
+using Silk.NET.Vulkan;
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    class DescriptorSetTemplate : IDisposable
+    {
+        private readonly VulkanRenderer _gd;
+        private readonly Device _device;
+
+        public readonly DescriptorUpdateTemplate Template;
+        public readonly int Size;
+
+        public unsafe DescriptorSetTemplate(VulkanRenderer gd, Device device, ResourceBindingSegment[] segments, PipelineLayoutCacheEntry plce, PipelineBindPoint pbp, int setIndex)
+        {
+            _gd = gd;
+            _device = device;
+
+            // Create a template from the set usages. Assumes the descriptor set is updated in segment order then binding order.
+
+            int entryCount = segments.Sum(segment => segment.Count);
+
+            DescriptorUpdateTemplateEntry* entries = stackalloc DescriptorUpdateTemplateEntry[entryCount];
+            int entryI = 0;
+            nuint structureOffset = 0;
+
+            for (int seg = 0; seg < segments.Length; seg++)
+            {
+                ResourceBindingSegment segment = segments[seg];
+
+                int binding = segment.Binding;
+                int count = segment.Count;
+
+                if (setIndex == PipelineBase.UniformSetIndex)
+                {
+                    entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                    {
+                        DescriptorType = DescriptorType.UniformBuffer,
+                        DstBinding = (uint)binding,
+                        DescriptorCount = (uint)count,
+                        Offset = structureOffset,
+                        Stride = (nuint)Unsafe.SizeOf<DescriptorBufferInfo>()
+                    };
+
+                    structureOffset += (nuint)(Unsafe.SizeOf<DescriptorBufferInfo>() * count);
+                }
+                else if (setIndex == PipelineBase.StorageSetIndex)
+                {
+                    entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                    {
+                        DescriptorType = DescriptorType.StorageBuffer,
+                        DstBinding = (uint)binding,
+                        DescriptorCount = (uint)count,
+                        Offset = structureOffset,
+                        Stride = (nuint)Unsafe.SizeOf<DescriptorBufferInfo>()
+                    };
+
+                    structureOffset += (nuint)(Unsafe.SizeOf<DescriptorBufferInfo>() * count);
+                }
+                else if (setIndex == PipelineBase.TextureSetIndex)
+                {
+                    if (segment.Type != ResourceType.BufferTexture)
+                    {
+                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        {
+                            DescriptorType = DescriptorType.CombinedImageSampler,
+                            DstBinding = (uint)binding,
+                            DescriptorCount = (uint)count,
+                            Offset = structureOffset,
+                            Stride = (nuint)Unsafe.SizeOf<DescriptorImageInfo>()
+                        };
+
+                        structureOffset += (nuint)(Unsafe.SizeOf<DescriptorImageInfo>() * count);
+                    }
+                    else
+                    {
+                        // TODO: current normal impl likes to skip these if null?
+
+                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        {
+                            DescriptorType = DescriptorType.UniformTexelBuffer,
+                            DstBinding = (uint)binding,
+                            DescriptorCount = (uint)count,
+                            Offset = structureOffset,
+                            Stride = (nuint)Unsafe.SizeOf<BufferView>()
+                        };
+
+                        structureOffset += (nuint)(Unsafe.SizeOf<BufferView>() * count);
+                    }
+                }
+                else if (setIndex == PipelineBase.ImageSetIndex)
+                {
+                    if (segment.Type != ResourceType.BufferImage)
+                    {
+                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        {
+                            DescriptorType = DescriptorType.StorageImage,
+                            DstBinding = (uint)binding,
+                            DescriptorCount = (uint)count,
+                            Offset = structureOffset,
+                            Stride = (nuint)Unsafe.SizeOf<DescriptorImageInfo>()
+                        };
+
+                        structureOffset += (nuint)(Unsafe.SizeOf<DescriptorImageInfo>() * count);
+                    }
+                    else
+                    {
+                        // TODO: current normal impl likes to skip these if null?
+
+                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        {
+                            DescriptorType = DescriptorType.StorageTexelBuffer,
+                            DstBinding = (uint)binding,
+                            DescriptorCount = (uint)count,
+                            Offset = structureOffset,
+                            Stride = (nuint)Unsafe.SizeOf<BufferView>()
+                        };
+
+                        structureOffset += (nuint)(Unsafe.SizeOf<BufferView>() * count);
+                    }
+                }
+            }
+
+            Size = (int)structureOffset;
+
+            var info = new DescriptorUpdateTemplateCreateInfo()
+            {
+                SType = StructureType.DescriptorUpdateTemplateCreateInfo,
+                DescriptorUpdateEntryCount = (uint)entryI,
+                PDescriptorUpdateEntries = entries,
+
+                TemplateType = DescriptorUpdateTemplateType.DescriptorSet,
+                DescriptorSetLayout = plce.DescriptorSetLayouts[setIndex],
+                PipelineBindPoint = pbp,
+                PipelineLayout = plce.PipelineLayout,
+                Set = (uint)setIndex,
+            };
+
+            DescriptorUpdateTemplate result;
+            gd.Api.CreateDescriptorUpdateTemplate(device, &info, null, &result).ThrowOnError();
+
+            Template = result;
+        }
+
+        public unsafe void Dispose()
+        {
+            _gd.Api.DestroyDescriptorUpdateTemplate(_device, Template, null);
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -21,10 +21,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             // Create a template from the set usages. Assumes the descriptor set is updated in segment order then binding order.
 
-            int entryCount = segments.Sum(segment => segment.Count);
-
-            DescriptorUpdateTemplateEntry* entries = stackalloc DescriptorUpdateTemplateEntry[entryCount];
-            int entryI = 0;
+            DescriptorUpdateTemplateEntry* entries = stackalloc DescriptorUpdateTemplateEntry[segments.Length];
             nuint structureOffset = 0;
 
             for (int seg = 0; seg < segments.Length; seg++)
@@ -36,7 +33,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (setIndex == PipelineBase.UniformSetIndex)
                 {
-                    entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                    entries[seg] = new DescriptorUpdateTemplateEntry()
                     {
                         DescriptorType = DescriptorType.UniformBuffer,
                         DstBinding = (uint)binding,
@@ -49,7 +46,7 @@ namespace Ryujinx.Graphics.Vulkan
                 }
                 else if (setIndex == PipelineBase.StorageSetIndex)
                 {
-                    entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                    entries[seg] = new DescriptorUpdateTemplateEntry()
                     {
                         DescriptorType = DescriptorType.StorageBuffer,
                         DstBinding = (uint)binding,
@@ -64,7 +61,7 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     if (segment.Type != ResourceType.BufferTexture)
                     {
-                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        entries[seg] = new DescriptorUpdateTemplateEntry()
                         {
                             DescriptorType = DescriptorType.CombinedImageSampler,
                             DstBinding = (uint)binding,
@@ -79,7 +76,7 @@ namespace Ryujinx.Graphics.Vulkan
                     {
                         // NOTE: Current non-templated path skips these if null, we just send an empty handle.
 
-                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        entries[seg] = new DescriptorUpdateTemplateEntry()
                         {
                             DescriptorType = DescriptorType.UniformTexelBuffer,
                             DstBinding = (uint)binding,
@@ -95,7 +92,7 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     if (segment.Type != ResourceType.BufferImage)
                     {
-                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        entries[seg] = new DescriptorUpdateTemplateEntry()
                         {
                             DescriptorType = DescriptorType.StorageImage,
                             DstBinding = (uint)binding,
@@ -110,7 +107,7 @@ namespace Ryujinx.Graphics.Vulkan
                     {
                         // NOTE: Current non-templated path skips these if null, we just send an empty handle.
 
-                        entries[entryI++] = new DescriptorUpdateTemplateEntry()
+                        entries[seg] = new DescriptorUpdateTemplateEntry()
                         {
                             DescriptorType = DescriptorType.StorageTexelBuffer,
                             DstBinding = (uint)binding,
@@ -129,7 +126,7 @@ namespace Ryujinx.Graphics.Vulkan
             var info = new DescriptorUpdateTemplateCreateInfo()
             {
                 SType = StructureType.DescriptorUpdateTemplateCreateInfo,
-                DescriptorUpdateEntryCount = (uint)entryI,
+                DescriptorUpdateEntryCount = (uint)segments.Length,
                 PDescriptorUpdateEntries = entries,
 
                 TemplateType = DescriptorUpdateTemplateType.DescriptorSet,

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -1,7 +1,6 @@
 ﻿using Ryujinx.Graphics.GAL;
 using Silk.NET.Vulkan;
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Vulkan

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -73,8 +73,6 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                     else
                     {
-                        // NOTE: Current non-templated path skips these if null, we just send an empty handle.
-
                         entries[seg] = new DescriptorUpdateTemplateEntry()
                         {
                             DescriptorType = DescriptorType.UniformTexelBuffer,
@@ -104,8 +102,6 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                     else
                     {
-                        // NOTE: Current non-templated path skips these if null, we just send an empty handle.
-
                         entries[seg] = new DescriptorUpdateTemplateEntry()
                         {
                             DescriptorType = DescriptorType.StorageTexelBuffer,

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                     else
                     {
-                        // NOTE: Current non-templated path skips these if null, we just send a 0 handle.
+                        // NOTE: Current non-templated path skips these if null, we just send an empty handle.
 
                         entries[entryI++] = new DescriptorUpdateTemplateEntry()
                         {
@@ -108,7 +108,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                     else
                     {
-                        // NOTE: Current non-templated path skips these if null, we just send a 0 handle.
+                        // NOTE: Current non-templated path skips these if null, we just send an empty handle.
 
                         entries[entryI++] = new DescriptorUpdateTemplateEntry()
                         {

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.GAL;
 using Silk.NET.Vulkan;
 using System;
 using System.Runtime.CompilerServices;

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplateUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplateUpdater.cs
@@ -1,0 +1,58 @@
+﻿using Ryujinx.Common;
+using Silk.NET.Vulkan;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    unsafe class DescriptorSetTemplateUpdater : IDisposable
+    {
+        private const int SizeGranularity = 512;
+
+        private DescriptorSetTemplate _activeTemplate;
+        private NativeArray<byte> _data;
+        private byte* _dataPtr;
+
+        private void EnsureSize(int size)
+        {
+            if (_data == null || _data.Length < size)
+            {
+                _data?.Dispose();
+
+                int dataSize = BitUtils.AlignUp(size, SizeGranularity);
+                _data = new NativeArray<byte>(dataSize);
+            }
+        }
+
+        public void Begin(DescriptorSetTemplate template)
+        {
+            _activeTemplate = template;
+
+            if (template != null)
+            {
+                EnsureSize(template.Size);
+
+                _dataPtr = _data.Pointer;
+            }
+        }
+
+        public void Push<T>(ReadOnlySpan<T> values) where T : unmanaged
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                *((T*)_dataPtr) = values[i];
+                _dataPtr += Unsafe.SizeOf<T>();
+            }
+        }
+
+        public void Commit(VulkanRenderer gd, Device device, DescriptorSet set)
+        {
+            gd.Api.UpdateDescriptorSetWithTemplate(device, set, _activeTemplate.Template, _data.Pointer);
+        }
+
+        public void Dispose()
+        {
+            _data?.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplateUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplateUpdater.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Common;
+using Ryujinx.Common;
 using Silk.NET.Vulkan;
 using System;
 using System.Runtime.CompilerServices;

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -640,8 +640,8 @@ namespace Ryujinx.Graphics.Vulkan
                         {
                             dsc.UpdateBufferImages(0, binding, bufferTextures[..count], DescriptorType.UniformTexelBuffer);
                         }
-                        }
                     }
+                }
                 else if (setIndex == PipelineBase.ImageSetIndex)
                 {
                     if (segment.Type != ResourceType.BufferImage)

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             gd.Api.CreatePipelineCache(device, pipelineCacheCreateInfo, null, out PipelineCache).ThrowOnError();
 
-            _descriptorSetUpdater = new DescriptorSetUpdater(gd, this);
+            _descriptorSetUpdater = new DescriptorSetUpdater(gd, device, this);
             _vertexBufferUpdater = new VertexBufferUpdater(gd);
 
             _transformFeedbackBuffers = new BufferState[Constants.MaxTransformFeedbackBuffers];

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -247,16 +247,13 @@ namespace Ryujinx.Graphics.Vulkan
         {
             var templates = new DescriptorSetTemplate[BindingSegments.Length];
 
-            if (VulkanConfiguration.UseDescriptorUpdateTemplates)
+            for (int setIndex = 0; setIndex < BindingSegments.Length; setIndex++)
             {
-                for (int setIndex = 0; setIndex < BindingSegments.Length; setIndex++)
-                {
-                    ResourceBindingSegment[] segments = BindingSegments[setIndex];
+                ResourceBindingSegment[] segments = BindingSegments[setIndex];
 
-                    if (segments != null && segments.Length > 0)
-                    {
-                        templates[setIndex] = new DescriptorSetTemplate(_gd, _device, segments, _plce, IsCompute ? PipelineBindPoint.Compute : PipelineBindPoint.Graphics, setIndex);
-                    }
+                if (segments != null && segments.Length > 0)
+                {
+                    templates[setIndex] = new DescriptorSetTemplate(_gd, _device, segments, _plce, IsCompute ? PipelineBindPoint.Compute : PipelineBindPoint.Graphics, setIndex);
                 }
             }
 

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -247,7 +247,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             var templates = new DescriptorSetTemplate[BindingSegments.Length];
 
-            if (!HasMinimalLayout) // or if unsupported...
+            if (VulkanConfiguration.UseDescriptorUpdateTemplates)
             {
                 for (int setIndex = 0; setIndex < BindingSegments.Length; setIndex++)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -26,6 +26,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public ResourceBindingSegment[][] ClearSegments { get; }
         public ResourceBindingSegment[][] BindingSegments { get; }
+        public DescriptorSetTemplate[] Templates { get; }
 
         public ProgramLinkStatus LinkStatus { get; private set; }
 
@@ -118,6 +119,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             ClearSegments = BuildClearSegments(resourceLayout.Sets);
             BindingSegments = BuildBindingSegments(resourceLayout.SetUsages);
+            Templates = BuildTemplates();
 
             _compileTask = Task.CompletedTask;
             _firstBackgroundUse = false;
@@ -239,6 +241,26 @@ namespace Ryujinx.Graphics.Vulkan
             }
 
             return segments;
+        }
+
+        private DescriptorSetTemplate[] BuildTemplates()
+        {
+            var templates = new DescriptorSetTemplate[BindingSegments.Length];
+
+            if (!HasMinimalLayout) // or if unsupported...
+            {
+                for (int setIndex = 0; setIndex < BindingSegments.Length; setIndex++)
+                {
+                    ResourceBindingSegment[] segments = BindingSegments[setIndex];
+
+                    if (segments != null && segments.Length > 0)
+                    {
+                        templates[setIndex] = new DescriptorSetTemplate(_gd, _device, segments, _plce, IsCompute ? PipelineBindPoint.Compute : PipelineBindPoint.Graphics, setIndex);
+                    }
+                }
+            }
+
+            return templates;
         }
 
         private async Task BackgroundCompilation()
@@ -502,6 +524,11 @@ namespace Ryujinx.Graphics.Vulkan
                     {
                         pipeline.Dispose();
                     }
+                }
+
+                for (int i = 0; i < Templates.Length; i++)
+                {
+                    Templates[i]?.Dispose();
                 }
 
                 if (_dummyRenderPass.Value.Handle != 0)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.Graphics.Vulkan
         public const bool UseFastBufferUpdates = true;
         public const bool UseUnsafeBlit = true;
         public const bool UsePushDescriptors = false;
+        public const bool UseDescriptorUpdateTemplates = true;
 
         public const bool ForceD24S8Unsupported = false;
         public const bool ForceRGB16IntFloatUnsupported = false;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
@@ -5,7 +5,6 @@ namespace Ryujinx.Graphics.Vulkan
         public const bool UseFastBufferUpdates = true;
         public const bool UseUnsafeBlit = true;
         public const bool UsePushDescriptors = false;
-        public const bool UseDescriptorUpdateTemplates = true;
 
         public const bool ForceD24S8Unsupported = false;
         public const bool ForceRGB16IntFloatUnsupported = false;


### PR DESCRIPTION
This PR changes the descriptor updater to use descriptor update templates unique to each program. A descriptor update template describes all of the descriptor fields that will be updated at the same time, and how their values will be laid out in memory. Each template defines one subset of descriptors that will be updated, you can't omit or add any without creating another template. This makes sense for us, since we always update all descriptors that are used for a program when updating a descriptor set (as we don't keep track of its existing state).

The descriptors are assumed to update in segment order, and be back to back in memory. There's a simple class for pushing data into a native array that can then be submitted as part of a descriptor update.

The old code for non-templated updates is still present as a VulkanConfiguration switch, though it should be supported by all Vulkan 1.1 conformant drivers. I originally left this in in case the change to how null buffer textures are handled breaks anything and needs templates to be disabled... I guess it's worth testing UE4 games across a variety of platforms to see if that difference causes any issues.

I'm not sure if we should just remove the non-template path if this pans out. It would simplify DescriptorSetUpdater a little and remove a bunch of methods from DescriptorSetCollection.

## Improves
AMD Mesa (Linux)

## Very small improvment (benchmarks imply, at least)
NVIDIA

## Unknown
AMD (Windows)
Intel (Mesa/Windows)
Apple (MacOS)