### PR TITLE
Ava UI: Mod Manager Fixes (Again)

### DIFF
--- a/src/Ryujinx.Ava/UI/Models/ModModel.cs
+++ b/src/Ryujinx.Ava/UI/Models/ModModel.cs
@@ -17,14 +17,16 @@ namespace Ryujinx.Ava.UI.Models
             }
         }
 
+        public bool InSd { get; }
         public string Path { get; }
         public string Name { get; }
 
-        public ModModel(string path, string name, bool enabled)
+        public ModModel(string path, string name, bool enabled, bool inSd)
         {
             Path = path;
             Name = name;
             Enabled = enabled;
+            InSd = inSd;
         }
     }
 }

--- a/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
@@ -102,13 +102,14 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             foreach (var path in modsBasePaths)
             {
+                var inSd = path == ModLoader.GetSdModsBasePath();
                 var modCache = new ModLoader.ModCache();
 
                 ModLoader.QueryContentsDir(modCache, new DirectoryInfo(Path.Combine(path, "contents")), applicationId);
 
                 foreach (var mod in modCache.RomfsDirs)
                 {
-                    var modModel = new ModModel(mod.Path.Parent.FullName, mod.Name, mod.Enabled);
+                    var modModel = new ModModel(mod.Path.Parent.FullName, mod.Name, mod.Enabled, inSd);
                     if (Mods.All(x => x.Path != mod.Path.Parent.FullName))
                     {
                         Mods.Add(modModel);
@@ -117,12 +118,12 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 foreach (var mod in modCache.RomfsContainers)
                 {
-                    Mods.Add(new ModModel(mod.Path.FullName, mod.Name, mod.Enabled));
+                    Mods.Add(new ModModel(mod.Path.FullName, mod.Name, mod.Enabled, inSd));
                 }
 
                 foreach (var mod in modCache.ExefsDirs)
                 {
-                    var modModel = new ModModel(mod.Path.Parent.FullName, mod.Name, mod.Enabled);
+                    var modModel = new ModModel(mod.Path.Parent.FullName, mod.Name, mod.Enabled, inSd);
                     if (Mods.All(x => x.Path != mod.Path.Parent.FullName))
                     {
                         Mods.Add(modModel);
@@ -131,7 +132,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 foreach (var mod in modCache.ExefsContainers)
                 {
-                    Mods.Add(new ModModel(mod.Path.FullName, mod.Name, mod.Enabled));
+                    Mods.Add(new ModModel(mod.Path.FullName, mod.Name, mod.Enabled, inSd));
                 }
             }
 
@@ -185,26 +186,14 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             var parentDir = String.Empty;
 
-            var modsDir = ModLoader.GetApplicationDir(ModLoader.GetSdModsBasePath(), _applicationId.ToString("x16"));
+            var basePath = model.InSd ? ModLoader.GetSdModsBasePath() : ModLoader.GetModsBasePath();
+            var modsDir = ModLoader.GetApplicationDir(basePath, _applicationId.ToString("x16"));
 
             foreach (var dir in Directory.GetDirectories(modsDir, "*", SearchOption.TopDirectoryOnly))
             {
                 if (Directory.GetDirectories(dir, "*", SearchOption.AllDirectories).Contains(model.Path))
                 {
                     parentDir = dir;
-                }
-            }
-
-            if (parentDir == String.Empty)
-            {
-                modsDir = ModLoader.GetApplicationDir(ModLoader.GetModsBasePath(), _applicationId.ToString("x16"));
-
-                foreach (var dir in Directory.GetDirectories(modsDir, "*", SearchOption.TopDirectoryOnly))
-                {
-                    if (Directory.GetDirectories(dir, "*", SearchOption.AllDirectories).Contains(model.Path))
-                    {
-                        parentDir = dir;
-                    }
                 }
             }
 

--- a/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
@@ -194,6 +194,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 if (Directory.GetDirectories(dir, "*", SearchOption.AllDirectories).Contains(model.Path))
                 {
                     parentDir = dir;
+                    break;
                 }
             }
 

--- a/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
@@ -183,8 +183,9 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public void Delete(ModModel model)
         {
-            var modsDir = ModLoader.GetApplicationDir(ModLoader.GetSdModsBasePath(), _applicationId.ToString("x16"));
             var parentDir = String.Empty;
+
+            var modsDir = ModLoader.GetApplicationDir(ModLoader.GetSdModsBasePath(), _applicationId.ToString("x16"));
 
             foreach (var dir in Directory.GetDirectories(modsDir, "*", SearchOption.TopDirectoryOnly))
             {
@@ -196,11 +197,24 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             if (parentDir == String.Empty)
             {
+                modsDir = ModLoader.GetApplicationDir(ModLoader.GetModsBasePath(), _applicationId.ToString("x16"));
+
+                foreach (var dir in Directory.GetDirectories(modsDir, "*", SearchOption.TopDirectoryOnly))
+                {
+                    if (Directory.GetDirectories(dir, "*", SearchOption.AllDirectories).Contains(model.Path))
+                    {
+                        parentDir = dir;
+                    }
+                }
+            }
+
+            if (parentDir == String.Empty)
+            {
                 Dispatcher.UIThread.Post(async () =>
                 {
                     await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(
                         LocaleKeys.DialogModDeleteNoParentMessage,
-                        parentDir));
+                        model.Path));
                 });
                 return;
             }

--- a/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/ModManagerViewModel.cs
@@ -189,7 +189,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             var basePath = model.InSd ? ModLoader.GetSdModsBasePath() : ModLoader.GetModsBasePath();
             var modsDir = ModLoader.GetApplicationDir(basePath, _applicationId.ToString("x16"));
 
-            if (new DirectoryInfo(model.Path).Parent?.FullName == basePath)
+            if (new DirectoryInfo(model.Path).Parent?.FullName == modsDir)
             {
                 isSubdir = false;
             }


### PR DESCRIPTION
- Fixed a typo in the error message when the mod fails to delete
- Fixed deleting mods from non-Atmosphere directory
- Fixed deleting non-subdirectory mods
- Fixed excessive looping if parent directory is found