### PR TITLE
Support portable mode using the macOS app bundle.

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -70,8 +70,7 @@ namespace Ryujinx.Common.Configuration
                 // Make sure we're actually running within an app bundle.
                 if (bundlePath.EndsWith(".app"))
                 {
-                    string bundleParentPath = Path.GetFullPath(Path.Combine(bundlePath, ".."));
-                    portablePath = Path.Combine(bundleParentPath, DefaultPortableDir);
+                    portablePath = Path.GetFullPath(Path.Combine(bundlePath, "..", DefaultPortableDir));
                 }
             }
 

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -63,6 +63,18 @@ namespace Ryujinx.Common.Configuration
             string userProfilePath = Path.Combine(appDataPath, DefaultBaseDir);
             string portablePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, DefaultPortableDir);
 
+            // On macOS, check for a portable directory next to the app bundle as well.
+            if (OperatingSystem.IsMacOS() && !Directory.Exists(portablePath))
+            {
+                string bundlePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", ".."));
+                // Make sure we're actually running within an app bundle.
+                if (bundlePath.EndsWith(".app"))
+                {
+                    string bundleParentPath = Path.GetFullPath(Path.Combine(bundlePath, ".."));
+                    portablePath = Path.Combine(bundleParentPath, DefaultPortableDir);
+                }
+            }
+
             if (Directory.Exists(portablePath))
             {
                 BaseDirPath = portablePath;


### PR DESCRIPTION
Adds support for using a portable directory placed next to the macOS app bundle. Currently the logic just checks if a portable directory is next to the actual executable, which only works as intended when running Ryujinx as a standalone executable.

I wasn't able to find any proper API for getting the bundle directory in .NET, so I used a similar method to what the updater does to find the bundle path.

Tested this on my Mac to verify it works as intended.