### PR TITLE
Change shader cache init wait method

### DIFF
--- a/src/ARMeilleure/Translation/Translator.cs
+++ b/src/ARMeilleure/Translation/Translator.cs
@@ -57,9 +57,6 @@ namespace ARMeilleure.Translation
         private Thread[] _backgroundTranslationThreads;
         private volatile int _threadCount;
 
-        // FIXME: Remove this once the init logic of the emulator will be redone.
-        public static readonly ManualResetEvent IsReadyForTranslation = new(false);
-
         public Translator(IJitMemoryAllocator allocator, IMemoryManager memory, bool for64Bits)
         {
             _allocator = allocator;
@@ -105,8 +102,6 @@ namespace ARMeilleure.Translation
         {
             if (Interlocked.Increment(ref _threadCount) == 1)
             {
-                IsReadyForTranslation.WaitOne();
-
                 if (_ptc.State == PtcState.Enabled)
                 {
                     Debug.Assert(Functions.Count == 0);

--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -916,7 +915,6 @@ namespace Ryujinx.Ava
             {
                 Device.Gpu.SetGpuThread();
                 Device.Gpu.InitializeShaderCache(_gpuCancellationTokenSource.Token);
-                Translator.IsReadyForTranslation.Set();
 
                 _renderer.Window.ChangeVSyncMode(Device.EnableDeviceVsync);
 

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -106,6 +106,8 @@ namespace Ryujinx.Graphics.Gpu
         private long _modifiedSequence;
         private readonly ulong _firstTimestamp;
 
+        private ManualResetEvent _gpuReadyEvent;
+
         /// <summary>
         /// Creates a new instance of the GPU emulation context.
         /// </summary>
@@ -121,6 +123,7 @@ namespace Ryujinx.Graphics.Gpu
             Window = new Window(this);
 
             HostInitalized = new ManualResetEvent(false);
+            _gpuReadyEvent = new ManualResetEvent(false);
 
             SyncActions = new List<ISyncActionHandler>();
             SyncpointActions = new List<ISyncActionHandler>();
@@ -216,7 +219,7 @@ namespace Ryujinx.Graphics.Gpu
         /// Gets a sequence number for resource modification ordering. This increments on each call.
         /// </summary>
         /// <returns>A sequence number for resource modification ordering</returns>
-        public long GetModifiedSequence()
+        internal long GetModifiedSequence()
         {
             return _modifiedSequence++;
         }
@@ -225,7 +228,7 @@ namespace Ryujinx.Graphics.Gpu
         /// Gets the value of the GPU timer.
         /// </summary>
         /// <returns>The current GPU timestamp</returns>
-        public ulong GetTimestamp()
+        internal ulong GetTimestamp()
         {
             // Guest timestamp will start at 0, instead of host value.
             ulong ticks = ConvertNanosecondsToTicks((ulong)PerformanceCounter.ElapsedNanoseconds) - _firstTimestamp;
@@ -262,6 +265,16 @@ namespace Ryujinx.Graphics.Gpu
             {
                 physicalMemory.ShaderCache.Initialize(cancellationToken);
             }
+
+            _gpuReadyEvent.Set();
+        }
+
+        /// <summary>
+        /// Waits until the GPU is ready to receive commands.
+        /// </summary>
+        public void WaitUntilGpuReady()
+        {
+            _gpuReadyEvent.WaitOne();
         }
 
         /// <summary>
@@ -399,6 +412,7 @@ namespace Ryujinx.Graphics.Gpu
         {
             GPFifo.Dispose();
             HostInitalized.Dispose();
+            _gpuReadyEvent.Dispose();
 
             // Has to be disposed before processing deferred actions, as it will produce some.
             foreach (var physicalMemory in PhysicalMemoryRegistry.Values)

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -106,7 +106,7 @@ namespace Ryujinx.Graphics.Gpu
         private long _modifiedSequence;
         private readonly ulong _firstTimestamp;
 
-        private ManualResetEvent _gpuReadyEvent;
+        private readonly ManualResetEvent _gpuReadyEvent;
 
         /// <summary>
         /// Creates a new instance of the GPU emulation context.

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -161,7 +161,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     _graphicsShaderCache,
                     _computeShaderCache,
                     _diskCacheHostStorage,
-                    ShaderCacheStateUpdate, cancellationToken);
+                    ShaderCacheStateUpdate,
+                    cancellationToken);
 
                 loader.LoadShaders();
 

--- a/src/Ryujinx.HLE/HOS/ArmProcessContext.cs
+++ b/src/Ryujinx.HLE/HOS/ArmProcessContext.cs
@@ -57,6 +57,8 @@ namespace Ryujinx.HLE.HOS
 
         public void Execute(IExecutionContext context, ulong codeAddress)
         {
+            // We must wait until shader cache is loaded, among other things, before executing CPU code.
+            _gpuContext.WaitUntilGpuReady();
             _cpuContext.Execute(context, codeAddress);
         }
 

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation;
 using CommandLine;
 using LibHac.Tools.FsSystem;
 using Ryujinx.Audio.Backends.SDL2;
@@ -710,9 +709,6 @@ namespace Ryujinx.Headless.SDL2
             }
 
             SetupProgressHandler();
-
-            Translator.IsReadyForTranslation.Reset();
-
             ExecutionEntrypoint();
 
             return true;

--- a/src/Ryujinx.Headless.SDL2/WindowBase.cs
+++ b/src/Ryujinx.Headless.SDL2/WindowBase.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Logging;
@@ -276,7 +275,6 @@ namespace Ryujinx.Headless.SDL2
             {
                 Device.Gpu.SetGpuThread();
                 Device.Gpu.InitializeShaderCache(_gpuCancellationTokenSource.Token);
-                Translator.IsReadyForTranslation.Set();
 
                 while (_isActive)
                 {

--- a/src/Ryujinx.Tests/Cpu/CpuTest.cs
+++ b/src/Ryujinx.Tests/Cpu/CpuTest.cs
@@ -61,7 +61,6 @@ namespace Ryujinx.Tests.Cpu
             _memory.Map(DataBaseAddress, Size, Size, MemoryMapFlags.Private);
 
             _context = CpuContext.CreateExecutionContext();
-            Translator.IsReadyForTranslation.Set();
 
             _cpuContext = new CpuContext(_memory, for64Bit: true);
 

--- a/src/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/src/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -56,7 +56,6 @@ namespace Ryujinx.Tests.Cpu
 
             _context = CpuContext.CreateExecutionContext();
             _context.IsAarch32 = true;
-            Translator.IsReadyForTranslation.Set();
 
             _cpuContext = new CpuContext(_memory, for64Bit: false);
 

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation;
 using Gtk;
 using LibHac.Common;
 using LibHac.Common.Keys;
@@ -930,8 +929,6 @@ namespace Ryujinx.Ui
                 _currentEmulatedGamePath = path;
 
                 _deviceExitStatus.Reset();
-
-                Translator.IsReadyForTranslation.Reset();
 
                 Thread windowThread = new(CreateGameWindow)
                 {

--- a/src/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/src/Ryujinx/Ui/RendererWidgetBase.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation;
 using Gdk;
 using Gtk;
 using Ryujinx.Common;
@@ -450,7 +449,6 @@ namespace Ryujinx.Ui
             {
                 Device.Gpu.SetGpuThread();
                 Device.Gpu.InitializeShaderCache(_gpuCancellationTokenSource.Token);
-                Translator.IsReadyForTranslation.Set();
 
                 Renderer.Window.ChangeVSyncMode(Device.EnableDeviceVsync);
 


### PR DESCRIPTION
We current have a static field event on `ARMeilleure.Translator`, which is initially unsignaled, and we signal it once shader cache load is finished. This prevents the game from running before the shader cache has been loaded, but there are many problems with it:
- It is not reset consistently across UI, only GTK seems to reset it, which means that Avalonia probably doesn't wait for shader cache load on the 2nd launch onwards.
- Does not play nicely with multiple execution engines (as it only exists on ARMeilleure). For example, I think it currently does not wait for shader cache load when using hypervisor on macOS (but it would be hard to notice since GPU does not process commands until shader cache is loaded, so most games would get stuck until it is loaded anyway).
- It is bad design in general, CPU emulation should not need to concern itself with this. Plus the way how it is exposed (public static field) is also bad, does not work well with multiple translator instances, etc.

To remedy the situation I introduced a `WaitUntilGpuReady` method on the GPU context that waits until shader is loaded, and it is called from `ArmProcessContext.Execute` (which is execution engine agnostic, so it is always called regardless of which JIT/hypervisor is being used).

While I'm still not 100% happy with this solution, I believe it is better than what we had before, and should solve the existing problems. Eventually we might need a strategy to handle shader cache load for multiple processes.

Testing is welcome.
