### PR TITLE
[macOS] Correctly set filetypes in Info.plist

### DIFF
--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -10,14 +10,25 @@
     <string>Ryujinx</string>
     <key>CFBundleIconFile</key>
     <string>Ryujinx.icns</string>
-    <key>CFBundleTypeExtensions</key>
-    <array>
-        <string>nca</string>
-        <string>nro</string>
-        <string>nso</string>
-        <string>nsp</string>
-        <string>xci</string>
-    </array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>nca</string>
+				<string>nro</string>
+				<string>nso</string>
+				<string>nsp</string>
+				<string>xci</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Nintendo Switch File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+		</dict>
+	</array>
     <key>CFBundleIdentifier</key>
     <string>org.ryujinx.Ryujinx</string>
     <key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
Currently the filetype association is not working: 

<img width="234" alt="Screenshot 2023-12-09 at 14 55 54" src="https://github.com/Ryujinx/Ryujinx/assets/50119606/f765bffc-c61d-4f60-a045-514d0af1b486">

This should hopefully fix it. 

Testing: 

- [ ] Check that Finder correctly associates `nca`, `nro`, `nso`, `nsp` and `xci` files with Ryujinx. 
An example on how it should look: 
<img width="227" alt="Screenshot 2023-12-09 at 13 16 20" src="https://github.com/Ryujinx/Ryujinx/assets/50119606/8f9206cc-ec4f-42de-a951-b5e5abd322f3">
