### PR TITLE
[UI] Fix Crash when Windows is moved after a modal is dismissed

### DIFF
--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -336,6 +336,11 @@ namespace Ryujinx.Ava.UI.Helpers
 
                 void OverlayOnPositionChanged(object sender, PixelPointEventArgs e)
                 {
+                    if (_contentDialogOverlayWindow is null)
+                    {
+                        return;
+                    }
+
                     _contentDialogOverlayWindow.Position = parent.PointToScreen(new Point());
                 }
 


### PR DESCRIPTION
Fixes #6222 
Resolve an issue where changes to the main window's positioning could cause the application to crash if a modal was dismissed beforehand.

To be honest, we probably should be unbinding the OverlayOnPositionChanged event before the window closes for memory reasons. But I'll let the reviewers dictate if thats a priority.