### PR TITLE
Ava UI: Mod Manager Fixes

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -383,6 +383,7 @@
   "DialogControllerSettingsModifiedConfirmSubMessage": "Do you want to save?",
   "DialogLoadFileErrorMessage": "{0}. Errored File: {1}",
   "DialogModAlreadyExistsMessage": "Mod already exists",
+  "DialogModInvalidMessage": "The specified directory does not contain a mod!",
   "DialogDlcNoDlcErrorMessage": "The specified file does not contain a DLC for the selected title!",
   "DialogPerformanceCheckLoggingEnabledMessage": "You have trace logging enabled, which is designed to be used by developers only.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "For optimal performance, it's recommended to disable trace logging. Would you like to disable trace logging now?",

--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -384,6 +384,7 @@
   "DialogLoadFileErrorMessage": "{0}. Errored File: {1}",
   "DialogModAlreadyExistsMessage": "Mod already exists",
   "DialogModInvalidMessage": "The specified directory does not contain a mod!",
+  "DialogModDeleteNoParentMessage": "Failed to Delete: Could not find the parent directory for mod \"{0}\"!",
   "DialogDlcNoDlcErrorMessage": "The specified file does not contain a DLC for the selected title!",
   "DialogPerformanceCheckLoggingEnabledMessage": "You have trace logging enabled, which is designed to be used by developers only.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "For optimal performance, it's recommended to disable trace logging. Would you like to disable trace logging now?",

--- a/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
@@ -193,6 +193,13 @@ namespace Ryujinx.Ava.UI.ViewModels
             var directories = Directory.GetDirectories(directory.ToString(), "*", SearchOption.AllDirectories);
             var destinationDir = ModLoader.GetApplicationDir(ModLoader.GetSdModsBasePath(), _applicationId.ToString("x16"));
 
+            if (directories.Length == 0)
+            {
+                // Not a valid mod directory
+                // TODO: More robust checking for valid mod folders
+                return;
+            }
+
             foreach (var dir in directories)
             {
                 string dirToCreate = dir.Replace(directory.Parent.ToString(), destinationDir);
@@ -202,7 +209,10 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     Dispatcher.UIThread.Post(async () =>
                     {
-                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogLoadFileErrorMessage, LocaleKeys.DialogModAlreadyExistsMessage, dirToCreate));
+                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(
+                            LocaleKeys.DialogLoadFileErrorMessage,
+                            LocaleManager.Instance[LocaleKeys.DialogModAlreadyExistsMessage],
+                            dirToCreate));
                     });
 
                     return;

--- a/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
@@ -215,7 +215,24 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         private void AddMod(DirectoryInfo directory)
         {
-            var directories = Directory.GetDirectories(directory.ToString(), "*", SearchOption.AllDirectories);
+            string[] directories;
+
+            try
+            {
+                directories = Directory.GetDirectories(directory.ToString(), "*", SearchOption.AllDirectories);
+            }
+            catch (Exception exception)
+            {
+                Dispatcher.UIThread.Post(async () =>
+                {
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(
+                        LocaleKeys.DialogLoadFileErrorMessage,
+                        exception.ToString(),
+                        directory));
+                });
+                return;
+            }
+
             var destinationDir = ModLoader.GetApplicationDir(ModLoader.GetSdModsBasePath(), _applicationId.ToString("x16"));
 
             // TODO: More robust checking for valid mod folders

--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -324,7 +324,7 @@ namespace Ryujinx.HLE.HOS
                 return;
             }
 
-            Logger.Info?.Print(LogClass.ModLoader, $"Searching mods for {((applicationId & 0x1000) != 0 ? "DLC" : "Application")} {applicationId:X16}");
+            Logger.Info?.Print(LogClass.ModLoader, $"Searching mods for {((applicationId & 0x1000) != 0 ? "DLC" : "Application")} {applicationId:X16} in \"{contentsDir.FullName}\"");
 
             var applicationDir = FindApplicationDir(contentsDir, $"{applicationId:x16}");
 


### PR DESCRIPTION
Changes:
- Fixes a crash when selecting an invalid mod directory
- Fixes a crash when trying to enumerate through a directory that Ryujinx doesn't have permissions to access
- Fixes deleting a mod not deleting at the parent directory, leaving invisible orphan files that would prevent re-importing of the same mod
- Better logging and user feedback

TODO: More robust testing of folders to see if they contain valid mods before copying them to the mod directory. This will still copy invalid folders to the mod directory if they have subdirectories, where they won't appear in the list.

Since copying is recursive, this is especially important. Selecting a top-level folder by accident could be very expensive.