### PR TITLE
Vulkan: Enumerate Query Pool properly

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
@@ -67,9 +67,18 @@ namespace Ryujinx.Graphics.Vulkan.Queries
             lock (_queryPool)
             {
                 count = Math.Min(count, _queryPool.Count);
-                for (int i = 0; i < count; i++)
+
+                if (count > 0)
                 {
-                    _queryPool.ElementAt(i).PoolReset(cmd, ResetSequence);
+                    foreach (BufferedQuery query in _queryPool)
+                    {
+                        query.PoolReset(cmd, ResetSequence);
+
+                        if (--count == 0)
+                        {
+                            break;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Turns out that `ElementAt<T>` for `Queue<T>` runs the default implementation as it doesn't implement `IList<T>`, which enumerates elements of the queue up to the given index. This code was creating `count` enumerators and iterating way more queue items than it needed to at higher counts. The solution is just to use one enumerator and break out of the loop when we get the count that we need.

3.5% of backend time was being spent _just_ enumerating at the usual spot in SMO. Only affects games using occlusion queries.