### PR TITLE
Infra: Run Mac Actions on Apple Silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,12 +52,12 @@ jobs:
       - name: Change config filename
         run: sed -r --in-place 's/\%\%RYUJINX_CONFIG_FILE_NAME\%\%/PRConfig\.json/g;' src/Ryujinx.Common/ReleaseInformation.cs
         shell: bash
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
       - name: Change config filename for macOS
         run: sed -r -i '' 's/\%\%RYUJINX_CONFIG_FILE_NAME\%\%/PRConfig\.json/g;' src/Ryujinx.Common/ReleaseInformation.cs
         shell: bash
-        if: github.event_name == 'pull_request' && matrix.os == 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os == 'macOS-14'
 
       - name: Build
         run: dotnet build -c "${{ matrix.configuration }}" -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-14, windows-latest]
         configuration: [Debug, Release]
         include:
         - os: ubuntu-latest
@@ -23,10 +23,10 @@ jobs:
           DOTNET_RUNTIME_IDENTIFIER: linux-x64
           RELEASE_ZIP_OS_NAME: linux_x64
 
-        - os: macOS-latest
-          OS_NAME: macOS x64
-          DOTNET_RUNTIME_IDENTIFIER: osx-x64
-          RELEASE_ZIP_OS_NAME: osx_x64
+        - os: macOS-14
+          OS_NAME: macOS ARM
+          DOTNET_RUNTIME_IDENTIFIER: osx-arm64
+          RELEASE_ZIP_OS_NAME: osx_arm
 
         - os: windows-latest
           OS_NAME: Windows x64
@@ -71,15 +71,15 @@ jobs:
 
       - name: Publish Ryujinx
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx --self-contained true
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
       - name: Publish Ryujinx.Headless.SDL2
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_sdl2_headless -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx.Headless.SDL2 --self-contained true
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
       - name: Publish Ryujinx.Ava
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_ava -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx.Ava --self-contained true
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
       - name: Set executable bit
         run: |
@@ -93,21 +93,21 @@ jobs:
         with:
           name: ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
       - name: Upload Ryujinx.Headless.SDL2 artifact
         uses: actions/upload-artifact@v4
         with:
           name: sdl2-ryujinx-headless-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish_sdl2_headless
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
       - name: Upload Ryujinx.Ava artifact
         uses: actions/upload-artifact@v4
         with:
           name: ava-ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish_ava
-        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-14'
 
   build_macos:
     name: macOS Universal (${{ matrix.configuration }})


### PR DESCRIPTION
This will run macOS actions on the newly released Apple Silicon runners. The reasoning is two-fold:
- Ryujinx is primarily targeting Apple Silicon not Intel Macs, so it makes sense for the tests to be run on this architecture
- Apple Silicon runners use significantly newer hardware, which should reduce the build time

TODO:
- Deal with Unicorn, going to leave how that should happen up to the maintainers.