### PR TITLE
Linux: Reorder available executables in Ryujinx.sh

### DIFF
--- a/distribution/linux/Ryujinx.sh
+++ b/distribution/linux/Ryujinx.sh
@@ -1,14 +1,21 @@
 #!/bin/sh
 
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
-RYUJINX_BIN="Ryujinx"
+
+if [ -f "$SCRIPT_DIR/Ryujinx.Headless.SDL2" ]; then
+    RYUJINX_BIN="Ryujinx.Headless.SDL2"
+fi
 
 if [ -f "$SCRIPT_DIR/Ryujinx.Ava" ]; then
     RYUJINX_BIN="Ryujinx.Ava"
 fi
 
-if [ -f "$SCRIPT_DIR/Ryujinx.Headless.SDL2" ]; then
-    RYUJINX_BIN="Ryujinx.Headless.SDL2"
+if [ -f "$SCRIPT_DIR/Ryujinx" ]; then
+    RYUJINX_BIN="Ryujinx"
+fi
+
+if [ -z "$RYUJINX_BIN" ]; then
+    exit 1
 fi
 
 COMMAND="env DOTNET_EnableAlternateStackCheck=1"
@@ -17,4 +24,4 @@ if command -v gamemoderun > /dev/null 2>&1; then
     COMMAND="$COMMAND gamemoderun"
 fi
 
-$COMMAND "$SCRIPT_DIR/$RYUJINX_BIN" "$@"
+exec $COMMAND "$SCRIPT_DIR/$RYUJINX_BIN" "$@"


### PR DESCRIPTION
Hi, I want to contribute. Also, see https://github.com/NixOS/nixpkgs/pull/278605.

* Avoid Ryujinx.Headless.SDL2 as a last resort in Ryujinx.desktop if you have all three executables installed.
