### PR TITLE
Vulkan: Use staging buffer for temporary constants

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -384,7 +384,7 @@ namespace Ryujinx.Graphics.Vulkan
             var baseData = new Span<byte>((void*)(_map + offset), size);
             var modData = _pendingData.AsSpan(offset, size);
 
-            StagingBufferReserved? newMirror = _gd.BufferManager.StagingBuffer.TryReserveData(cbs, size, (int)_gd.Capabilities.MinResourceAlignment);
+            StagingBufferReserved? newMirror = _gd.BufferManager.StagingBuffer.TryReserveData(cbs, size);
 
             if (newMirror != null)
             {

--- a/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -4,6 +4,7 @@ using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using VkBuffer = Silk.NET.Vulkan.Buffer;
 using VkFormat = Silk.NET.Vulkan.Format;
@@ -836,6 +837,11 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 _gd.BufferManager.StagingBuffer.PushData(_gd.CommandBufferPool, null, null, this, offset, data);
             }
+        }
+
+        public unsafe void SetDataUnchecked<T>(int offset, ReadOnlySpan<T> data) where T : unmanaged
+        {
+            SetDataUnchecked(offset, MemoryMarshal.AsBytes(data));
         }
 
         public void SetDataInline(CommandBufferScoped cbs, Action endRenderPass, int dstOffset, ReadOnlySpan<byte> data)

--- a/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -266,9 +266,9 @@ namespace Ryujinx.Graphics.Vulkan
             return Unsafe.As<ulong, BufferHandle>(ref handle64);
         }
 
-        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, out BufferHolder holder, int alignment = -1)
+        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, out BufferHolder holder)
         {
-            StagingBufferReserved? result = StagingBuffer.TryReserveData(cbs, size, alignment);
+            StagingBufferReserved? result = StagingBuffer.TryReserveData(cbs, size);
 
             if (result.HasValue)
             {
@@ -284,9 +284,9 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, int alignment = -1)
+        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size)
         {
-            return ReserveOrCreate(gd, cbs, size, out _, alignment);
+            return ReserveOrCreate(gd, cbs, size, out _);
         }
 
         public unsafe MemoryRequirements GetHostImportedUsageRequirements(VulkanRenderer gd)

--- a/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -9,6 +9,34 @@ using VkFormat = Silk.NET.Vulkan.Format;
 
 namespace Ryujinx.Graphics.Vulkan
 {
+    readonly struct ScopedTemporaryBuffer : IDisposable
+    {
+        private readonly BufferManager _bufferManager;
+        private readonly bool _isReserved;
+
+        public readonly BufferRange Range;
+
+        public BufferHandle Handle => Range.Handle;
+        public int Offset => Range.Offset;
+
+        public ScopedTemporaryBuffer(BufferManager bufferManager, BufferHandle handle, int offset, int size, bool isReserved)
+        {
+            _bufferManager = bufferManager;
+
+            Range = new BufferRange(handle, offset, size);
+
+            _isReserved = isReserved;
+        }
+
+        public void Dispose()
+        {
+            if (!_isReserved)
+            {
+                _bufferManager.Delete(Range.Handle);
+            }
+        }
+    }
+
     class BufferManager : IDisposable
     {
         public const MemoryPropertyFlags DefaultBufferMemoryFlags =
@@ -236,6 +264,23 @@ namespace Ryujinx.Graphics.Vulkan
             ulong handle64 = (uint)_buffers.Add(holder);
 
             return Unsafe.As<ulong, BufferHandle>(ref handle64);
+        }
+
+        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, int alignment = -1)
+        {
+            StagingBufferReserved? result = StagingBuffer.TryReserveData(cbs, size, alignment);
+
+            if (result.HasValue)
+            {
+                return new ScopedTemporaryBuffer(this, StagingBuffer.Handle, result.Value.Offset, result.Value.Size, true);
+            }
+            else
+            {
+                // Create a temporary buffer.
+                BufferHandle handle = CreateWithHandle(gd, size);
+
+                return new ScopedTemporaryBuffer(this, handle, 0, size, false);
+            }
         }
 
         public unsafe MemoryRequirements GetHostImportedUsageRequirements(VulkanRenderer gd)
@@ -635,13 +680,14 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (disposing)
             {
+                StagingBuffer.Dispose();
+
                 foreach (BufferHolder buffer in _buffers)
                 {
                     buffer.Dispose();
                 }
 
                 _buffers.Clear();
-                StagingBuffer.Dispose();
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -266,21 +266,27 @@ namespace Ryujinx.Graphics.Vulkan
             return Unsafe.As<ulong, BufferHandle>(ref handle64);
         }
 
-        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, int alignment = -1)
+        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, out BufferHolder holder, int alignment = -1)
         {
             StagingBufferReserved? result = StagingBuffer.TryReserveData(cbs, size, alignment);
 
             if (result.HasValue)
             {
+                holder = result.Value.Buffer;
                 return new ScopedTemporaryBuffer(this, StagingBuffer.Handle, result.Value.Offset, result.Value.Size, true);
             }
             else
             {
                 // Create a temporary buffer.
-                BufferHandle handle = CreateWithHandle(gd, size);
+                BufferHandle handle = CreateWithHandle(gd, size, out holder);
 
                 return new ScopedTemporaryBuffer(this, handle, 0, size, false);
             }
+        }
+
+        public ScopedTemporaryBuffer ReserveOrCreate(VulkanRenderer gd, CommandBufferScoped cbs, int size, int alignment = -1)
+        {
+            return ReserveOrCreate(gd, cbs, size, out _, alignment);
         }
 
         public unsafe MemoryRequirements GetHostImportedUsageRequirements(VulkanRenderer gd)

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
@@ -142,19 +142,18 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             };
 
             int rangeSize = dimensionsBuffer.Length * sizeof(float);
-            var bufferHandle = _renderer.BufferManager.CreateWithHandle(_renderer, rangeSize);
-            _renderer.BufferManager.SetData(bufferHandle, 0, dimensionsBuffer);
+            using var buffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, rangeSize);
+            _renderer.BufferManager.SetData(buffer.Handle, buffer.Offset, dimensionsBuffer);
 
-            ReadOnlySpan<float> sharpeningBuffer = stackalloc float[] { 1.5f - (Level * 0.01f * 1.5f) };
-            var sharpeningBufferHandle = _renderer.BufferManager.CreateWithHandle(_renderer, sizeof(float));
-            _renderer.BufferManager.SetData(sharpeningBufferHandle, 0, sharpeningBuffer);
+            ReadOnlySpan<float> sharpeningBufferData = stackalloc float[] { 1.5f - (Level * 0.01f * 1.5f) };
+            using var sharpeningBuffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, sizeof(float));
+            _renderer.BufferManager.SetData(sharpeningBuffer.Handle, sharpeningBuffer.Offset, sharpeningBufferData);
 
             int threadGroupWorkRegionDim = 16;
             int dispatchX = (width + (threadGroupWorkRegionDim - 1)) / threadGroupWorkRegionDim;
             int dispatchY = (height + (threadGroupWorkRegionDim - 1)) / threadGroupWorkRegionDim;
 
-            var bufferRanges = new BufferRange(bufferHandle, 0, rangeSize);
-            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
+            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, buffer.Range) });
             _pipeline.SetImage(0, _intermediaryTexture, FormatTable.ConvertRgba8SrgbToUnorm(view.Info.Format));
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
@@ -162,16 +161,12 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             // Sharpening pass
             _pipeline.SetProgram(_sharpeningProgram);
             _pipeline.SetTextureAndSampler(ShaderStage.Compute, 1, _intermediaryTexture, _sampler);
-            var sharpeningRange = new BufferRange(sharpeningBufferHandle, 0, sizeof(float));
-            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(4, sharpeningRange) });
+            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(4, sharpeningBuffer.Range) });
             _pipeline.SetImage(0, destinationTexture);
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
 
             _pipeline.Finish();
-
-            _renderer.BufferManager.Delete(bufferHandle);
-            _renderer.BufferManager.Delete(sharpeningBufferHandle);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
@@ -143,11 +143,11 @@ namespace Ryujinx.Graphics.Vulkan.Effects
 
             int rangeSize = dimensionsBuffer.Length * sizeof(float);
             using var buffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, rangeSize);
-            _renderer.BufferManager.SetData(buffer.Handle, buffer.Offset, dimensionsBuffer);
+            buffer.Holder.SetDataUnchecked(buffer.Offset, dimensionsBuffer);
 
             ReadOnlySpan<float> sharpeningBufferData = stackalloc float[] { 1.5f - (Level * 0.01f * 1.5f) };
             using var sharpeningBuffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, sizeof(float));
-            _renderer.BufferManager.SetData(sharpeningBuffer.Handle, sharpeningBuffer.Offset, sharpeningBufferData);
+            sharpeningBuffer.Holder.SetDataUnchecked(sharpeningBuffer.Offset, sharpeningBufferData);
 
             int threadGroupWorkRegionDim = 16;
             int dispatchX = (width + (threadGroupWorkRegionDim - 1)) / threadGroupWorkRegionDim;

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
@@ -66,12 +66,11 @@ namespace Ryujinx.Graphics.Vulkan.Effects
 
             ReadOnlySpan<float> resolutionBuffer = stackalloc float[] { view.Width, view.Height };
             int rangeSize = resolutionBuffer.Length * sizeof(float);
-            var bufferHandle = _renderer.BufferManager.CreateWithHandle(_renderer, rangeSize);
+            using var buffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, rangeSize);
 
-            _renderer.BufferManager.SetData(bufferHandle, 0, resolutionBuffer);
+            _renderer.BufferManager.SetData(buffer.Handle, buffer.Offset, resolutionBuffer);
 
-            var bufferRanges = new BufferRange(bufferHandle, 0, rangeSize);
-            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
+            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, buffer.Range) });
 
             var dispatchX = BitUtils.DivRoundUp(view.Width, IPostProcessingEffect.LocalGroupSize);
             var dispatchY = BitUtils.DivRoundUp(view.Height, IPostProcessingEffect.LocalGroupSize);
@@ -79,7 +78,6 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.SetImage(0, _texture, FormatTable.ConvertRgba8SrgbToUnorm(view.Info.Format));
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
 
-            _renderer.BufferManager.Delete(bufferHandle);
             _pipeline.ComputeBarrier();
 
             _pipeline.Finish();

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             int rangeSize = resolutionBuffer.Length * sizeof(float);
             using var buffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, rangeSize);
 
-            _renderer.BufferManager.SetData(buffer.Handle, buffer.Offset, resolutionBuffer);
+            buffer.Holder.SetDataUnchecked(buffer.Offset, resolutionBuffer);
 
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, buffer.Range) });
 

--- a/src/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
@@ -217,7 +217,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             int rangeSize = resolutionBuffer.Length * sizeof(float);
             using var buffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, rangeSize);
 
-            _renderer.BufferManager.SetData(buffer.Handle, buffer.Offset, resolutionBuffer);
+            buffer.Holder.SetDataUnchecked(buffer.Offset, resolutionBuffer);
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, buffer.Range) });
             _pipeline.SetImage(0, _edgeOutputTexture, FormatTable.ConvertRgba8SrgbToUnorm(view.Info.Format));
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);

--- a/src/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
@@ -215,11 +215,10 @@ namespace Ryujinx.Graphics.Vulkan.Effects
 
             ReadOnlySpan<float> resolutionBuffer = stackalloc float[] { view.Width, view.Height };
             int rangeSize = resolutionBuffer.Length * sizeof(float);
-            var bufferHandle = _renderer.BufferManager.CreateWithHandle(_renderer, rangeSize);
+            using var buffer = _renderer.BufferManager.ReserveOrCreate(_renderer, cbs, rangeSize);
 
-            _renderer.BufferManager.SetData(bufferHandle, 0, resolutionBuffer);
-            var bufferRanges = new BufferRange(bufferHandle, 0, rangeSize);
-            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
+            _renderer.BufferManager.SetData(buffer.Handle, buffer.Offset, resolutionBuffer);
+            _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, buffer.Range) });
             _pipeline.SetImage(0, _edgeOutputTexture, FormatTable.ConvertRgba8SrgbToUnorm(view.Info.Format));
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
@@ -244,8 +243,6 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.ComputeBarrier();
 
             _pipeline.Finish();
-
-            _renderer.BufferManager.Delete(bufferHandle);
 
             return _outputTexture;
         }

--- a/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -1015,7 +1015,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             const int ParamsBufferSize = 4;
 
-            Span<int> shaderParams = stackalloc int[sizeof(int)];
+            Span<int> shaderParams = stackalloc int[ParamsBufferSize / sizeof(int)];
 
             int srcBpp = src.Info.BytesPerPixel;
             int dstBpp = dst.Info.BytesPerPixel;

--- a/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -432,7 +432,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, RegionBufferSize);
 
-            gd.BufferManager.SetData<float>(buffer.Handle, buffer.Offset, region);
+            buffer.Holder.SetDataUnchecked<float>(buffer.Offset, region);
 
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(1, buffer.Range) });
 
@@ -527,7 +527,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, RegionBufferSize);
 
-            gd.BufferManager.SetData<float>(buffer.Handle, buffer.Offset, region);
+            buffer.Holder.SetDataUnchecked<float>(buffer.Offset, region);
 
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(1, buffer.Range) });
 
@@ -679,7 +679,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ClearColorBufferSize);
 
-            gd.BufferManager.SetData(buffer.Handle, buffer.Offset, clearColor);
+            buffer.Holder.SetDataUnchecked(buffer.Offset, clearColor);
 
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(1, buffer.Range) });
 
@@ -741,7 +741,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ClearColorBufferSize);
 
-            gd.BufferManager.SetData<float>(buffer.Handle, buffer.Offset, stackalloc float[] { depthValue });
+            buffer.Holder.SetDataUnchecked<float>(buffer.Offset, stackalloc float[] { depthValue });
 
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(1, buffer.Range) });
 
@@ -872,7 +872,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize);
 
-                gd.BufferManager.SetData<int>(buffer.Handle, buffer.Offset, shaderParams);
+                buffer.Holder.SetDataUnchecked<int>(buffer.Offset, shaderParams);
 
                 _pipeline.SetCommandBuffer(cbs);
 
@@ -1026,7 +1026,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize);
 
-            gd.BufferManager.SetData<int>(buffer.Handle, buffer.Offset, shaderParams);
+            buffer.Holder.SetDataUnchecked<int>(buffer.Offset, shaderParams);
 
             TextureView.InsertImageBarrier(
                 gd.Api,
@@ -1118,7 +1118,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize);
 
-            gd.BufferManager.SetData<int>(buffer.Handle, buffer.Offset, shaderParams);
+            buffer.Holder.SetDataUnchecked<int>(buffer.Offset, shaderParams);
 
             TextureView.InsertImageBarrier(
                 gd.Api,
@@ -1249,7 +1249,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize);
 
-            gd.BufferManager.SetData<int>(buffer.Handle, buffer.Offset, shaderParams);
+            buffer.Holder.SetDataUnchecked<int>(buffer.Offset, shaderParams);
 
             TextureView.InsertImageBarrier(
                 gd.Api,
@@ -1600,10 +1600,11 @@ namespace Ryujinx.Graphics.Vulkan
 
             pattern.OffsetIndex.CopyTo(shaderParams[..pattern.OffsetIndex.Length]);
 
-            using var patternScoped = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize, out var patternBuffer);
+            using var patternScoped = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize);
+            var patternBuffer = patternScoped.Holder;
             var patternBufferAuto = patternBuffer.GetBuffer();
 
-            gd.BufferManager.SetData<int>(patternScoped.Handle, patternScoped.Offset, shaderParams);
+            patternBuffer.SetDataUnchecked<int>(patternScoped.Offset, shaderParams);
 
             _pipeline.SetCommandBuffer(cbs);
 
@@ -1711,7 +1712,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             using var buffer = gd.BufferManager.ReserveOrCreate(gd, cbs, ParamsBufferSize);
 
-            gd.BufferManager.SetData<int>(buffer.Handle, buffer.Offset, shaderParams);
+            buffer.Holder.SetDataUnchecked<int>(buffer.Offset, shaderParams);
 
             _pipeline.SetCommandBuffer(cbs);
 

--- a/src/Ryujinx.Graphics.Vulkan/StagingBuffer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/StagingBuffer.cs
@@ -203,18 +203,13 @@ namespace Ryujinx.Graphics.Vulkan
         /// </summary>
         /// <param name="cbs">Command buffer to reserve the data on</param>
         /// <param name="size">The minimum size the reserved data requires</param>
-        /// <param name="alignment">The required alignment for the buffer offset. -1 uses the most permissive alignment</param>
+        /// <param name="alignment">The required alignment for the buffer offset</param>
         /// <returns>The reserved range of the staging buffer</returns>
-        public unsafe StagingBufferReserved? TryReserveData(CommandBufferScoped cbs, int size, int alignment = -1)
+        public unsafe StagingBufferReserved? TryReserveData(CommandBufferScoped cbs, int size, int alignment)
         {
             if (size > BufferSize)
             {
                 return null;
-            }
-
-            if (alignment == -1)
-            {
-                alignment = _resourceAlignment;
             }
 
             // Temporary reserved data cannot be fragmented.
@@ -231,6 +226,18 @@ namespace Ryujinx.Graphics.Vulkan
             }
 
             return ReserveDataImpl(cbs, size, alignment);
+        }
+
+        /// <summary>
+        /// Reserve a range on the staging buffer for the current command buffer and upload data to it.
+        /// Uses the most permissive byte alignment.
+        /// </summary>
+        /// <param name="cbs">Command buffer to reserve the data on</param>
+        /// <param name="size">The minimum size the reserved data requires</param>
+        /// <returns>The reserved range of the staging buffer</returns>
+        public unsafe StagingBufferReserved? TryReserveData(CommandBufferScoped cbs, int size)
+        {
+            return TryReserveData(cbs, size, _resourceAlignment);
         }
 
         private bool WaitFreeCompleted(CommandBufferPool cbp)


### PR DESCRIPTION
Helper shaders and post processing effects typically need some parameters to tell them what to do, which we pass via constant buffers that are created and destroyed each time.

This can vary in cost between different Vulkan drivers. It shows up on profiles on mesa and MoltenVK, so it's worth avoiding. Some games only do it once (BlitColor for present), others multiple times. It's also done for post processing filters and FSR upscaling, which creates two buffers.

For mirrors, I added the ability to reserve a range on the staging buffer for use as any type of binding. This PR allows these constant buffers to instead be temporarily reserved on the staging buffer similar to mirrors, skipping allocation and buffer management costs entirely. If there isn't enough space for the reservation, it creates a temporary buffer that will be disposed after use, similar to how it's done right now.

Two temporary allocations do remain:
- DrawTexture, because it doesn't have access to the command buffer scope.
- ~~Index buffer indirect conversion, because one of them is a storage buffer and thus is a little more complicated.~~
  - Added, but needs testing

There's a small cost in that the uniform buffer takes up more space due to alignment requirements. At worst that's 256 bytes (on a GTX 1070) but more modern GPUs should have a better time.

Worth testing across different games and post effects to make sure they still work.