### PR TITLE
Vulkan: Use push descriptors for uniform bindings when possible

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/Constants.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Constants.cs
@@ -16,6 +16,7 @@ namespace Ryujinx.Graphics.Vulkan
         public const int MaxStorageBufferBindings = MaxStorageBuffersPerStage * MaxShaderStages;
         public const int MaxTextureBindings = MaxTexturesPerStage * MaxShaderStages;
         public const int MaxImageBindings = MaxImagesPerStage * MaxShaderStages;
+        public const int MaxPushDescriptorBinding = 64;
 
         public const ulong SparseBufferAlignment = 0x10000;
     }

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -20,7 +20,13 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly DescriptorUpdateTemplate Template;
         public readonly int Size;
 
-        public unsafe DescriptorSetTemplate(VulkanRenderer gd, Device device, ResourceBindingSegment[] segments, PipelineLayoutCacheEntry plce, PipelineBindPoint pbp, int setIndex)
+        public unsafe DescriptorSetTemplate(
+            VulkanRenderer gd,
+            Device device,
+            ResourceBindingSegment[] segments,
+            PipelineLayoutCacheEntry plce,
+            PipelineBindPoint pbp,
+            int setIndex)
         {
             _gd = gd;
             _device = device;
@@ -144,7 +150,14 @@ namespace Ryujinx.Graphics.Vulkan
             Template = result;
         }
 
-        public unsafe DescriptorSetTemplate(VulkanRenderer gd, Device device, ResourceDescriptorCollection descriptors, long updateMask, PipelineLayoutCacheEntry plce, PipelineBindPoint pbp, int setIndex)
+        public unsafe DescriptorSetTemplate(
+            VulkanRenderer gd,
+            Device device,
+            ResourceDescriptorCollection descriptors,
+            long updateMask,
+            PipelineLayoutCacheEntry plce,
+            PipelineBindPoint pbp,
+            int setIndex)
         {
             _gd = gd;
             _device = device;
@@ -156,7 +169,7 @@ namespace Ryujinx.Graphics.Vulkan
             int entry = 0;
             nuint structureOffset = 0;
 
-            void addBinding(int binding, int count)
+            void AddBinding(int binding, int count)
             {
                 entries[entry++] = new DescriptorUpdateTemplateEntry()
                 {
@@ -183,7 +196,7 @@ namespace Ryujinx.Graphics.Vulkan
                     {
                         if (bindingCount > 0 && (RenderdocPushCountBug || startBinding + bindingCount != binding))
                         {
-                            addBinding(startBinding, bindingCount);
+                            AddBinding(startBinding, bindingCount);
 
                             bindingCount = 0;
                         }
@@ -200,7 +213,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (bindingCount > 0)
             {
-                addBinding(startBinding, bindingCount);
+                AddBinding(startBinding, bindingCount);
             }
 
             Size = (int)structureOffset;

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplate.cs
@@ -1,12 +1,19 @@
 using Ryujinx.Graphics.GAL;
 using Silk.NET.Vulkan;
 using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Vulkan
 {
     class DescriptorSetTemplate : IDisposable
     {
+        /// <summary>
+        /// Renderdoc seems to crash when doing a templated uniform update with count > 1 on a push descriptor.
+        /// When this is true, consecutive buffers are always updated individually.
+        /// </summary>
+        private const bool RenderdocPushCountBug = true;
+
         private readonly VulkanRenderer _gd;
         private readonly Device _device;
 
@@ -125,6 +132,86 @@ namespace Ryujinx.Graphics.Vulkan
                 PDescriptorUpdateEntries = entries,
 
                 TemplateType = DescriptorUpdateTemplateType.DescriptorSet,
+                DescriptorSetLayout = plce.DescriptorSetLayouts[setIndex],
+                PipelineBindPoint = pbp,
+                PipelineLayout = plce.PipelineLayout,
+                Set = (uint)setIndex,
+            };
+
+            DescriptorUpdateTemplate result;
+            gd.Api.CreateDescriptorUpdateTemplate(device, &info, null, &result).ThrowOnError();
+
+            Template = result;
+        }
+
+        public unsafe DescriptorSetTemplate(VulkanRenderer gd, Device device, ResourceDescriptorCollection descriptors, long updateMask, PipelineLayoutCacheEntry plce, PipelineBindPoint pbp, int setIndex)
+        {
+            _gd = gd;
+            _device = device;
+
+            // Create a template from the set usages. Assumes the descriptor set is updated in segment order then binding order.
+            int segmentCount = BitOperations.PopCount((ulong)updateMask);
+
+            DescriptorUpdateTemplateEntry* entries = stackalloc DescriptorUpdateTemplateEntry[segmentCount];
+            int entry = 0;
+            nuint structureOffset = 0;
+
+            void addBinding(int binding, int count)
+            {
+                entries[entry++] = new DescriptorUpdateTemplateEntry()
+                {
+                    DescriptorType = DescriptorType.UniformBuffer,
+                    DstBinding = (uint)binding,
+                    DescriptorCount = (uint)count,
+                    Offset = structureOffset,
+                    Stride = (nuint)Unsafe.SizeOf<DescriptorBufferInfo>()
+                };
+
+                structureOffset += (nuint)(Unsafe.SizeOf<DescriptorBufferInfo>() * count);
+            }
+
+            int startBinding = 0;
+            int bindingCount = 0;
+
+            foreach (ResourceDescriptor descriptor in descriptors.Descriptors)
+            {
+                for (int i = 0; i < descriptor.Count; i++)
+                {
+                    int binding = descriptor.Binding + i;
+
+                    if ((updateMask & (1L << binding)) != 0)
+                    {
+                        if (bindingCount > 0 && (RenderdocPushCountBug || startBinding + bindingCount != binding))
+                        {
+                            addBinding(startBinding, bindingCount);
+
+                            bindingCount = 0;
+                        }
+
+                        if (bindingCount == 0)
+                        {
+                            startBinding = binding;
+                        }
+
+                        bindingCount++;
+                    }
+                }
+            }
+
+            if (bindingCount > 0)
+            {
+                addBinding(startBinding, bindingCount);
+            }
+
+            Size = (int)structureOffset;
+
+            var info = new DescriptorUpdateTemplateCreateInfo()
+            {
+                SType = StructureType.DescriptorUpdateTemplateCreateInfo,
+                DescriptorUpdateEntryCount = (uint)entry,
+                PDescriptorUpdateEntries = entries,
+
+                TemplateType = DescriptorUpdateTemplateType.PushDescriptorsKhr,
                 DescriptorSetLayout = plce.DescriptorSetLayouts[setIndex],
                 PipelineBindPoint = pbp,
                 PipelineLayout = plce.PipelineLayout,

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplateUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetTemplateUpdater.cs
@@ -52,9 +52,21 @@ namespace Ryujinx.Graphics.Vulkan
             return new DescriptorSetTemplateWriter(new Span<byte>(_data.Pointer, template.Size));
         }
 
+        public DescriptorSetTemplateWriter Begin(int maxSize)
+        {
+            EnsureSize(maxSize);
+
+            return new DescriptorSetTemplateWriter(new Span<byte>(_data.Pointer, maxSize));
+        }
+
         public void Commit(VulkanRenderer gd, Device device, DescriptorSet set)
         {
             gd.Api.UpdateDescriptorSetWithTemplate(device, set, _activeTemplate.Template, _data.Pointer);
+        }
+
+        public void CommitPushDescriptor(VulkanRenderer gd, CommandBufferScoped cbs, DescriptorSetTemplate template, PipelineLayout layout)
+        {
+            gd.PushDescriptorApi.CmdPushDescriptorSetWithTemplate(cbs.CommandBuffer, template.Template, layout, 0, _data.Pointer);
         }
 
         public void Dispose()

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -237,7 +237,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public void SetProgram(CommandBufferScoped cbs, ShaderCollection program)
+        public void SetProgram(CommandBufferScoped cbs, ShaderCollection program, bool isBound)
         {
             if (!program.HasSameLayout(_program))
             {
@@ -245,7 +245,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 AdvancePdSequence();
 
-                if (_gd.IsNvidiaPreTuring && !program.UsePushDescriptors && _program?.UsePushDescriptors == true)
+                if (_gd.IsNvidiaPreTuring && !program.UsePushDescriptors && _program?.UsePushDescriptors == true && isBound)
                 {
                     // On older nvidia GPUs, we need to clear out the active push descriptor bindings when switching
                     // to normal descriptors. Keeping them bound can prevent buffers from binding properly in future.
@@ -757,8 +757,6 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 int binding = segment.Binding;
                 int count = segment.Count;
-
-                ReadOnlySpan<DescriptorBufferInfo> uniformBuffers = _uniformBuffers;
 
                 for (int i = 0; i < count; i++)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -245,7 +245,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 AdvancePdSequence();
 
-                if (_gd.Vendor == Vendor.Nvidia && !program.UsePushDescriptors && _program?.UsePushDescriptors == true)
+                if (_gd.IsNvidiaPreTuring && !program.UsePushDescriptors && _program?.UsePushDescriptors == true)
                 {
                     // On older nvidia GPUs, we need to clear out the active push descriptor bindings when switching
                     // to normal descriptors. Keeping them bound can prevent buffers from binding properly in future.

--- a/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -34,6 +34,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly bool SupportsMultiView;
         public readonly bool SupportsNullDescriptors;
         public readonly bool SupportsPushDescriptors;
+        public readonly uint MaxPushDescriptors;
         public readonly bool SupportsPrimitiveTopologyListRestart;
         public readonly bool SupportsPrimitiveTopologyPatchListRestart;
         public readonly bool SupportsTransformFeedback;
@@ -71,6 +72,7 @@ namespace Ryujinx.Graphics.Vulkan
             bool supportsMultiView,
             bool supportsNullDescriptors,
             bool supportsPushDescriptors,
+            uint maxPushDescriptors,
             bool supportsPrimitiveTopologyListRestart,
             bool supportsPrimitiveTopologyPatchListRestart,
             bool supportsTransformFeedback,
@@ -107,6 +109,7 @@ namespace Ryujinx.Graphics.Vulkan
             SupportsMultiView = supportsMultiView;
             SupportsNullDescriptors = supportsNullDescriptors;
             SupportsPushDescriptors = supportsPushDescriptors;
+            MaxPushDescriptors = maxPushDescriptors;
             SupportsPrimitiveTopologyListRestart = supportsPrimitiveTopologyListRestart;
             SupportsPrimitiveTopologyPatchListRestart = supportsPrimitiveTopologyPatchListRestart;
             SupportsTransformFeedback = supportsTransformFeedback;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -976,7 +976,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             _program = internalProgram;
 
-            _descriptorSetUpdater.SetProgram(Cbs, internalProgram);
+            _descriptorSetUpdater.SetProgram(Cbs, internalProgram, _currentPipelineHandle != 0);
 
             _newState.PipelineLayout = internalProgram.PipelineLayout;
             _newState.StagesCount = (uint)stages.Length;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -976,7 +976,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             _program = internalProgram;
 
-            _descriptorSetUpdater.SetProgram(internalProgram);
+            _descriptorSetUpdater.SetProgram(Cbs, internalProgram);
 
             _newState.PipelineLayout = internalProgram.PipelineLayout;
             _newState.StagesCount = (uint)stages.Length;

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -183,13 +183,23 @@ namespace Ryujinx.Graphics.Vulkan
                     // Push descriptors apply here. Remove reserved bindings.
                     ResourceDescriptorCollection original = sets[i];
 
-                    var pdUniforms = new List<ResourceDescriptor>();
+                    var pdUniforms = new ResourceDescriptor[original.Descriptors.Count];
+                    int j = 0;
 
                     foreach (ResourceDescriptor descriptor in original.Descriptors)
                     {
-                        if (!reserved.Contains(descriptor.Binding))
+                        if (reserved.Contains(descriptor.Binding))
                         {
-                            pdUniforms.Add(descriptor);
+                            // If the binding is reserved, set its descriptor count to 0.
+                            pdUniforms[j++] = new ResourceDescriptor(
+                                descriptor.Binding,
+                                0,
+                                descriptor.Type,
+                                descriptor.Stages);
+                        }
+                        else
+                        {
+                            pdUniforms[j++] = descriptor;
                         }
                     }
 

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -114,7 +114,7 @@ namespace Ryujinx.Graphics.Vulkan
                 !IsCompute &&
                 CanUsePushDescriptors(gd, resourceLayout, IsCompute);
 
-            ReadOnlyCollection<ResourceDescriptorCollection> sets = usePushDescriptors ? 
+            ReadOnlyCollection<ResourceDescriptorCollection> sets = usePushDescriptors ?
                 BuildPushDescriptorSets(gd, resourceLayout.Sets) : resourceLayout.Sets;
 
             _plce = gd.PipelineLayoutCache.GetOrCreate(gd, device, sets, usePushDescriptors);

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (reserved.Contains(binding) ||
                     binding >= Constants.MaxPushDescriptorBinding ||
-                    binding >= gd.Capabilities.MaxPushDescriptors + reserved.Length)
+                    binding >= gd.Capabilities.MaxPushDescriptors + reserved.Count(id => id < binding))
                 {
                     return false;
                 }

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -158,7 +158,9 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 var binding = uniformUsage[i].Binding;
 
-                if (reserved.Contains(binding) || binding >= gd.Capabilities.MaxPushDescriptors + reserved.Length)
+                if (reserved.Contains(binding) ||
+                    binding >= Constants.MaxPushDescriptorBinding ||
+                    binding >= gd.Capabilities.MaxPushDescriptors + reserved.Length)
                 {
                     return false;
                 }

--- a/src/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -20,6 +20,9 @@ namespace Ryujinx.Graphics.Vulkan
         [GeneratedRegex("Radeon (((HD|R(5|7|9|X)) )?((M?[2-6]\\d{2}(\\D|$))|([7-8]\\d{3}(\\D|$))|Fury|Nano))|(Pro Duo)")]
         public static partial Regex AmdGcnRegex();
 
+        [GeneratedRegex("NVIDIA GeForce (R|G)?TX? (\\d{3}\\d?)M?")]
+        public static partial Regex NvidiaConsumerClassRegex();
+
         public static Vendor FromId(uint id)
         {
             return id switch

--- a/src/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.Graphics.Vulkan
     {
         public const bool UseFastBufferUpdates = true;
         public const bool UseUnsafeBlit = true;
-        public const bool UsePushDescriptors = false;
+        public const bool UsePushDescriptors = true;
 
         public const bool ForceD24S8Unsupported = false;
         public const bool ForceRGB16IntFloatUnsupported = false;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -418,13 +418,13 @@ namespace Ryujinx.Graphics.Vulkan
             _initialized = true;
         }
 
-        public int[] GetPushDescriptorReservedBindings(bool isOgl)
+        internal int[] GetPushDescriptorReservedBindings(bool isOgl)
         {
             // The first call of this method determines what push descriptor layout is used for all shaders on this renderer.
-            // This is chosen to minimize shaders that can't fit on 32 entry push descriptor sets.
+            // This is chosen to minimize shaders that can't fit their uniforms on the device's max number of push descriptors.
             if (_pdReservedBindings == null)
             {
-                if (Capabilities.MaxPushDescriptors == 32)
+                if (Capabilities.MaxPushDescriptors <= Constants.MaxUniformBuffersPerStage * 2)
                 {
                     _pdReservedBindings = isOgl ? _pdReservedBindingsOgl : _pdReservedBindingsNvn;
                 }

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -337,7 +337,7 @@ namespace Ryujinx.Graphics.Vulkan
                 _physicalDevice.IsDeviceExtensionPresent(ExtExtendedDynamicState.ExtensionName),
                 features2.Features.MultiViewport && !(IsMoltenVk && Vendor == Vendor.Amd), // Workaround for AMD on MoltenVK issue
                 featuresRobustness2.NullDescriptor || IsMoltenVk,
-                supportsPushDescriptors,
+                supportsPushDescriptors && !IsMoltenVk,
                 propertiesPushDescriptor.MaxPushDescriptors,
                 featuresPrimitiveTopologyListRestart.PrimitiveTopologyListRestart,
                 featuresPrimitiveTopologyListRestart.PrimitiveTopologyPatchListRestart,

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -84,6 +84,7 @@ namespace Ryujinx.Graphics.Vulkan
         internal bool IsAmdWindows { get; private set; }
         internal bool IsIntelWindows { get; private set; }
         internal bool IsAmdGcn { get; private set; }
+        internal bool IsNvidiaPreTuring { get; private set; }
         internal bool IsMoltenVk { get; private set; }
         internal bool IsTBDR { get; private set; }
         internal bool IsSharedMemory { get; private set; }
@@ -752,6 +753,20 @@ namespace Ryujinx.Graphics.Vulkan
             GpuVersion = $"Vulkan v{ParseStandardVulkanVersion(properties.ApiVersion)}, Driver v{ParseDriverVersion(ref properties)}";
 
             IsAmdGcn = !IsMoltenVk && Vendor == Vendor.Amd && VendorUtils.AmdGcnRegex().IsMatch(GpuRenderer);
+
+            if (Vendor == Vendor.Nvidia)
+            {
+                var match = VendorUtils.NvidiaConsumerClassRegex().Match(GpuRenderer);
+
+                if (match != null && int.TryParse(match.Groups[2].Value, out int gpuNumber))
+                {
+                    IsNvidiaPreTuring = gpuNumber < 2000;
+                }
+                else if (GpuDriver.Contains("TITAN") && !GpuDriver.Contains("RTX"))
+                {
+                    IsNvidiaPreTuring = true;
+                }
+            }
 
             Logger.Notice.Print(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
         }


### PR DESCRIPTION
Followup to https://github.com/Ryujinx/Ryujinx/pull/6014. Uses push descriptors for uniform buffers when possible - when it's not possible it just falls back to the regular descriptor set with templated updates.

Push descriptors are also using templated updates, since it allows us to submit multiple bindings in one call. This is useful when all the bindings change, or we have to resubmit the bindings due to a pipeline layout change. There's a dictionary lookup for the template within the pipeline layout, but there's a fast path if it's the same updated bindings as last time.

## Reserved bindings
There can only be 32 push descriptors, but we tend to have 37 uniform buffer bindings when fragment and vertex are both using uniforms. The chosen solution to this problem is to select a subset of uniforms that are "reserved" and skip them in the push descriptor set. If any shader programs use these reserved bindings, they must use the full layout and normal template update for their uniform set.

This set of reserved bindings was manually selected by observation after checking a few NVN games, to maximize the number of programs that can use push descriptors in popular games. However, guest OGL games tend to use different bindings, so there is an alternate mode that's activated if binding 3 is used on the first shader using push descriptors (typically not used on NVN). This mode is set for the remainder of the life of the VulkanRenderer, so it prefers whatever 

The reason we want one set of bindings for an entire run is so that bindings can continue to live between program bindings without being reset. This is the case as long as the new program doesn't use a different pipeline layout, so we get this for free on similar shader programs so long as the push descriptor arrangement is the same between them.

## Improvements
All screenshots here have been taken with a modified version of Ryujinx that's able to measure how much % time the backend thread is active. You can find that here: https://github.com/riperiperi/Ryujinx/tree/backend-statistics-bad . Measuring the backend time _can_ interfere with performance unlike FIFO% measurement, and the way it's done is kind of messy, so no PR for that.

Improvements depend on the game and the system you're using. Every PC and game combination could have a different bottleneck limiting your framerate, and could have different reactions to using push descriptors vs full set update + binds.

### NVIDIA
The NVIDIA driver is already wonderfully fast, but using push descriptors still shaves off an extra 10% or more depending on game. Unfortunately, it was so fast before that the difference isn't visible in FPS in my testing games, but CPU time is saved and framerate stability could be improved due to there being more breathing room in intense situations.

**Before:**
![image](https://github.com/Ryujinx/Ryujinx/assets/6294155/7cdbd09c-39c4-4a53-82dd-c7b54ed8f0c9)

**After:**
![image-1](https://github.com/Ryujinx/Ryujinx/assets/6294155/94cdca4b-e175-4809-baf3-4f29a8d265fe)

### AMD (mesa, steam deck)
The mesa driver was most impacted by using descriptor set templates, and similarly is most impacted by switching to use push descriptors. In many games, the backend performance is actually the bottleneck on mesa, so improvements are seen as real FPS gain, as well as the reduced CPU usage and improvements to stability.

**Before:**
![Screenshot_20240120_104313](https://github.com/Ryujinx/Ryujinx/assets/6294155/6eea6c7c-36d9-41f4-86d4-d8854e6ec58e)

**After:**
![Screenshot_20240120_104604](https://github.com/Ryujinx/Ryujinx/assets/6294155/360ac6fa-65db-4417-948d-b28986111848)

### AMD (windows, steam deck)
The Windows AMD driver has consistently been faster than mesa in the hardest to run games, but that lead seems to be changing. While push descriptors do improve performance on this driver, it's not as much as with mesa.

**Before:**
![image](https://github.com/Ryujinx/Ryujinx/assets/6294155/e6e89fa4-7d81-4f14-a831-833dab66493e)

**After:**
![image-1](https://github.com/Ryujinx/Ryujinx/assets/6294155/bca7a3a6-076e-4efb-a614-388d46ac1b5f)

### MoltenVK
<img width="1204" alt="image" src="https://github.com/Ryujinx/Ryujinx/assets/6294155/7880c2f3-ccf1-4e38-b0c7-4eae546f898a">

MoltenVK, uh... CPU time here is essentially doubled between VK and Metal threads, so I'm hoping that the push descriptor model better matching how games actually update uniform buffer bindings can reduce that significantly. Not that we can test that right now, since it just breaks completely. ~~Might be related to mirrors,~~ (still happens when they are disabled and doesn't happen when forcing them on NV) might be something else.

## TODO
This PR is draft until the following things are done:
- More game testing to ensure nothing breaks
- More performance testing + examples (ACNH has big gains in backend time from ~40% to ~32%, but ARM JIT execution is usually the bottleneck)
- Identify and fix issue with MoltenVK, or disable push descriptors on MoltenVK.
- Why does renderdoc break when updating more than one binding at a time in a single push descriptor template update entry?
- Think about compute shaders. They don't use push descriptors right now, but I don't think there's as much reason to use it. Draws can be heavily batched with a minimal set of uniform bindings changing between each, while compute is usually one and done or multiple different passes that need different data.
- Clean up magic numbers + implicit limits? (64 max binding index limit on push descriptor templates, though this can't activate right now)