### PR TITLE
Fix vertex buffer size when switching between inline and state draw parameters

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -103,6 +103,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// <param name="argument">Method call argument</param>
         public void DrawEnd(ThreedClass engine, int argument)
         {
+            _drawState.DrawUsesEngineState = true;
+
             DrawEnd(
                 engine,
                 _state.State.IndexBufferState.First,
@@ -205,10 +207,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             }
             else
             {
-#pragma warning disable IDE0059 // Remove unnecessary value assignment
-                var drawState = _state.State.VertexBufferDrawState;
-#pragma warning restore IDE0059
-
                 DrawImpl(engine, drawVertexCount, 1, 0, drawFirstVertex, firstInstance, indexed: false);
             }
 
@@ -379,6 +377,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             bool oldDrawIndexed = _drawState.DrawIndexed;
 
             _drawState.DrawIndexed = true;
+            _drawState.DrawUsesEngineState = false;
             engine.ForceStateDirty(IndexBufferCountMethodOffset * 4);
 
             DrawEnd(engine, firstIndex, indexCount, 0, 0);
@@ -424,6 +423,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             bool oldDrawIndexed = _drawState.DrawIndexed;
 
             _drawState.DrawIndexed = false;
+            _drawState.DrawUsesEngineState = false;
             engine.ForceStateDirty(VertexBufferFirstMethodOffset * 4);
 
             DrawEnd(engine, 0, 0, firstVertex, vertexCount);
@@ -544,6 +544,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             _state.State.FirstInstance = (uint)firstInstance;
 
             _drawState.DrawIndexed = indexed;
+            _drawState.DrawUsesEngineState = true;
             _currentSpecState.SetHasConstantBufferDrawParameters(true);
 
             engine.UpdateState();
@@ -676,6 +677,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _drawState.DrawIndexed = indexed;
             _drawState.DrawIndirect = true;
+            _drawState.DrawUsesEngineState = true;
             _currentSpecState.SetHasConstantBufferDrawParameters(true);
 
             engine.UpdateState();

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawState.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Shader;
 
 namespace Ryujinx.Graphics.Gpu.Engine.Threed

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawState.cs
@@ -1,4 +1,4 @@
-using Ryujinx.Graphics.GAL;
+﻿using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Shader;
 
 namespace Ryujinx.Graphics.Gpu.Engine.Threed
@@ -39,6 +39,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public bool DrawIndirect;
 
         /// <summary>
+        /// Indicates that the draw is using the draw parameters on the 3D engine state, rather than inline parameters submitted with the draw command.
+        /// </summary>
+        public bool DrawUsesEngineState;
+
+        /// <summary>
         /// Indicates if any of the currently used vertex shaders reads the instance ID.
         /// </summary>
         public bool VsUsesInstanceId;
@@ -47,11 +52,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Indicates if any of the currently used vertex buffers is instanced.
         /// </summary>
         public bool IsAnyVbInstanced;
-
-        /// <summary>
-        /// Indicates that the draw is writing the base vertex, base instance and draw index to Constant Buffer 0.
-        /// </summary>
-        public bool HasConstantBufferDrawParameters;
 
         /// <summary>
         /// Primitive topology for the next draw.

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Common.Logging;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Threed.Blender;
 using Ryujinx.Graphics.Gpu.Engine.Types;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -1,4 +1,4 @@
-using Ryujinx.Common.Logging;
+﻿using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Threed.Blender;
 using Ryujinx.Graphics.Gpu.Engine.Types;
@@ -47,7 +47,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         private uint _vbEnableMask;
 
         private bool _prevDrawIndexed;
-        private readonly bool _prevDrawIndirect;
+        private bool _prevDrawIndirect;
+        private bool _prevDrawUsesEngineState;
         private IndexType _prevIndexType;
         private uint _prevFirstVertex;
         private bool _prevTfEnable;
@@ -236,7 +237,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             // method when doing indexed draws, so we need to make sure
             // to update the vertex buffers if we are doing a regular
             // draw after a indexed one and vice-versa.
-            if (_drawState.DrawIndexed != _prevDrawIndexed)
+            // Some draws also do not update the engine state, so it is possible for it
+            // to not be dirty even if the vertex counts or other state changed. We need to force it to be dirty in this case.
+            if (_drawState.DrawIndexed != _prevDrawIndexed || _drawState.DrawUsesEngineState != _prevDrawUsesEngineState)
             {
                 _updateTracker.ForceDirty(VertexBufferStateIndex);
 
@@ -251,6 +254,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 }
 
                 _prevDrawIndexed = _drawState.DrawIndexed;
+                _prevDrawUsesEngineState = _drawState.DrawUsesEngineState;
             }
 
             // Some draw parameters are used to restrict the vertex buffer size,
@@ -260,6 +264,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             if (_drawState.DrawIndirect != _prevDrawIndirect)
             {
                 _updateTracker.ForceDirty(VertexBufferStateIndex);
+
+                _prevDrawIndirect = _drawState.DrawIndirect;
             }
 
             // In some cases, the index type is also used to guess the


### PR DESCRIPTION
Some draw commands have passes the parameters (such as vertex count as first vertex) "inline", and does not modify 3D engine state. This currently causes a problem, where the vertex buffer sizes are calculated using the new inline vertex count, but when a draw using 3D engine state happens, it does not detect the count as being modified (since the inline draw did not modify it), and keeps using the previous vertex buffer size.

This PR fixes the issue by forcing a vertex buffer update when switching between inline and state parameter draws.

Fixes rendering on Citizens of Space (it was using the wrong vertex buffer size for a specific draw, and last vertex was 0 as a result).

Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/fab928e9-a72c-4388-8f95-d3ac910fa534)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/3c7a7d8f-9b2a-4f55-b75c-3a8a9326ffa8)

Fixes #5974.
Testing is welcome.
