### PR TITLE
Use driver name instead of vendor name in the status bar for Vulkan.

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -980,7 +980,7 @@ namespace Ryujinx.Ava
                 ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                 LocaleManager.Instance[LocaleKeys.Game] + $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                 $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %",
-                $"GPU: {_renderer.GetHardwareInfo().GpuVendor}"));
+                $"GPU: {_renderer.GetHardwareInfo().GpuDriver}"));
         }
 
         public async Task ShowExitPrompt()

--- a/src/Ryujinx.Graphics.GAL/HardwareInfo.cs
+++ b/src/Ryujinx.Graphics.GAL/HardwareInfo.cs
@@ -4,11 +4,13 @@ namespace Ryujinx.Graphics.GAL
     {
         public string GpuVendor { get; }
         public string GpuModel { get; }
+        public string GpuDriver { get; }
 
-        public HardwareInfo(string gpuVendor, string gpuModel)
+        public HardwareInfo(string gpuVendor, string gpuModel, string gpuDriver)
         {
             GpuVendor = gpuVendor;
             GpuModel = gpuModel;
+            GpuDriver = gpuDriver;
         }
     }
 }

--- a/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -121,7 +121,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public HardwareInfo GetHardwareInfo()
         {
-            return new HardwareInfo(GpuVendor, GpuRenderer);
+            return new HardwareInfo(GpuVendor, GpuRenderer, GpuVendor); // OpenGL does not provide a driver name, vendor name is closest analogue.
         }
 
         public PinnedSpan<byte> GetBufferData(BufferHandle buffer, int offset, int size)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -25,7 +25,6 @@ namespace Ryujinx.Graphics.Vulkan
             PhysicalDeviceFeatures = api.GetPhysicalDeviceFeature(PhysicalDevice);
 
             api.GetPhysicalDeviceProperties(PhysicalDevice, out var physicalDeviceProperties);
-
             PhysicalDeviceProperties = physicalDeviceProperties;
 
             api.GetPhysicalDeviceMemoryProperties(PhysicalDevice, out PhysicalDeviceMemoryProperties);

--- a/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Graphics.Vulkan
             PhysicalDeviceFeatures = api.GetPhysicalDeviceFeature(PhysicalDevice);
 
             PhysicalDeviceProperties physicalDeviceProperties = default;
-            PhysicalDeviceVulkan12Properties physicalDeviceVulkan12Properties = new()
+            PhysicalDeviceVulkan12Properties physicalDeviceVulkan12Properties = new() // We need this to retrive driver-related details.
             {
                 SType = StructureType.PhysicalDeviceVulkan12Properties
             };

--- a/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly PhysicalDevice PhysicalDevice;
         public readonly PhysicalDeviceFeatures PhysicalDeviceFeatures;
         public readonly PhysicalDeviceProperties PhysicalDeviceProperties;
+        public readonly PhysicalDeviceVulkan12Properties PhysicalDeviceVulkan12Properties;
         public readonly PhysicalDeviceMemoryProperties PhysicalDeviceMemoryProperties;
         public readonly QueueFamilyProperties[] QueueFamilyProperties;
         public readonly string DeviceName;
@@ -24,8 +25,27 @@ namespace Ryujinx.Graphics.Vulkan
             PhysicalDevice = physicalDevice;
             PhysicalDeviceFeatures = api.GetPhysicalDeviceFeature(PhysicalDevice);
 
-            api.GetPhysicalDeviceProperties(PhysicalDevice, out var physicalDeviceProperties);
+            PhysicalDeviceProperties physicalDeviceProperties = default;
+            PhysicalDeviceVulkan12Properties physicalDeviceVulkan12Properties = new()
+            {
+                SType = StructureType.PhysicalDeviceVulkan12Properties
+            };
+
+            unsafe
+            {
+                PhysicalDeviceProperties2 properties2 = new()
+                {
+                    SType = StructureType.PhysicalDeviceProperties2,
+                    PNext = &physicalDeviceVulkan12Properties
+                };
+
+                api.GetPhysicalDeviceProperties2(physicalDevice, &properties2);
+
+                physicalDeviceProperties = properties2.Properties;
+            }
+
             PhysicalDeviceProperties = physicalDeviceProperties;
+            PhysicalDeviceVulkan12Properties = physicalDeviceVulkan12Properties;
 
             api.GetPhysicalDeviceMemoryProperties(PhysicalDevice, out PhysicalDeviceMemoryProperties);
 

--- a/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -63,6 +63,7 @@ namespace Ryujinx.Graphics.Vulkan
             if (!IsDeviceExtensionPresent("VK_KHR_driver_properties"))
             {
                 res = default;
+
                 return false;
             }
 
@@ -80,6 +81,7 @@ namespace Ryujinx.Graphics.Vulkan
             api.GetPhysicalDeviceProperties2(PhysicalDevice, &physicalDeviceProperties2);
 
             res = physicalDeviceDriverProperties;
+
             return true;
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -71,16 +71,13 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDeviceDriverPropertiesKhr
             };
 
-            unsafe
+            PhysicalDeviceProperties2 physicalDeviceProperties2 = new()
             {
-                PhysicalDeviceProperties2 physicalDeviceProperties2 = new()
-                {
-                    SType = StructureType.PhysicalDeviceProperties2,
-                    PNext = &physicalDeviceDriverProperties
-                };
+                SType = StructureType.PhysicalDeviceProperties2,
+                PNext = &physicalDeviceDriverProperties
+            };
 
-                api.GetPhysicalDeviceProperties2(PhysicalDevice, &physicalDeviceProperties2);
-            }
+            api.GetPhysicalDeviceProperties2(PhysicalDevice, &physicalDeviceProperties2);
 
             res = physicalDeviceDriverProperties;
             return true;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -692,8 +692,7 @@ namespace Ryujinx.Graphics.Vulkan
         private unsafe void PrintGpuInformation()
         {
             var properties = _physicalDevice.PhysicalDeviceProperties;
-
-            string vendorName = VendorUtils.GetNameFromId(properties.VendorID);
+            var propertiesVk12 = _physicalDevice.PhysicalDeviceVulkan12Properties;
 
             Vendor = VendorUtils.FromId(properties.VendorID);
 
@@ -706,7 +705,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Vendor == Vendor.Broadcom ||
                 Vendor == Vendor.ImgTec;
 
-            GpuVendor = vendorName;
+            GpuVendor = Marshal.PtrToStringAnsi((IntPtr)propertiesVk12.DriverName);
             GpuRenderer = Marshal.PtrToStringAnsi((IntPtr)properties.DeviceName);
             GpuVersion = $"Vulkan v{ParseStandardVulkanVersion(properties.ApiVersion)}, Driver v{ParseDriverVersion(ref properties)}";
 

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -693,7 +693,8 @@ namespace Ryujinx.Graphics.Vulkan
         private unsafe void PrintGpuInformation()
         {
             var properties = _physicalDevice.PhysicalDeviceProperties;
-            var propertiesVk12 = _physicalDevice.PhysicalDeviceVulkan12Properties;
+
+            var hasDriverProperties = _physicalDevice.TryGetPhysicalDeviceDriverPropertiesKHR(Api, out var driverProperties);
 
             string vendorName = VendorUtils.GetNameFromId(properties.VendorID);
 
@@ -709,7 +710,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Vendor == Vendor.ImgTec;
 
             GpuVendor = vendorName;
-            GpuDriver = Marshal.PtrToStringAnsi((IntPtr)propertiesVk12.DriverName);
+            GpuDriver = hasDriverProperties ? Marshal.PtrToStringAnsi((IntPtr)driverProperties.DriverName) : vendorName; // Fall back to vendor name if driver name isn't available.
             GpuRenderer = Marshal.PtrToStringAnsi((IntPtr)properties.DeviceName);
             GpuVersion = $"Vulkan v{ParseStandardVulkanVersion(properties.ApiVersion)}, Driver v{ParseDriverVersion(ref properties)}";
 

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -84,6 +84,7 @@ namespace Ryujinx.Graphics.Vulkan
         internal bool IsTBDR { get; private set; }
         internal bool IsSharedMemory { get; private set; }
         public string GpuVendor { get; private set; }
+        public string GpuDriver { get; private set; }
         public string GpuRenderer { get; private set; }
         public string GpuVersion { get; private set; }
 
@@ -636,7 +637,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public HardwareInfo GetHardwareInfo()
         {
-            return new HardwareInfo(GpuVendor, GpuRenderer);
+            return new HardwareInfo(GpuVendor, GpuRenderer, GpuDriver);
         }
 
         /// <summary>
@@ -694,6 +695,8 @@ namespace Ryujinx.Graphics.Vulkan
             var properties = _physicalDevice.PhysicalDeviceProperties;
             var propertiesVk12 = _physicalDevice.PhysicalDeviceVulkan12Properties;
 
+            string vendorName = VendorUtils.GetNameFromId(properties.VendorID);
+
             Vendor = VendorUtils.FromId(properties.VendorID);
 
             IsAmdWindows = Vendor == Vendor.Amd && OperatingSystem.IsWindows();
@@ -705,7 +708,8 @@ namespace Ryujinx.Graphics.Vulkan
                 Vendor == Vendor.Broadcom ||
                 Vendor == Vendor.ImgTec;
 
-            GpuVendor = Marshal.PtrToStringAnsi((IntPtr)propertiesVk12.DriverName);
+            GpuVendor = vendorName;
+            GpuDriver = Marshal.PtrToStringAnsi((IntPtr)propertiesVk12.DriverName);
             GpuRenderer = Marshal.PtrToStringAnsi((IntPtr)properties.DeviceName);
             GpuVersion = $"Vulkan v{ParseStandardVulkanVersion(properties.ApiVersion)}, Driver v{ParseDriverVersion(ref properties)}";
 

--- a/src/Ryujinx.Headless.SDL2/WindowBase.cs
+++ b/src/Ryujinx.Headless.SDL2/WindowBase.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Headless.SDL2
         private bool _isStopped;
         private uint _windowId;
 
-        private string _gpuVendorName;
+        private string _gpuDriverName;
 
         private readonly AspectRatio _aspectRatio;
         private readonly bool _enableMouse;
@@ -242,9 +242,9 @@ namespace Ryujinx.Headless.SDL2
 
         public abstract SDL_WindowFlags GetWindowFlags();
 
-        private string GetGpuVendorName()
+        private string GetGpuDriverName()
         {
-            return Renderer.GetHardwareInfo().GpuVendor;
+            return Renderer.GetHardwareInfo().GpuDriver;
         }
 
         private void SetAntiAliasing()
@@ -270,7 +270,7 @@ namespace Ryujinx.Headless.SDL2
 
             SetScalingFilter();
 
-            _gpuVendorName = GetGpuVendorName();
+            _gpuDriverName = GetGpuDriverName();
 
             Device.Gpu.Renderer.RunLoop(() =>
             {
@@ -316,7 +316,7 @@ namespace Ryujinx.Headless.SDL2
                             Device.Configuration.AspectRatio.ToText(),
                             $"Game: {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                             $"FIFO: {Device.Statistics.GetFifoPercent():0.00} %",
-                            $"GPU: {_gpuVendorName}"));
+                            $"GPU: {_gpuDriverName}"));
 
                         _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame);
                     }

--- a/src/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/src/Ryujinx/Ui/RendererWidgetBase.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Ui
         private readonly IKeyboard _keyboardInterface;
         private readonly GraphicsDebugLevel _glLogLevel;
         private string _gpuBackendName;
-        private string _gpuVendorName;
+        private string _gpuDriverName;
         private bool _isMouseInClient;
 
         public RendererWidgetBase(InputManager inputManager, GraphicsDebugLevel glLogLevel)
@@ -142,9 +142,9 @@ namespace Ryujinx.Ui
 
         protected abstract string GetGpuBackendName();
 
-        private string GetGpuVendorName()
+        private string GetGpuDriverName()
         {
-            return Renderer.GetHardwareInfo().GpuVendor;
+            return Renderer.GetHardwareInfo().GpuDriver;
         }
 
         private void HideCursorStateChanged(object sender, ReactiveEventArgs<HideCursorMode> state)
@@ -444,7 +444,7 @@ namespace Ryujinx.Ui
             Renderer.Window.SetScalingFilterLevel(ConfigurationState.Instance.Graphics.ScalingFilterLevel.Value);
 
             _gpuBackendName = GetGpuBackendName();
-            _gpuVendorName = GetGpuVendorName();
+            _gpuDriverName = GetGpuDriverName();
 
             Device.Gpu.Renderer.RunLoop(() =>
             {
@@ -496,7 +496,7 @@ namespace Ryujinx.Ui
                             ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                             $"Game: {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                             $"FIFO: {Device.Statistics.GetFifoPercent():0.00} %",
-                            $"GPU: {_gpuVendorName}"));
+                            $"GPU: {_gpuDriverName}"));
 
                         _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame);
                     }


### PR DESCRIPTION
This PR handles #3682 by displaying the more specific driver name in the status bar rather than only the device vendor. OpenGL has no such API, so there we just continue to display the vendor name.

In many cases such as Windows/NV the name displayed for the vendor and the driver are the same. Seeking testers on Linux to confirm.