### PR TITLE
Input: Improve controller identification

### DIFF
--- a/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -138,7 +138,6 @@ namespace Ryujinx.Input.SDL2
                     OnGamepadDisconnected?.Invoke(id);
                 }
 
-
                 lock (_lock)
                 {
                     _gamepadsIds.Clear();

--- a/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -9,8 +9,18 @@ namespace Ryujinx.Input.SDL2
     {
         private readonly Dictionary<int, string> _gamepadsInstanceIdsMapping;
         private readonly List<string> _gamepadsIds;
+        private readonly object _lock = new object();
 
-        public ReadOnlySpan<string> GamepadsIds => _gamepadsIds.ToArray();
+        public ReadOnlySpan<string> GamepadsIds
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _gamepadsIds.ToArray();
+                }
+            }
+        }
 
         public string DriverName => "SDL2";
 
@@ -35,28 +45,39 @@ namespace Ryujinx.Input.SDL2
             }
         }
 
-        private static string GenerateGamepadId(int joystickIndex)
+        private string GenerateGamepadId(int joystickIndex)
         {
             Guid guid = SDL_JoystickGetDeviceGUID(joystickIndex);
+
+            // Add a unique identifier to the start of the GUID in case of duplicates.
 
             if (guid == Guid.Empty)
             {
                 return null;
             }
 
-            return joystickIndex + "-" + guid;
-        }
+            string id;
 
-        private static int GetJoystickIndexByGamepadId(string id)
-        {
-            string[] data = id.Split("-");
-
-            if (data.Length != 6 || !int.TryParse(data[0], out int joystickIndex))
+            lock (_lock)
             {
-                return -1;
+                int guidIndex = 0;
+                id = guidIndex + "-" + guid;
+
+                while (_gamepadsIds.Contains(id))
+                {
+                    id = (++guidIndex) + "-" + guid;
+                }
             }
 
-            return joystickIndex;
+            return id;
+        }
+
+        private int GetJoystickIndexByGamepadId(string id)
+        {
+            lock (_lock)
+            {
+                return _gamepadsIds.IndexOf(id);
+            }
         }
 
         private void HandleJoyStickDisconnected(int joystickInstanceId)
@@ -64,7 +85,11 @@ namespace Ryujinx.Input.SDL2
             if (_gamepadsInstanceIdsMapping.TryGetValue(joystickInstanceId, out string id))
             {
                 _gamepadsInstanceIdsMapping.Remove(joystickInstanceId);
-                _gamepadsIds.Remove(id);
+
+                lock (_lock)
+                {
+                    _gamepadsIds.Remove(id);
+                }
 
                 OnGamepadDisconnected?.Invoke(id);
             }
@@ -74,6 +99,13 @@ namespace Ryujinx.Input.SDL2
         {
             if (SDL_IsGameController(joystickDeviceId) == SDL_bool.SDL_TRUE)
             {
+                if (_gamepadsInstanceIdsMapping.ContainsKey(joystickInstanceId))
+                {
+                    // Sometimes a JoyStick connected event fires after the app starts even though it was connected before
+                    // so it is rejected to avoid doubling the entries.
+                    return;
+                }
+
                 string id = GenerateGamepadId(joystickDeviceId);
 
                 if (id == null)
@@ -81,16 +113,12 @@ namespace Ryujinx.Input.SDL2
                     return;
                 }
 
-                // Sometimes a JoyStick connected event fires after the app starts even though it was connected before
-                // so it is rejected to avoid doubling the entries.
-                if (_gamepadsIds.Contains(id))
-                {
-                    return;
-                }
-
                 if (_gamepadsInstanceIdsMapping.TryAdd(joystickInstanceId, id))
                 {
-                    _gamepadsIds.Add(id);
+                    lock (_lock)
+                    {
+                        _gamepadsIds.Add(id);
+                    }
 
                     OnGamepadConnected?.Invoke(id);
                 }
@@ -110,7 +138,11 @@ namespace Ryujinx.Input.SDL2
                     OnGamepadDisconnected?.Invoke(id);
                 }
 
-                _gamepadsIds.Clear();
+
+                lock (_lock)
+                {
+                    _gamepadsIds.Clear();
+                }
 
                 SDL2Driver.Instance.Dispose();
             }
@@ -127,11 +159,6 @@ namespace Ryujinx.Input.SDL2
             int joystickIndex = GetJoystickIndexByGamepadId(id);
 
             if (joystickIndex == -1)
-            {
-                return null;
-            }
-
-            if (id != GenerateGamepadId(joystickIndex))
             {
                 return null;
             }


### PR DESCRIPTION
Controllers were identified before by a combination of their _global_ index in the list of controllers and their GUID. The problem is, disconnecting and reconnecting a controller can change its global index; the controller can appear at the end when it was originally at the start. This would give it another ID, and the controller would need to be reconfigured.

This happened to me a lot with a switch pro controller and a USB game controller, it was essentially random which appeared first, and sometimes I had to pull cables or reconfigure the controllers. Now, it consistently detects them.

This PR changes the controller identification to be a combination of an index of controllers with the same GUID (generally 0), and its GUID. It also reworks managing the list of controllers to properly consider instance IDs.

This also changes the NpadManager to attempt to reuse old controllers when refreshing input configuration, which can prevent input from going dead for seconds whenever an unrelated controller connects or disconnects (and the switch pro controller just entirely dying).

Testing with different controller types, OS and Avalonia is welcome. Remember that the target is connecting a ton of controllers, and pulling/reconnecting them.