### PR TITLE
Default to Avalonia on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Upload Ryujinx artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
+          name: gtk-ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish
         if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
@@ -95,7 +95,7 @@ jobs:
       - name: Upload Ryujinx.Ava artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ava-ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
+          name: ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish_ava
         if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
@@ -146,8 +146,8 @@ jobs:
       - name: Upload Ryujinx.Ava artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ava-ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-macos_universal
           path: "publish_ava/*.tar.gz"
+          name: ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-macos_universal
         if: github.event_name == 'pull_request'
 
       - name: Upload Ryujinx.Headless.SDL2 artifact

--- a/.github/workflows/nightly_pr_comment.yml
+++ b/.github/workflows/nightly_pr_comment.yml
@@ -39,24 +39,24 @@ jobs:
               return core.error(`No artifacts found`);
             }
             let body = `Download the artifacts for this pull request:\n`;
-            let hidden_avalonia_artifacts = `\n\n <details><summary>Experimental GUI (Avalonia)</summary>\n`;
+            let hidden_gtk_artifacts = `\n\n <details><summary>Deprecated GUI (GTK)</summary>\n`;
             let hidden_headless_artifacts = `\n\n <details><summary>GUI-less (SDL2)</summary>\n`;
             let hidden_debug_artifacts = `\n\n <details><summary>Only for Developers</summary>\n`;
             for (const art of artifacts) {
               if(art.name.includes('Debug')) {
                 hidden_debug_artifacts += `\n* [${art.name}](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
-              } else if(art.name.includes('ava-ryujinx')) {
-                hidden_avalonia_artifacts += `\n* [${art.name}](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+              } else if(art.name.includes('gtk-ryujinx')) {
+                hidden_gtk_artifacts += `\n* [${art.name}](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
               } else if(art.name.includes('sdl2-ryujinx-headless')) {
                 hidden_headless_artifacts += `\n* [${art.name}](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
               } else {
                 body += `\n* [${art.name}](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
               }
             }
-            hidden_avalonia_artifacts += `\n</details>`;
+            hidden_gtk_artifacts += `\n</details>`;
             hidden_headless_artifacts += `\n</details>`;
             hidden_debug_artifacts += `\n</details>`;
-            body += hidden_avalonia_artifacts;
+            body += hidden_gtk_artifacts;
             body += hidden_headless_artifacts;
             body += hidden_debug_artifacts;
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           pushd publish_gtk
-          7z a ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-win_x64.zip publish
+          7z a ../release_output/gtk-ryujinx-${{ steps.version_info.outputs.build_version }}-win_x64.zip publish
           popd
 
           pushd publish_sdl2_headless
@@ -108,7 +108,7 @@ jobs:
           popd
 
           pushd publish_ava
-          7z a ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-win_x64.zip publish
+          7z a ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-win_x64.zip publish
           popd
         shell: bash
 
@@ -117,7 +117,7 @@ jobs:
         run: |
           pushd publish_gtk
           chmod +x publish/Ryujinx.sh publish/Ryujinx
-          tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-linux_x64.tar.gz publish
+          tar -czvf ../release_output/gtk-ryujinx-${{ steps.version_info.outputs.build_version }}-linux_x64.tar.gz publish
           popd
 
           pushd publish_sdl2_headless
@@ -127,7 +127,7 @@ jobs:
 
           pushd publish_ava
           chmod +x publish/Ryujinx.sh publish/Ryujinx.Ava
-          tar -czvf ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-linux_x64.tar.gz publish
+          tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-linux_x64.tar.gz publish
           popd
         shell: bash
 

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -103,7 +103,7 @@ namespace Ryujinx.Modules
 
                 foreach (var asset in fetched.Assets)
                 {
-                    if (asset.Name.StartsWith("test-ava-ryujinx") && asset.Name.EndsWith(_platformExt))
+                    if (asset.Name.StartsWith("ryujinx") && asset.Name.EndsWith(_platformExt))
                     {
                         _buildUrl = asset.BrowserDownloadUrl;
 
@@ -308,7 +308,7 @@ namespace Ryujinx.Modules
                         // Fallback if the executable could not be found.
                         if (!Path.Exists(Path.Combine(executableDirectory, ryuName)))
                         {
-                            ryuName = OperatingSystem.IsWindows() ? "Ryujinx.Ava.exe" : "Ryujinx.Ava";
+                            ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
                         }
 
                         ProcessStartInfo processStart = new(ryuName)

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Modules
 
         private static string _buildVer;
         private static string _platformExt;
-        private static string _platformPrefix = "test-ava-ryujinx";
+        private static string _platformPrefix = "ryujinx";
         private static string _buildUrl;
         private static long _buildSize;
 
@@ -80,7 +80,7 @@ namespace Ryujinx.Modules
             else if (OperatingSystem.IsLinux())
             {
                 _platformExt = "linux_x64.tar.gz";
-                _platformPrefix = "ryujinx";
+                _platformPrefix = "gtk-ryujinx";
                 artifactIndex = 0;
             }
 

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.Modules
 
         private static string _buildVer;
         private static string _platformExt;
+        private static string _platformPrefix = "test-ava-ryujinx";
         private static string _buildUrl;
         private static long _buildSize;
 
@@ -79,6 +80,7 @@ namespace Ryujinx.Modules
             else if (OperatingSystem.IsLinux())
             {
                 _platformExt = "linux_x64.tar.gz";
+                _platformPrefix = "ryujinx";
                 artifactIndex = 0;
             }
 
@@ -117,7 +119,7 @@ namespace Ryujinx.Modules
 
                 foreach (var asset in fetched.Assets)
                 {
-                    if (asset.Name.StartsWith("ryujinx") && asset.Name.EndsWith(_platformExt))
+                    if (asset.Name.StartsWith(_platformPrefix) && asset.Name.EndsWith(_platformExt))
                     {
                         _buildUrl = asset.BrowserDownloadUrl;
 


### PR DESCRIPTION
- Makes Avalonia executables the default for Windows
- In order to prevent NVAPI issues, `Ryujinx.Ava.exe` has been renamed to `Ryujinx.exe`

**Maintainers, please check the changes to updaters and workflows.**

# Rationale
The transition to Avalonia is long overdue. The only remaining issues involve Gamescope on the Steam Deck. Avalonia has been used for months by many Windows users without issues.

In contrast, the significant number of bugs in GTK continuously creates issues in support channels. GTK is outdated, lacking several features, and has significantly reduced quality of life compared with Avalonia.

To quote Metro "Continuing to have such a broken interface as the default only hinders the development progress, the general user experience and, subsequently, the users' general perception of Ryujinx."

Succeeds #5949. @AcK77 Please do not close this PR without further discussion.