### PR TITLE
GUI: Fix opening the wrong log directory

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1352,9 +1352,9 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
 
-            if (ReleaseInformation.IsValid)
+            if (LoggerModule.LogDirectoryPath != null)
             {
-                logPath = Path.Combine(AppDataManager.BaseDirPath, "Logs");
+                logPath = LoggerModule.LogDirectoryPath;
             }
 
             new DirectoryInfo(logPath).Create();

--- a/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Common.Logging.Targets
         public static FileStream PrepareLogFile(string path)
         {
             // Ensure directory is present
-            DirectoryInfo logDir = new(Path.Combine(path, "Logs"));
+            DirectoryInfo logDir = new(path);
             try
             {
                 logDir.Create();

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -427,11 +427,11 @@ namespace Ryujinx.Headless.SDL2
 
             if (!option.DisableFileLog)
             {
-                FileStream logFile = FileLogTarget.PrepareLogFile(AppDomain.CurrentDomain.BaseDirectory);
+                FileStream logFile = FileLogTarget.PrepareLogFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs"));
 
                 if (logFile == null)
                 {
-                    logFile = FileLogTarget.PrepareLogFile(AppDataManager.BaseDirPath);
+                    logFile = FileLogTarget.PrepareLogFile(Path.Combine(AppDataManager.BaseDirPath, "Logs"));
 
                     if (logFile == null)
                     {

--- a/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
@@ -9,6 +9,8 @@ namespace Ryujinx.Ui.Common.Configuration
 {
     public static class LoggerModule
     {
+        public static string LogDirectoryPath { get; private set; }
+
         public static void Initialize()
         {
             ConfigurationState.Instance.Logger.EnableDebug.Event += ReloadEnableDebug;
@@ -82,20 +84,25 @@ namespace Ryujinx.Ui.Common.Configuration
         {
             if (e.NewValue)
             {
-                FileStream logFile = FileLogTarget.PrepareLogFile(AppDomain.CurrentDomain.BaseDirectory);
+                string logDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
+                FileStream logFile = FileLogTarget.PrepareLogFile(logDir);
 
                 if (logFile == null)
                 {
-                    logFile = FileLogTarget.PrepareLogFile(AppDataManager.BaseDirPath);
+                    logDir = Path.Combine(AppDataManager.BaseDirPath, "Logs");
+                    logFile = FileLogTarget.PrepareLogFile(logDir);
 
                     if (logFile == null)
                     {
                         Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the application directory or the Ryujinx directory is writable.");
+                        LogDirectoryPath = null;
                         Logger.RemoveTarget("file");
 
                         return;
                     }
                 }
+
+                LogDirectoryPath = logDir;
 
                 Logger.AddTarget(new AsyncLogTargetWrapper(
                     new FileLogTarget("file", logFile),

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1378,9 +1378,9 @@ namespace Ryujinx.Ui
         {
             string logPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
 
-            if (ReleaseInformation.IsValid)
+            if (LoggerModule.LogDirectoryPath != null)
             {
-                logPath = System.IO.Path.Combine(AppDataManager.BaseDirPath, "Logs");
+                logPath = LoggerModule.LogDirectoryPath;
             }
 
             new DirectoryInfo(logPath).Create();


### PR DESCRIPTION
This small PR fixes an issue caused by #4707 where the menu item to open the log directory opens the wrong one.