### PR TITLE
#6040 Fix issues with Invert X / Y and Rotate when mapping different physical stick to JoyCon logical stick

### DIFF
--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -313,6 +313,33 @@ namespace Ryujinx.Input.SDL2
             return value * ConvertRate;
         }
 
+        private JoyconConfigControllerStick<GamepadInputId, Common.Configuration.Hid.Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId) 
+        {
+            switch(inputId) 
+            {
+                case StickInputId.Left:
+                    if (_configuration.RightJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Left)
+                    {
+                        return _configuration.RightJoyconStick;
+                    }
+                    else
+                    { 
+                        return _configuration.LeftJoyconStick;
+                    }
+                case StickInputId.Right:
+                    if (_configuration.LeftJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Right)
+                    {
+                        return _configuration.LeftJoyconStick;
+                    } 
+                    else
+                    {
+                        return _configuration.RightJoyconStick;
+                    }
+            }
+
+            return null;
+        }
+
         public (float, float) GetStick(StickInputId inputId)
         {
             if (inputId == StickInputId.Unbound)
@@ -343,24 +370,19 @@ namespace Ryujinx.Input.SDL2
 
             if (HasConfiguration)
             {
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.InvertStickX) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.InvertStickX))
-                {
-                    resultX = -resultX;
-                }
+                var joyconStickConfig = GetLogicalJoyStickConfig(inputId);
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.InvertStickY) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.InvertStickY))
+                if (joyconStickConfig != null)
                 {
-                    resultY = -resultY;
-                }
+                    if (joyconStickConfig.InvertStickX) resultX = -resultX;
+                    if (joyconStickConfig.InvertStickY) resultY = -resultY;
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.Rotate90CW) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.Rotate90CW))
-                {
-                    float temp = resultX;
-                    resultX = resultY;
-                    resultY = -temp;
+                    if (joyconStickConfig.Rotate90CW)
+                    {
+                        float temp = resultX;
+                        resultX = resultY;
+                        resultY = -temp;
+                    }
                 }
             }
 


### PR DESCRIPTION
Ensure the Invert X / Y and Rotate stick configuration is used based on the logical mapped stick instead of the physical stick. This change addresses Bug #6040 .