### PR TITLE
Fix exception when trying to read output pointer buffer size

### DIFF
--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessage.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessage.cs
@@ -181,6 +181,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
             }
 
             Span<uint> dataWords = Span<uint>.Empty;
+            Span<uint> dataWordsUnpadded = Span<uint>.Empty;
 
             if (meta.DataWordsCount != 0)
             {
@@ -189,6 +190,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
                 int padding = (dataOffsetAligned - dataOffset) / sizeof(uint);
 
                 dataWords = MemoryMarshal.Cast<byte, uint>(data)[padding..meta.DataWordsCount];
+                dataWordsUnpadded = MemoryMarshal.Cast<byte, uint>(data)[..meta.DataWordsCount];
 
                 data = data[(meta.DataWordsCount * sizeof(uint))..];
             }
@@ -209,6 +211,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
                 ReceiveBuffers = receiveBuffers,
                 ExchangeBuffers = exchangeBuffers,
                 DataWords = dataWords,
+                DataWordsUnpadded = dataWordsUnpadded,
                 ReceiveList = receiveList,
                 CopyHandles = copyHandles,
                 MoveHandles = moveHandles,

--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessage.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessage.cs
@@ -181,7 +181,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
             }
 
             Span<uint> dataWords = Span<uint>.Empty;
-            Span<uint> dataWordsUnpadded = Span<uint>.Empty;
+            Span<uint> dataWordsPadded = Span<uint>.Empty;
 
             if (meta.DataWordsCount != 0)
             {
@@ -190,7 +190,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
                 int padding = (dataOffsetAligned - dataOffset) / sizeof(uint);
 
                 dataWords = MemoryMarshal.Cast<byte, uint>(data)[padding..meta.DataWordsCount];
-                dataWordsUnpadded = MemoryMarshal.Cast<byte, uint>(data)[..meta.DataWordsCount];
+                dataWordsPadded = MemoryMarshal.Cast<byte, uint>(data)[..meta.DataWordsCount];
 
                 data = data[(meta.DataWordsCount * sizeof(uint))..];
             }
@@ -211,7 +211,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
                 ReceiveBuffers = receiveBuffers,
                 ExchangeBuffers = exchangeBuffers,
                 DataWords = dataWords,
-                DataWordsUnpadded = dataWordsUnpadded,
+                DataWordsPadded = dataWordsPadded,
                 ReceiveList = receiveList,
                 CopyHandles = copyHandles,
                 MoveHandles = moveHandles,

--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessageData.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessageData.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
         public Span<HipcBufferDescriptor> ReceiveBuffers;
         public Span<HipcBufferDescriptor> ExchangeBuffers;
         public Span<uint> DataWords;
-        public Span<uint> DataWordsUnpadded;
+        public Span<uint> DataWordsPadded;
         public Span<HipcReceiveListEntry> ReceiveList;
         public Span<int> CopyHandles;
         public Span<int> MoveHandles;

--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessageData.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/HipcMessageData.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
         public Span<HipcBufferDescriptor> ReceiveBuffers;
         public Span<HipcBufferDescriptor> ExchangeBuffers;
         public Span<uint> DataWords;
+        public Span<uint> DataWordsUnpadded;
         public Span<HipcReceiveListEntry> ReceiveList;
         public Span<int> CopyHandles;
         public Span<int> MoveHandles;

--- a/src/Ryujinx.Horizon/Sdk/Sf/HipcCommandProcessor.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/HipcCommandProcessor.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.Horizon.Sdk.Sf
                         }
                         else
                         {
-                            var data = MemoryMarshal.Cast<uint, byte>(context.Request.Data.DataWords);
+                            var data = MemoryMarshal.Cast<uint, byte>(context.Request.Data.DataWordsUnpadded);
                             var recvPointerSizes = MemoryMarshal.Cast<byte, ushort>(data[runtimeMetadata.UnfixedOutPointerSizeOffset..]);
 
                             size = recvPointerSizes[unfixedRecvPointerIndex++];

--- a/src/Ryujinx.Horizon/Sdk/Sf/HipcCommandProcessor.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/HipcCommandProcessor.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.Horizon.Sdk.Sf
                         }
                         else
                         {
-                            var data = MemoryMarshal.Cast<uint, byte>(context.Request.Data.DataWordsUnpadded);
+                            var data = MemoryMarshal.Cast<uint, byte>(context.Request.Data.DataWordsPadded);
                             var recvPointerSizes = MemoryMarshal.Cast<byte, ushort>(data[runtimeMetadata.UnfixedOutPointerSizeOffset..]);
 
                             size = recvPointerSizes[unfixedRecvPointerIndex++];


### PR DESCRIPTION
Fixes a regression from #6174 that was causing Animal Crossing to crash on load.
The offset for the pointer buffer sizes was calculated as if the data array still had the padding on, but the actual array it accessed had the padding removed, which causes a `IndexOutOfRangeException`.