### PR TITLE
Fix missing data for new copy dependency textures with mismatching size

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -790,8 +790,12 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                         texture = new Texture(_context, _physicalMemory, info, sizeInfo, range.Value, scaleMode);
 
+                        // If the new texture is larger than the existing one, we need to fill the remaining space with CPU data,
+                        // otherwise we only need the data that is copied from the existing texture, without loading the CPU data.
+                        bool updateNewTexture = texture.Width > overlap.Width || texture.Height > overlap.Height;
+
                         texture.InitializeGroup(true, true, new List<TextureIncompatibleOverlap>());
-                        texture.InitializeData(false, false);
+                        texture.InitializeData(false, updateNewTexture);
 
                         overlap.SynchronizeMemory();
                         overlap.CreateCopyDependency(texture, oInfo.FirstLayer, oInfo.FirstLevel, true);


### PR DESCRIPTION
If two textures with different size overlap in memory, a copy dependency is created to ensure modifications to one textures flows into the other as needed. When the copy dependency is created, the assumption is that the existing texture has the latest data, so its data is copied to the new texture. This is a problem when the new texture is larger than the existing one, because the remaining width/height of the new texture will remain untiliased. To fix that, this PR forces the new texture to load its data from CPU if the width or height is greater than that of the existing texture.

Fixes text rendering on Shantae and the Pirate's Curse (regression caused by #4364).

Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/0b0c3a61-46ff-4909-a336-8e27c5cdfee6)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/61f61017-2b68-47c5-8c74-977abcf57af7)

Testing is welcome, texture cache related changes are prone to exploding.