### PR TITLE
Use unix timestamps on GetFileTimeStampRaw

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -186,7 +186,12 @@ namespace Ryujinx.HLE.FileSystem
 
         public void InitializeFsServer(LibHac.Horizon horizon, out HorizonClient fsServerClient)
         {
-            LocalFileSystem serverBaseFs = new(AppDataManager.BaseDirPath);
+            LocalFileSystem serverBaseFs = new(useUnixTimeStamps: true);
+            Result result = serverBaseFs.Initialize(AppDataManager.BaseDirPath, LocalFileSystem.PathMode.DefaultCaseSensitivity, ensurePathExists: true);
+            if (result.IsFailure())
+            {
+                throw new HorizonResultException(result, "Error creating LocalFileSystem.");
+            }
 
             fsServerClient = horizon.CreatePrivilegedHorizonClient();
             var fsServer = new FileSystemServer(fsServerClient);


### PR DESCRIPTION
LibHac supports returning the timestamps in Windows File Time or Unix timestamps. AFAIK Horizon only ever returns Unix timestamps. This PR changes the code to use a `LocalFileSystem` overload that allows Unix timestamps to be enabled. All the other overloads default to true, except the one that we use...

Fixes #6151.

Example:
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/5e6a09c8-3afb-453e-ab1d-9e47595b760d)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/487653c9-458e-49b5-8c38-ab16d9a2549d)
