### PR TITLE
Vulkan: Better UI Vendor & Driver Reporting

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -637,7 +637,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public HardwareInfo GetHardwareInfo()
         {
-            return new HardwareInfo(GpuVendor, GpuRenderer, GpuDriver);
+            return new HardwareInfo(GpuVendor, GpuRenderer, $"{GpuVendor} ({GpuDriver})");
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -637,7 +637,14 @@ namespace Ryujinx.Graphics.Vulkan
 
         public HardwareInfo GetHardwareInfo()
         {
-            return new HardwareInfo(GpuVendor, GpuRenderer, $"{GpuVendor} ({GpuDriver})");
+            var gpuDriver = GpuVendor;
+
+            if (GpuVendor.ToLowerInvariant() != GpuDriver.ToLowerInvariant())
+            {
+                gpuDriver += $" ({GpuDriver})";
+            }
+
+            return new HardwareInfo(GpuVendor, GpuRenderer, gpuDriver);
         }
 
         /// <summary>


### PR DESCRIPTION
Report Vendor & Driver on the UI when using Vulkan. Fixes macOS just showing as `MoltenVK`.