### PR TITLE
Mako: Remove events that trigger from a forked repository

### DIFF
--- a/.github/workflows/mako.yml
+++ b/.github/workflows/mako.yml
@@ -9,10 +9,6 @@ on:
     types: [created, edited]
   issues:
     types: [opened, edited, reopened, pinned, milestoned, demilestoned, assigned, unassigned, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, dismissed]
-  pull_request_review_comment:
-    types: [created, edited]
   pull_request_target:
     types: [opened, edited, reopened, synchronize, ready_for_review, assigned, unassigned]
 


### PR DESCRIPTION
Events that trigger workflows from forked repositories don't get any secrets, so they are useless for Mako.