### PR TITLE
Implement virtual buffer dependencies

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -738,12 +738,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 // Clamp range to the specified range.
                 ulong copySrcOffset = Math.Max(srcOffset, innerOffset);
-                copySize = Math.Min(innerEndOffset, srcOffset + copySize) - copySrcOffset;
-                dstOffset += copySrcOffset - srcOffset;
-                srcOffset = copySrcOffset;
+                ulong copySrcEndOffset = Math.Min(innerEndOffset, srcOffset + copySize);
 
-                if (copySize != 0)
+                if (copySrcEndOffset > copySrcOffset)
                 {
+                    copySize = copySrcEndOffset - copySrcOffset;
+                    dstOffset += copySrcOffset - srcOffset;
+                    srcOffset = copySrcOffset;
+
                     _context.Renderer.Pipeline.CopyBuffer(Handle, virtualBuffer.Handle, (int)srcOffset, (int)dstOffset, (int)copySize);
                 }
             }

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -67,7 +67,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private readonly Action<ulong, ulong> _modifiedDelegate;
 
         private HashSet<MultiRangeBuffer> _virtualDependencies;
-        private ReaderWriterLockSlim _virtualDependenciesLock;
+        private readonly ReaderWriterLockSlim _virtualDependenciesLock;
 
         private int _sequenceNumber;
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -546,7 +546,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public void CopyTo(Buffer destination, int dstOffset)
         {
             CopyFromDependantVirtualBuffers();
-
             _context.Renderer.Pipeline.CopyBuffer(Handle, destination.Handle, 0, dstOffset, (int)Size);
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -589,8 +589,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             _context.Renderer.BackgroundContextAction(() =>
             {
-                CopyFromDependantVirtualBuffers();
-
                 var ranges = _modifiedRanges;
 
                 if (ranges != null)

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -65,6 +65,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private readonly Action<ulong, ulong> _loadDelegate;
         private readonly Action<ulong, ulong> _modifiedDelegate;
 
+        private HashSet<MultiRangeBuffer> _virtualDependencies;
+
         private int _sequenceNumber;
 
         private readonly bool _useGranular;
@@ -220,8 +222,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </remarks>
         /// <param name="address">Start address of the range to synchronize</param>
         /// <param name="size">Size in bytes of the range to synchronize</param>
-        public void SynchronizeMemory(ulong address, ulong size)
+        /// <param name="copyBackVirtual">Whether virtual buffers that uses this buffer as backing memory should have its data copied back if modified</param>
+        public void SynchronizeMemory(ulong address, ulong size, bool copyBackVirtual = true)
         {
+            if (copyBackVirtual)
+            {
+                CopyFromDependantVirtualBuffers();
+            }
+
             if (_useGranular)
             {
                 _memoryTrackingGranular.QueryModified(address, size, _modifiedDelegate, _context.SequenceNumber);
@@ -239,6 +247,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     else
                     {
                         _context.Renderer.SetBufferData(Handle, 0, _physicalMemory.GetSpan(Address, (int)Size));
+                        CopyToDependantVirtualBuffers();
                     }
 
                     _sequenceNumber = _context.SequenceNumber;
@@ -460,6 +469,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
             int offset = (int)(mAddress - Address);
 
             _context.Renderer.SetBufferData(Handle, offset, _physicalMemory.GetSpan(mAddress, (int)mSize));
+
+            CopyToDependantVirtualBuffers(mAddress, mSize);
         }
 
         /// <summary>
@@ -520,6 +531,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="dstOffset">The offset of the destination buffer to copy into</param>
         public void CopyTo(Buffer destination, int dstOffset)
         {
+            CopyFromDependantVirtualBuffers();
+
             _context.Renderer.Pipeline.CopyBuffer(Handle, destination.Handle, 0, dstOffset, (int)Size);
         }
 
@@ -563,6 +576,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             _context.Renderer.BackgroundContextAction(() =>
             {
+                CopyFromDependantVirtualBuffers();
+
                 var ranges = _modifiedRanges;
 
                 if (ranges != null)
@@ -615,6 +630,123 @@ namespace Ryujinx.Graphics.Gpu.Memory
             modifiedRanges?.Clear(address, size);
 
             UnmappedSequence++;
+        }
+
+        /// <summary>
+        /// Adds a virtual buffer dependency, indicating that a virtual buffer depends on data from this buffer.
+        /// </summary>
+        /// <param name="virtualBuffer">Dependant virtual buffer</param>
+        public void AddVirtualDependency(MultiRangeBuffer virtualBuffer)
+        {
+            (_virtualDependencies ??= new()).Add(virtualBuffer);
+        }
+
+        /// <summary>
+        /// Removes a virtual buffer dependency, indicating that a virtual buffer no longer depends on data from this buffer.
+        /// </summary>
+        /// <param name="virtualBuffer">Dependant virtual buffer</param>
+        public void RemoveVirtualDependency(MultiRangeBuffer virtualBuffer)
+        {
+            if (_virtualDependencies != null)
+            {
+                _virtualDependencies.Remove(virtualBuffer);
+
+                if (_virtualDependencies.Count == 0)
+                {
+                    _virtualDependencies = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies the buffer data to all virtual buffers that depends on it.
+        /// </summary>
+        public void CopyToDependantVirtualBuffers()
+        {
+            CopyToDependantVirtualBuffers(Address, Size);
+        }
+
+        /// <summary>
+        /// Copies the buffer data inside the specifide range to all virtual buffers that depends on it.
+        /// </summary>
+        /// <param name="address">Address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        public void CopyToDependantVirtualBuffers(ulong address, ulong size)
+        {
+            if (_virtualDependencies != null)
+            {
+                foreach (var virtualBuffer in _virtualDependencies)
+                {
+                    CopyToDependantVirtualBuffer(virtualBuffer, address, size);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies all modified ranges from all virtual buffers back into this buffer.
+        /// </summary>
+        public void CopyFromDependantVirtualBuffers()
+        {
+            if (_virtualDependencies != null)
+            {
+                foreach (var virtualBuffer in _virtualDependencies)
+                {
+                    virtualBuffer.ConsumeModifiedRegion(this, (address, size) =>
+                    {
+                        // Get offset inside both this and the virtual buffer.
+                        // Note that sometimes there is no right answer for the virtual offset,
+                        // as the same physical range might be mapped multiple times inside a virtual buffer.
+                        // We just assume it does not happen in practice as it can only be implemented correctly
+                        // when the host has support for proper sparse mapping.
+
+                        int physicalOffset = (int)(address - Address);
+                        int virtualOffset = virtualBuffer.Range.FindOffset(new(address, size));
+
+                        _context.Renderer.Pipeline.CopyBuffer(virtualBuffer.Handle, Handle, virtualOffset, physicalOffset, (int)size);
+                    });
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies the buffer data to the specified virtual buffer.
+        /// </summary>
+        /// <param name="virtualBuffer">Virtual buffer to copy the data into</param>
+        public void CopyToDependantVirtualBuffer(MultiRangeBuffer virtualBuffer)
+        {
+            CopyToDependantVirtualBuffer(virtualBuffer, Address, Size);
+        }
+
+        /// <summary>
+        /// Copies the buffer data inside the given range to the specified virtual buffer.
+        /// </summary>
+        /// <param name="virtualBuffer">Virtual buffer to copy the data into</param>
+        /// <param name="address">Address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        public void CopyToDependantVirtualBuffer(MultiRangeBuffer virtualBuffer, ulong address, ulong size)
+        {
+            // Broadcast data to all ranges of the virtual buffer that are contained inside this buffer.
+
+            ulong lastOffset = 0;
+
+            while (virtualBuffer.TryGetPhysicalOffset(this, lastOffset, out ulong srcOffset, out ulong dstOffset, out ulong copySize))
+            {
+                ulong innerOffset = address - Address;
+                ulong innerEndOffset = (address + size) - Address;
+
+                lastOffset = dstOffset + copySize;
+
+                // Clamp range to the specified range.
+                ulong copySrcOffset = Math.Max(srcOffset, innerOffset);
+                copySize = Math.Min(innerEndOffset, srcOffset + copySize) - copySrcOffset;
+                dstOffset += copySrcOffset - srcOffset;
+                srcOffset = copySrcOffset;
+
+                if (copySize != 0)
+                {
+                    _context.Renderer.Pipeline.CopyBuffer(Handle, virtualBuffer.Handle, (int)srcOffset, (int)dstOffset, (int)copySize);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -712,7 +712,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Copies all modified ranges from all virtual buffers back into this buffer.
         /// </summary>
-        /// 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void CopyFromDependantVirtualBuffersImpl()
         {

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -3,6 +3,7 @@ using Ryujinx.Memory.Range;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Gpu.Memory
 {
@@ -944,7 +945,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 buffer = _buffers.FindFirstOverlap(address, size);
 
-                buffer.SynchronizeMemoryWithVirtualCopyBack(address, size);
+                buffer.CopyFromDependantVirtualBuffers();
+                buffer.SynchronizeMemory(address, size);
 
                 if (write)
                 {
@@ -986,6 +988,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="address">Start address of the memory range</param>
         /// <param name="size">Size in bytes of the memory range</param>
         /// <param name="copyBackVirtual">Whether virtual buffers that uses this buffer as backing memory should have its data copied back if modified</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SynchronizeBufferRange(ulong address, ulong size, bool copyBackVirtual)
         {
             if (size != 0)
@@ -994,12 +997,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if (copyBackVirtual)
                 {
-                    buffer.SynchronizeMemoryWithVirtualCopyBack(address, size);
+                    buffer.CopyFromDependantVirtualBuffers();
                 }
-                else
-                {
-                    buffer.SynchronizeMemory(address, size);
-                }
+
+                buffer.SynchronizeMemory(address, size);
             }
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -141,7 +141,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             // Fast path not taken for non-contiguous ranges,
             // since multi-range buffers are not coalesced, so a buffer that covers
             // the entire cached range might not actually exist.
-            if (memoryManager.VirtualBufferCache.TryGetOrAddRange(gpuVa, size, out MultiRange range) &&
+            if (memoryManager.VirtualRangeCache.TryGetOrAddRange(gpuVa, size, out MultiRange range) &&
                 range.Count == 1)
             {
                 return range;
@@ -170,7 +170,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             // Fast path not taken for non-contiguous ranges,
             // since multi-range buffers are not coalesced, so a buffer that covers
             // the entire cached range might not actually exist.
-            if (memoryManager.VirtualBufferCache.TryGetOrAddRange(gpuVa, size, out MultiRange range) &&
+            if (memoryManager.VirtualRangeCache.TryGetOrAddRange(gpuVa, size, out MultiRange range) &&
                 range.Count == 1)
             {
                 return range;

--- a/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -40,9 +40,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         internal PhysicalMemory Physical { get; }
 
         /// <summary>
-        /// Virtual buffer cache.
+        /// Virtual range cache.
         /// </summary>
-        internal VirtualBufferCache VirtualBufferCache { get; }
+        internal VirtualRangeCache VirtualRangeCache { get; }
 
         /// <summary>
         /// Cache of GPU counters.
@@ -56,12 +56,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
         internal MemoryManager(PhysicalMemory physicalMemory)
         {
             Physical = physicalMemory;
-            VirtualBufferCache = new VirtualBufferCache(this);
+            VirtualRangeCache = new VirtualRangeCache(this);
             CounterCache = new CounterCache();
             _pageTable = new ulong[PtLvl0Size][];
             MemoryUnmapped += Physical.TextureCache.MemoryUnmappedHandler;
             MemoryUnmapped += Physical.BufferCache.MemoryUnmappedHandler;
-            MemoryUnmapped += VirtualBufferCache.MemoryUnmappedHandler;
+            MemoryUnmapped += VirtualRangeCache.MemoryUnmappedHandler;
             MemoryUnmapped += CounterCache.MemoryUnmappedHandler;
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/MultiRangeBuffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MultiRangeBuffer.cs
@@ -181,7 +181,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 MemoryRange subRange = range.GetSubRange(i);
 
-                _modifiedRanges.Add(new(subRange.Address, subRange.Size, 0, null));
+                _modifiedRanges.SignalModified(subRange.Address, subRange.Size);
             }
 
             ModificationSequenceNumber = modifiedSequenceNumber;

--- a/src/Ryujinx.Graphics.Gpu/Memory/MultiRangeBuffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MultiRangeBuffer.cs
@@ -1,6 +1,7 @@
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Memory.Range;
 using System;
+using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gpu.Memory
 {
@@ -22,11 +23,67 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public MultiRange Range { get; }
 
         /// <summary>
+        /// Physical buffer dependency entry.
+        /// </summary>
+        private readonly struct PhysicalDependency
+        {
+            /// <summary>
+            /// Physical buffer.
+            /// </summary>
+            public readonly Buffer PhysicalBuffer;
+
+            /// <summary>
+            /// Offset of the range on the physical buffer.
+            /// </summary>
+            public readonly ulong PhysicalOffset;
+
+            /// <summary>
+            /// Offset of the range on the virtual buffer.
+            /// </summary>
+            public readonly ulong VirtualOffset;
+
+            /// <summary>
+            /// Size of the range.
+            /// </summary>
+            public readonly ulong Size;
+
+            /// <summary>
+            /// Creates a new physical dependency.
+            /// </summary>
+            /// <param name="physicalBuffer">Physical buffer</param>
+            /// <param name="physicalOffset">Offset of the range on the physical buffer</param>
+            /// <param name="virtualOffset">Offset of the range on the virtual buffer</param>
+            /// <param name="size">Size of the range</param>
+            public PhysicalDependency(Buffer physicalBuffer, ulong physicalOffset, ulong virtualOffset, ulong size)
+            {
+                PhysicalBuffer = physicalBuffer;
+                PhysicalOffset = physicalOffset;
+                VirtualOffset = virtualOffset;
+                Size = size;
+            }
+        }
+
+        private List<PhysicalDependency> _dependencies;
+        private BufferModifiedRangeList _modifiedRanges = null;
+
+        /// <summary>
         /// Creates a new instance of the buffer.
         /// </summary>
         /// <param name="context">GPU context that the buffer belongs to</param>
         /// <param name="range">Range of memory where the data is mapped</param>
-        /// <param name="storages">Backing memory for the buffers</param>
+        public MultiRangeBuffer(GpuContext context, MultiRange range)
+        {
+            _context = context;
+            Range = range;
+            Handle = context.Renderer.CreateBuffer((int)range.GetSize());
+        }
+
+        /// <summary>
+        /// Creates a new instance of the buffer.
+        /// </summary>
+        /// <param name="context">GPU context that the buffer belongs to</param>
+        /// <param name="range">Range of memory where the data is mapped</param>
+        /// <param name="storages">Backing memory for the buffer</param>
         public MultiRangeBuffer(GpuContext context, MultiRange range, ReadOnlySpan<BufferRange> storages)
         {
             _context = context;
@@ -50,10 +107,107 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Removes all physical buffer dependencies.
+        /// </summary>
+        public void ClearPhysicalDependencies()
+        {
+            _dependencies?.Clear();
+        }
+
+        /// <summary>
+        /// Adds a physical buffer dependency.
+        /// </summary>
+        /// <param name="buffer">Physical buffer to be added</param>
+        /// <param name="rangeAddress">Address inside the physical buffer where the virtual buffer range is located</param>
+        /// <param name="dstOffset">Offset inside the virtual buffer where the physical range is located</param>
+        /// <param name="rangeSize">Size of the range in bytes</param>
+        public void AddPhysicalDependency(Buffer buffer, ulong rangeAddress, ulong dstOffset, ulong rangeSize)
+        {
+            (_dependencies ??= new()).Add(new(buffer, rangeAddress - buffer.Address, dstOffset, rangeSize));
+            buffer.AddVirtualDependency(this);
+        }
+
+        /// <summary>
+        /// Tries to get the physical range corresponding to the given physical buffer.
+        /// </summary>
+        /// <param name="buffer">Physical buffer</param>
+        /// <param name="minimumVirtOffset">Minimum virtual offset that a range match can have</param>
+        /// <param name="physicalOffset">Physical offset of the match</param>
+        /// <param name="virtualOffset">Virtual offset of the match, always greater than or equal <paramref name="minimumVirtOffset"/></param>
+        /// <param name="size">Size of the range match</param>
+        /// <returns>True if a match was found for the given parameters, false otherwise</returns>
+        public bool TryGetPhysicalOffset(Buffer buffer, ulong minimumVirtOffset, out ulong physicalOffset, out ulong virtualOffset, out ulong size)
+        {
+            physicalOffset = 0;
+            virtualOffset = 0;
+            size = 0;
+
+            if (_dependencies != null)
+            {
+                foreach (var dependency in _dependencies)
+                {
+                    if (dependency.PhysicalBuffer == buffer && dependency.VirtualOffset >= minimumVirtOffset)
+                    {
+                        physicalOffset = dependency.PhysicalOffset;
+                        virtualOffset = dependency.VirtualOffset;
+                        size = dependency.Size;
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Adds a modified virtual memory range.
+        /// </summary>
+        /// <remarks>
+        /// This is only required when the host does not support sparse buffers, otherwise only physical buffers need to track modification.
+        /// </remarks>
+        /// <param name="range">Modified range</param>
+        public void AddModifiedRegion(MultiRange range)
+        {
+            _modifiedRanges ??= new(_context, null, null);
+
+            for (int i = 0; i < range.Count; i++)
+            {
+                MemoryRange subRange = range.GetSubRange(i);
+
+                _modifiedRanges.Add(new(subRange.Address, subRange.Size, 0, null));
+            }
+        }
+
+        /// <summary>
+        /// Calls the specified <paramref name="rangeAction"/> for all modified ranges that overlaps with <paramref name="buffer"/>.
+        /// </summary>
+        /// <param name="buffer">Buffer to have its range checked</param>
+        /// <param name="rangeAction">Action to perform for modified ranges</param>
+        public void ConsumeModifiedRegion(Buffer buffer, Action<ulong, ulong> rangeAction)
+        {
+            if (_modifiedRanges != null)
+            {
+                _modifiedRanges.GetRanges(buffer.Address, buffer.Size, rangeAction);
+                _modifiedRanges.Clear(buffer.Address, buffer.Size);
+            }
+        }
+
+        /// <summary>
         /// Disposes the host buffer.
         /// </summary>
         public void Dispose()
         {
+            if (_dependencies != null)
+            {
+                foreach (var dependency in _dependencies)
+                {
+                    dependency.PhysicalBuffer.RemoveVirtualDependency(this);
+                }
+
+                _dependencies = null;
+            }
+
             _context.Renderer.DeleteBuffer(Handle);
         }
     }

--- a/src/Ryujinx.Graphics.Gpu/Memory/MultiRangeBuffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MultiRangeBuffer.cs
@@ -212,6 +212,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        /// <summary>
+        /// Gets data from the specified region of the buffer, and places it on <paramref name="output"/>.
+        /// </summary>
+        /// <param name="output">Span to put the data into</param>
+        /// <param name="offset">Offset of the buffer to get the data from</param>
+        /// <param name="size">Size of the data in bytes</param>
         public void GetData(Span<byte> output, int offset, int size)
         {
             using PinnedSpan<byte> data = _context.Renderer.GetBufferData(Handle, offset, size);

--- a/src/Ryujinx.Graphics.Gpu/Memory/VirtualBufferCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/VirtualBufferCache.cs
@@ -102,10 +102,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="gpuVa">GPU virtual address to get the physical range from</param>
         /// <param name="size">Size in bytes of the region</param>
-        /// <param name="supportsSparse">Indicates host support for sparse buffer mapping of non-contiguous ranges</param>
         /// <param name="range">Physical range for the specified GPU virtual region</param>
         /// <returns>True if the range already existed, false if a new one was created and added</returns>
-        public bool TryGetOrAddRange(ulong gpuVa, ulong size, bool supportsSparse, out MultiRange range)
+        public bool TryGetOrAddRange(ulong gpuVa, ulong size, out MultiRange range)
         {
             VirtualRange[] overlaps = _virtualRangeOverlaps;
             int overlapsCount;
@@ -175,11 +174,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
             ShrinkOverlapsBufferIfNeeded();
 
             // If the the range is not properly aligned for sparse mapping,
-            // or if the host does not support sparse mapping, let's just
-            // force it to a single range.
+            // let's just force it to a single range.
             // This might cause issues in some applications that uses sparse
             // mappings.
-            if (!IsSparseAligned(range) || !supportsSparse)
+            if (!IsSparseAligned(range))
             {
                 range = new MultiRange(range.GetSubRange(0).Address, size);
             }

--- a/src/Ryujinx.Graphics.Gpu/Memory/VirtualRangeCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/VirtualRangeCache.cs
@@ -6,9 +6,9 @@ using System.Threading;
 namespace Ryujinx.Graphics.Gpu.Memory
 {
     /// <summary>
-    /// Virtual buffer cache.
+    /// Virtual range cache.
     /// </summary>
-    class VirtualBufferCache
+    class VirtualRangeCache
     {
         private readonly MemoryManager _memoryManager;
 
@@ -68,10 +68,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private int _hasDeferredUnmaps;
 
         /// <summary>
-        /// Creates a new instance of the virtual buffer cache.
+        /// Creates a new instance of the virtual range cache.
         /// </summary>
-        /// <param name="memoryManager">Memory manager that the virtual buffer cache belongs to</param>
-        public VirtualBufferCache(MemoryManager memoryManager)
+        /// <param name="memoryManager">Memory manager that the virtual range cache belongs to</param>
+        public VirtualRangeCache(MemoryManager memoryManager)
         {
             _memoryManager = memoryManager;
             _virtualRanges = new RangeList<VirtualRange>();

--- a/src/Ryujinx.Graphics.Gpu/Memory/VirtualRangeCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/VirtualRangeCache.cs
@@ -157,7 +157,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 }
                 else
                 {
-                    found = true;
+                    found = overlap0.Range.Count == 1 || IsSparseAligned(overlap0.Range);
                     range = overlap0.Range.Slice(gpuVa - overlap0.Address, size);
                 }
             }


### PR DESCRIPTION
This is similar to #5427, but while the linked change required the host to support sparse buffer mapping on Vulkan, this one does not require anything special. If the host does support sparse mapping, nothing should change, it will continue using it. But if the feature is not supported, this change improves the implementation by creating "virtual" buffers, that are also backed by "physical" buffers, but instead of doing actual memory aliasing on the GPU, it creates copy dependencies. Every time a physical buffer is updated, the data is also copied to the virtual buffer. The virtual buffer keeps track of GPU modifications, and copies it back on use (`SynchronizeMemory` call).

This should benefit platforms where sparse buffer mapping is not supported on Vulkan (macOS), and OpenGL.

Fixes model flickering on Apollo Justice: Ace Attorney Trilogy on macOS (and presumably on OpenGL in all platforms).
Before:

https://github.com/Ryujinx/Ryujinx/assets/5624669/a753b511-f65a-48e9-beb6-d64f29052e59

After:

https://github.com/Ryujinx/Ryujinx/assets/5624669/6ebe4b36-892f-41be-a9c2-e5e03adda94a

Also fixes a crash that could happen sometimes before displaying 3D models, which is related to the flickering issue.

Allows Monster Hunter Rise Sunbreak to work:
<img width="1392" alt="Captura de Tela 2024-01-27 às 21 23 46" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/7b5b7042-d9b5-419e-94d9-eeb6bcef792c">
<img width="1392" alt="Captura de Tela 2024-02-04 às 13 56 34" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/675a406f-b693-40de-9a7a-cea901166fcc">
(I only tested the demo, but in theory the full game should work too...)

Fixes #5747, fixes #6181.

Testing is welcome.