### PR TITLE
Switch to `Microsoft.IdentityModel.JsonWebTokens`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="LibHac" Version="0.19.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
@@ -46,7 +47,6 @@
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageVersion Include="SPB" Version="0.0.4-build28" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Management" Version="8.0.0" />
     <PackageVersion Include="UnicornEngine.Unicorn" Version="2.0.2-rc1-fb78016" />

--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -1,5 +1,5 @@
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Account.Acc.AsyncContext;

--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -1,10 +1,12 @@
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Account.Acc.AsyncContext;
 using System;
-using System.IdentityModel.Tokens.Jwt;
+using System.Collections.Generic;
 using System.Security.Cryptography;
+using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,11 +39,6 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
             credentials.Key.KeyId = parameters.ToString();
 
-            var header = new JwtHeader(credentials)
-            {
-                { "jku", "https://e0d67c509fb203858ebcb2fe3f88c2aa.baas.nintendo.com/1.0.0/certificates" },
-            };
-
             byte[] rawUserId = new byte[0x10];
             RandomNumberGenerator.Fill(rawUserId);
 
@@ -51,23 +48,25 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             byte[] deviceAccountId = new byte[0x10];
             RandomNumberGenerator.Fill(deviceId);
 
-            var payload = new JwtPayload
+            var descriptor = new SecurityTokenDescriptor
             {
-                { "sub", Convert.ToHexString(rawUserId).ToLower() },
-                { "aud", "ed9e2f05d286f7b8" },
-                { "di", Convert.ToHexString(deviceId).ToLower() },
-                { "sn", "XAW10000000000" },
-                { "bs:did", Convert.ToHexString(deviceAccountId).ToLower() },
-                { "iss", "https://e0d67c509fb203858ebcb2fe3f88c2aa.baas.nintendo.com" },
-                { "typ", "id_token" },
-                { "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() },
-                { "jti", Guid.NewGuid().ToString() },
-                { "exp", (DateTimeOffset.UtcNow + TimeSpan.FromHours(3)).ToUnixTimeSeconds() },
+                Subject = new GenericIdentity(Convert.ToHexString(rawUserId).ToLower()),
+                SigningCredentials = credentials,
+                Audience = "ed9e2f05d286f7b8",
+                Issuer = "https://e0d67c509fb203858ebcb2fe3f88c2aa.baas.nintendo.com",
+                TokenType = "id_token",
+                IssuedAt = DateTime.UtcNow,
+                Expires = DateTime.UtcNow + TimeSpan.FromHours(3),
+                Claims = new Dictionary<string, object>
+                {
+                    { "jku", "https://e0d67c509fb203858ebcb2fe3f88c2aa.baas.nintendo.com/1.0.0/certificates" },
+                    { "di", Convert.ToHexString(deviceId).ToLower() },
+                    { "sn", "XAW10000000000" },
+                    { "bs:did", Convert.ToHexString(deviceAccountId).ToLower() }
+                }
             };
 
-            JwtSecurityToken securityToken = new(header, payload);
-
-            return new JwtSecurityTokenHandler().WriteToken(securityToken);
+            return new JsonWebTokenHandler().CreateToken(descriptor);
         }
 
         public ResultCode CheckAvailability(ServiceCtx context)

--- a/src/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/src/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -23,10 +23,10 @@
   <ItemGroup>
     <PackageReference Include="Concentus" />
     <PackageReference Include="LibHac" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="MsgPack.Cli" />
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="NetCoreServer" />
   </ItemGroup>
 


### PR DESCRIPTION
Replaces deprecated and vulnerable `System.IdentityModel.Tokens.Jwt` 7.0.3 with `Microsoft.IdentityModel.JsonWebTokens` 7.2.0.

---

- Fixes GHSA-59j7-ghrg-fj52
- Fixes GHSA-8g9c-28fc-mcx2