### PR TITLE
Fix NRE when calling GetSockName before Bind

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -121,7 +121,14 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             IPEndPoint endPoint = isRemote ? socket.RemoteEndPoint : socket.LocalEndPoint;
 
-            context.Memory.Write(bufferPosition, BsdSockAddr.FromIPEndPoint(endPoint));
+            if (endPoint != null)
+            {
+                context.Memory.Write(bufferPosition, BsdSockAddr.FromIPEndPoint(endPoint));
+            }
+            else
+            {
+                context.Memory.Write(bufferPosition, new BsdSockAddr());
+            }
         }
 
         [CommandCmif(0)]


### PR DESCRIPTION
If `LocalEndPoint` is accessed before `Bind` is called on the socket, it will be null. This currently throws a `NullReferenceException`. On WinSocks, this would return an error, and on FreeBSD it would return a zero socket address, since it has not been set yet. It has been changed to write a zero socket address to match FreeBSD behaviour (the Switch uses FreeBSD code for the sockets implementation).

Fixes #6203.
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/0d4571cc-746b-4924-865f-5c0848447ffe)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/9418c6d4-9fb4-4381-9251-3265fd544cee)