### PR TITLE
Fix PPTC version string for firmware titles

### DIFF
--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
@@ -356,11 +356,22 @@ namespace Ryujinx.HLE.Loaders.Processes
                 return ProcessResult.Failed;
             }
 
+            string displayVersion;
+
+            if (metaLoader.GetProgramId() > 0x0100000000007FFF)
+            {
+                displayVersion = applicationControlProperties.Value.DisplayVersionString.ToString();
+            }
+            else
+            {
+                displayVersion = device.System.ContentManager.GetCurrentFirmwareVersion()?.VersionString ?? string.Empty;
+            }
+
             var processContextFactory = new ArmProcessContextFactory(
                 context.Device.System.TickSource,
                 context.Device.Gpu,
                 $"{programId:x16}",
-                applicationControlProperties.Value.DisplayVersionString.ToString(),
+                displayVersion,
                 diskCacheEnabled,
                 codeStart,
                 codeSize);


### PR DESCRIPTION
We can't get the version string from the nacp for firmware titles (it is empty), instead use the firmware version. This fixes an issue where changing firmware version would cause games using the JIT service to crash, because it would load the PPTC cache from the previous firmware version, which is not compatible with the new firmware binary.

This is likely a regression caused by the refactoring around that code some time ago.

Fixes #6021.