### PR TITLE
Fix Amiibo regression and some minor code improvements

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -440,10 +440,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                     try
                     {
-                        using (FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
-                        {
-                            dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
-                        }
+                        using FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough);
+                        dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
                     }
                     catch (Exception exception)
                     {

--- a/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -191,6 +191,13 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         private static bool TryGetAmiiboJson(string json, out AmiiboJson amiiboJson)
         {
+            if (string.IsNullOrEmpty(json))
+            {
+                amiiboJson = JsonHelper.Deserialize(DefaultJson, _serializerContext.AmiiboJson);
+
+                return false;
+            }
+
             try
             {
                 amiiboJson = JsonHelper.Deserialize(json, _serializerContext.AmiiboJson);
@@ -214,7 +221,10 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             try
             {
-                localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
+                if (File.Exists(_amiiboJsonPath))
+                {
+                    localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
+                }
 
                 if (!localIsValid || await NeedsUpdate(amiiboJson.LastUpdated))
                 {
@@ -394,11 +404,18 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         private async Task<bool> NeedsUpdate(DateTime oldLastModified)
         {
-            HttpResponseMessage response = await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, "https://amiibo.ryujinx.org/"));
-
-            if (response.IsSuccessStatusCode)
+            try
             {
-                return response.Content.Headers.LastModified != oldLastModified;
+                HttpResponseMessage response = await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, "https://amiibo.ryujinx.org/"));
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return response.Content.Headers.LastModified != oldLastModified;
+                }
+            }
+            catch (HttpRequestException exception)
+            {
+                Logger.Error?.Print(LogClass.Application, $"Unable to check for amiibo data updates: {exception}");
             }
 
             return false;
@@ -406,21 +423,28 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         private async Task<string> DownloadAmiiboJson()
         {
-            HttpResponseMessage response = await _httpClient.GetAsync("https://amiibo.ryujinx.org/");
-
-            if (response.IsSuccessStatusCode)
+            try
             {
-                string amiiboJsonString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await _httpClient.GetAsync("https://amiibo.ryujinx.org/");
 
-                using (FileStream amiiboJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
+                if (response.IsSuccessStatusCode)
                 {
-                    amiiboJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
+                    string amiiboJsonString = await response.Content.ReadAsStringAsync();
+
+                    using (FileStream amiiboJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
+                    {
+                        amiiboJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
+                    }
+
+                    return amiiboJsonString;
                 }
 
-                return amiiboJsonString;
+                Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data. Response status code: {response.StatusCode}");
             }
-
-            Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data. Response status code: {response.StatusCode}");
+            catch (HttpRequestException exception)
+            {
+                Logger.Error?.Print(LogClass.Application, $"Failed to request amiibo data: {exception}");
+            }
 
             await ContentDialogHelper.CreateInfoDialog(LocaleManager.Instance[LocaleKeys.DialogAmiiboApiTitle],
                 LocaleManager.Instance[LocaleKeys.DialogAmiiboApiFailFetchMessage],
@@ -428,9 +452,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 "",
                 LocaleManager.Instance[LocaleKeys.RyujinxInfo]);
 
-            Close();
-
-            return DefaultJson;
+            return null;
         }
 
         private void Close()

--- a/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -188,17 +188,17 @@ namespace Ryujinx.Ava.UI.ViewModels
             _httpClient.Dispose();
         }
 
-        private bool TryGetAmiiboJson(string json, out AmiiboJson amiiboJson)
+        private static bool TryGetAmiiboJson(string json, out AmiiboJson amiiboJson)
         {
             try
             {
-                amiiboJson = JsonHelper.Deserialize<AmiiboJson>(json, _serializerContext.AmiiboJson);
+                amiiboJson = JsonHelper.Deserialize(json, _serializerContext.AmiiboJson);
 
                 return true;
             }
             catch
             {
-                amiiboJson = JsonHelper.Deserialize<AmiiboJson>(DefaultJson, _serializerContext.AmiiboJson);
+                amiiboJson = JsonHelper.Deserialize(DefaultJson, _serializerContext.AmiiboJson);
 
                 return false;
             }
@@ -208,11 +208,11 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             bool localIsValid = false;
             bool remoteIsValid = false;
-            AmiiboJson amiiboJson = JsonHelper.Deserialize<AmiiboJson>(DefaultJson, _serializerContext.AmiiboJson);
+            AmiiboJson amiiboJson = new();
 
             try
             {
-                localIsValid = TryGetAmiiboJson(File.ReadAllText(_amiiboJsonPath), out amiiboJson);
+                localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
 
                 if (!localIsValid || await NeedsUpdate(amiiboJson.LastUpdated))
                 {

--- a/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -221,9 +221,16 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             try
             {
-                if (File.Exists(_amiiboJsonPath))
+                try
                 {
-                    localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
+                    if (File.Exists(_amiiboJsonPath))
+                    {
+                        localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Logger.Warning?.Print(LogClass.Application, $"Unable to read data from '{_amiiboJsonPath}': {exception}");
                 }
 
                 if (!localIsValid || await NeedsUpdate(amiiboJson.LastUpdated))
@@ -431,9 +438,16 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     string amiiboJsonString = await response.Content.ReadAsStringAsync();
 
-                    using (FileStream amiiboJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
+                    try
                     {
-                        amiiboJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
+                        using (FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
+                        {
+                            dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        Logger.Warning?.Print(LogClass.Application, $"Couldn't write amiibo data to file '{_amiiboJsonPath}: {exception}'");
                     }
 
                     return amiiboJsonString;

--- a/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Ryujinx.Ava.UI.ViewModels
@@ -196,8 +197,9 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 return true;
             }
-            catch
+            catch (JsonException exception)
             {
+                Logger.Error?.Print(LogClass.Application, $"Unable to deserialize amiibo data: {exception}");
                 amiiboJson = JsonHelper.Deserialize(DefaultJson, _serializerContext.AmiiboJson);
 
                 return false;
@@ -219,16 +221,20 @@ namespace Ryujinx.Ava.UI.ViewModels
                     remoteIsValid = TryGetAmiiboJson(await DownloadAmiiboJson(), out amiiboJson);
                 }
             }
-            catch
+            catch (Exception exception)
             {
                 if (!(localIsValid || remoteIsValid))
                 {
+                    Logger.Error?.Print(LogClass.Application, $"Couldn't get valid amiibo data: {exception}");
+
                     // Neither local or remote files are valid JSON, close window.
                     ShowInfoDialog();
                     Close();
                 }
                 else if (!remoteIsValid)
                 {
+                    Logger.Warning?.Print(LogClass.Application, $"Couldn't update amiibo data: {exception}");
+
                     // Only the local file is valid, the local one should be used
                     // but the user should be warned.
                     ShowInfoDialog();

--- a/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Window = Gtk.Window;
 
@@ -82,8 +83,9 @@ namespace Ryujinx.Ui.Windows
 
                 return true;
             }
-            catch
+            catch (JsonException exception)
             {
+                Logger.Error?.Print(LogClass.Application, $"Unable to deserialize amiibo data: {exception}");
                 amiiboJson = JsonHelper.Deserialize(DefaultJson, _serializerContext.AmiiboJson);
 
                 return false;
@@ -105,16 +107,20 @@ namespace Ryujinx.Ui.Windows
                     remoteIsValid = TryGetAmiiboJson(await DownloadAmiiboJson(), out amiiboJson);
                 }
             }
-            catch
+            catch (Exception exception)
             {
                 if (!(localIsValid || remoteIsValid))
                 {
+                    Logger.Error?.Print(LogClass.Application, $"Couldn't get valid amiibo data: {exception}");
+
                     // Neither local or remote files are valid JSON, close window.
                     ShowInfoDialog();
                     Close();
                 }
                 else if (!remoteIsValid)
                 {
+                    Logger.Warning?.Print(LogClass.Application, $"Couldn't update amiibo data: {exception}");
+
                     // Only the local file is valid, the local one should be used
                     // but the user should be warned.
                     ShowInfoDialog();

--- a/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -250,10 +250,8 @@ namespace Ryujinx.Ui.Windows
 
                     try
                     {
-                        using (FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
-                        {
-                            dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
-                        }
+                        using FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough);
+                        dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
                     }
                     catch (Exception exception)
                     {

--- a/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -107,9 +107,16 @@ namespace Ryujinx.Ui.Windows
 
             try
             {
-                if (File.Exists(_amiiboJsonPath))
+                try
                 {
-                    localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
+                    if (File.Exists(_amiiboJsonPath))
+                    {
+                        localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Logger.Warning?.Print(LogClass.Application, $"Unable to read data from '{_amiiboJsonPath}': {exception}");
                 }
 
                 if (!localIsValid || await NeedsUpdate(amiiboJson.LastUpdated))
@@ -241,9 +248,16 @@ namespace Ryujinx.Ui.Windows
                 {
                     string amiiboJsonString = await response.Content.ReadAsStringAsync();
 
-                    using (FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
+                    try
                     {
-                        dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
+                        using (FileStream dlcJsonStream = File.Create(_amiiboJsonPath, 4096, FileOptions.WriteThrough))
+                        {
+                            dlcJsonStream.Write(Encoding.UTF8.GetBytes(amiiboJsonString));
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        Logger.Warning?.Print(LogClass.Application, $"Couldn't write amiibo data to file '{_amiiboJsonPath}: {exception}'");
                     }
 
                     return amiiboJsonString;


### PR DESCRIPTION
This PR fixes a regression from 1.1.1102 (#3681) by making sure `Amiibo.json` exists before we try to read it.

This PR also addresses a few other issues in the Amiibo loading code:

- We now actually log the exceptions, so it's easier to help with or debug issues.
- Instead of closing the dialog when aren't able to download Amiibo data, we now show the successfully parsed local `Amiibo.json` data to the user.
- A few more try/catch statements have been added, so we still parse the local `Amiibo.json` in case one of the HTTP requests threw an exception before.

---

Fixes #6094