### PR TITLE
Standardize logging locations across desktop platforms

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1353,8 +1353,6 @@ namespace Ryujinx.Ava.UI.ViewModels
             string logPath = AppDataManager.LogsDirPath;
             if (!string.IsNullOrEmpty(logPath))
             {
-                new DirectoryInfo(logPath).Create();
-
                 OpenHelper.OpenFolder(logPath);
             }
         }

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1350,7 +1350,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public void OpenLogsFolder()
         {
-            string logPath = AppDataManager.LogsDirPath;
+            string logPath = AppDataManager.GetOrCreateLogsDir();
             if (!string.IsNullOrEmpty(logPath))
             {
                 OpenHelper.OpenFolder(logPath);

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1352,9 +1352,9 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
 
-            if (LoggerModule.LogDirectoryPath != null)
+            if (AppDataManager.LogsDirPath != null)
             {
-                logPath = LoggerModule.LogDirectoryPath;
+                logPath = AppDataManager.LogsDirPath;
             }
 
             new DirectoryInfo(logPath).Create();

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1350,16 +1350,13 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public void OpenLogsFolder()
         {
-            string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
-
-            if (AppDataManager.LogsDirPath != null)
+            string logPath = AppDataManager.LogsDirPath;
+            if (!string.IsNullOrEmpty(logPath))
             {
-                logPath = AppDataManager.LogsDirPath;
+                new DirectoryInfo(logPath).Create();
+
+                OpenHelper.OpenFolder(logPath);
             }
-
-            new DirectoryInfo(logPath).Create();
-
-            OpenHelper.OpenFolder(logPath);
         }
 
         public void ToggleDockMode()

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -118,6 +118,7 @@ namespace Ryujinx.Common.Configuration
             {
                 return LogsDirPath;
             }
+
             Logger.Notice.Print(LogClass.Application, "Logging directory not found; attempting to create new logging directory.");
             LogsDirPath = SetUpLogsDir();
 

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Common.Configuration
                 {
                     Logger.Warning?.Print(LogClass.Application,
                         $"Logging directory could not be created '{logDir}'");
-                    logDir = "";
+                    return null;
                 }
             }
             else
@@ -148,11 +148,10 @@ namespace Ryujinx.Common.Configuration
                         logDir = "";
                     }
 
-                    if (logDir == "")
+                    if (string.IsNullOrEmpty(logDir))
                     {
                         //Should evaluate to ~/Library/Application Support/Ryujinx/Logs
-                        logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                            DefaultBaseDir, "Logs");
+                        logDir = Path.Combine(BaseDirPath, "Logs");
 
                         try
                         {
@@ -162,7 +161,7 @@ namespace Ryujinx.Common.Configuration
                         {
                             Logger.Warning?.Print(LogClass.Application,
                                 $"Logging directory could not be created '{logDir}'");
-                            logDir = "";
+                            return null;
                         }
                     }
                 }
@@ -181,7 +180,7 @@ namespace Ryujinx.Common.Configuration
                         logDir = "";
                     }
 
-                    if (logDir == "")
+                    if (string.IsNullOrEmpty(logDir))
                     {
                         //Should evaluate to C:\Users\user\AppData\Roaming\Ryujinx\Logs
                         logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
@@ -195,7 +194,7 @@ namespace Ryujinx.Common.Configuration
                         {
                             Logger.Warning?.Print(LogClass.Application,
                                 $"Logging directory could not be created '{logDir}'");
-                            logDir = "";
+                            return null;
                         }
                     }
                 }
@@ -213,7 +212,7 @@ namespace Ryujinx.Common.Configuration
                     {
                         Logger.Warning?.Print(LogClass.Application,
                             $"Logging directory could not be created '{logDir}'");
-                        logDir = "";
+                        return null;
                     }
                 }
             }
@@ -222,8 +221,8 @@ namespace Ryujinx.Common.Configuration
 
         private static void SetupBasePaths()
         {
-            LogsDirPath = SetUpLogsDir();
             Directory.CreateDirectory(BaseDirPath);
+            LogsDirPath = SetUpLogsDir();
             Directory.CreateDirectory(GamesDirPath = Path.Combine(BaseDirPath, GamesDir));
             Directory.CreateDirectory(ProfilesDirPath = Path.Combine(BaseDirPath, ProfilesDir));
             Directory.CreateDirectory(KeysDirPath = Path.Combine(BaseDirPath, KeysDir));

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -120,6 +120,7 @@ namespace Ryujinx.Common.Configuration
             }
             Logger.Notice.Print(LogClass.Application, "Logging directory not found; attempting to create new logging directory.");
             LogsDirPath = SetUpLogsDir();
+
             return LogsDirPath;
         }
 
@@ -137,6 +138,7 @@ namespace Ryujinx.Common.Configuration
                 catch
                 {
                     Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
+
                     return null;
                 }
             }
@@ -144,7 +146,7 @@ namespace Ryujinx.Common.Configuration
             {
                 if (OperatingSystem.IsMacOS())
                 {
-                    // Should evaluate to ~/Library/Logs/Ryujinx/
+                    // NOTE: Should evaluate to "~/Library/Logs/Ryujinx/".
                     logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Logs", DefaultBaseDir);
                     try
                     {
@@ -158,7 +160,7 @@ namespace Ryujinx.Common.Configuration
 
                     if (string.IsNullOrEmpty(logDir))
                     {
-                        // Should evaluate to ~/Library/Application Support/Ryujinx/Logs
+                        // NOTE: Should evaluate to "~/Library/Application Support/Ryujinx/Logs".
                         logDir = Path.Combine(BaseDirPath, "Logs");
 
                         try
@@ -168,13 +170,14 @@ namespace Ryujinx.Common.Configuration
                         catch
                         {
                             Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
+
                             return null;
                         }
                     }
                 }
                 else if (OperatingSystem.IsWindows())
                 {
-                    // Should evaluate to a 'Logs' directory in whatever directory Ryujinx was launched from.
+                    // NOTE: Should evaluate to a "Logs" directory in whatever directory Ryujinx was launched from.
                     logDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
                     try
                     {
@@ -188,7 +191,7 @@ namespace Ryujinx.Common.Configuration
 
                     if (string.IsNullOrEmpty(logDir))
                     {
-                        // Should evaluate to C:\Users\user\AppData\Roaming\Ryujinx\Logs
+                        // NOTE: Should evaluate to "C:\Users\user\AppData\Roaming\Ryujinx\Logs".
                         logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir, "Logs");
 
                         try
@@ -198,13 +201,14 @@ namespace Ryujinx.Common.Configuration
                         catch
                         {
                             Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
+
                             return null;
                         }
                     }
                 }
                 else if (OperatingSystem.IsLinux())
                 {
-                    // Should evaluate to ~/.config/Ryujinx/Logs
+                    // NOTE: Should evaluate to "~/.config/Ryujinx/Logs".
                     logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir, "Logs");
 
                     try
@@ -214,6 +218,7 @@ namespace Ryujinx.Common.Configuration
                     catch
                     {
                         Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
+
                         return null;
                     }
                 }

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -48,8 +48,7 @@ namespace Ryujinx.Common.Configuration
 
         public static void Initialize(string baseDirPath)
         {
-            string appDataPath;
-            appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
             if (appDataPath.Length == 0)
             {
@@ -116,6 +115,7 @@ namespace Ryujinx.Common.Configuration
         private static string SetUpLogsDir()
         {
             string logDir = "";
+
             if (Mode == LaunchMode.Portable)
             {
                 logDir = Path.Combine(BaseDirPath, "Logs");
@@ -125,8 +125,7 @@ namespace Ryujinx.Common.Configuration
                 }
                 catch
                 {
-                    Logger.Warning?.Print(LogClass.Application,
-                        $"Logging directory could not be created '{logDir}'");
+                    Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
                     return null;
                 }
             }
@@ -134,23 +133,21 @@ namespace Ryujinx.Common.Configuration
             {
                 if (OperatingSystem.IsMacOS())
                 {
-                    //Should evaluate to ~/Library/Logs/Ryujinx/
-                    logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library",
-                        "Logs", DefaultBaseDir);
+                    // Should evaluate to ~/Library/Logs/Ryujinx/
+                    logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Logs", DefaultBaseDir);
                     try
                     {
                         Directory.CreateDirectory(logDir);
                     }
                     catch
                     {
-                        Logger.Warning?.Print(LogClass.Application,
-                            $"Logging directory could not be created '{logDir}'");
+                        Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
                         logDir = "";
                     }
 
                     if (string.IsNullOrEmpty(logDir))
                     {
-                        //Should evaluate to ~/Library/Application Support/Ryujinx/Logs
+                        // Should evaluate to ~/Library/Application Support/Ryujinx/Logs
                         logDir = Path.Combine(BaseDirPath, "Logs");
 
                         try
@@ -159,15 +156,14 @@ namespace Ryujinx.Common.Configuration
                         }
                         catch
                         {
-                            Logger.Warning?.Print(LogClass.Application,
-                                $"Logging directory could not be created '{logDir}'");
+                            Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
                             return null;
                         }
                     }
                 }
                 else if (OperatingSystem.IsWindows())
                 {
-                    //Should evaluate to a 'Logs' directory in whatever directory Ryujinx was launched from.
+                    // Should evaluate to a 'Logs' directory in whatever directory Ryujinx was launched from.
                     logDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
                     try
                     {
@@ -175,16 +171,14 @@ namespace Ryujinx.Common.Configuration
                     }
                     catch
                     {
-                        Logger.Warning?.Print(LogClass.Application,
-                            $"Logging directory could not be created '{logDir}'");
+                        Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
                         logDir = "";
                     }
 
                     if (string.IsNullOrEmpty(logDir))
                     {
-                        //Should evaluate to C:\Users\user\AppData\Roaming\Ryujinx\Logs
-                        logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                            DefaultBaseDir, "Logs");
+                        // Should evaluate to C:\Users\user\AppData\Roaming\Ryujinx\Logs
+                        logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir, "Logs");
 
                         try
                         {
@@ -192,17 +186,15 @@ namespace Ryujinx.Common.Configuration
                         }
                         catch
                         {
-                            Logger.Warning?.Print(LogClass.Application,
-                                $"Logging directory could not be created '{logDir}'");
+                            Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
                             return null;
                         }
                     }
                 }
                 else if (OperatingSystem.IsLinux())
                 {
-                    //Should evaluate to ~/.config/Ryujinx/Logs
-                    logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                        DefaultBaseDir, "Logs");
+                    // Should evaluate to ~/.config/Ryujinx/Logs
+                    logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir, "Logs");
 
                     try
                     {
@@ -210,12 +202,12 @@ namespace Ryujinx.Common.Configuration
                     }
                     catch
                     {
-                        Logger.Warning?.Print(LogClass.Application,
-                            $"Logging directory could not be created '{logDir}'");
+                        Logger.Warning?.Print(LogClass.Application, $"Logging directory could not be created '{logDir}'");
                         return null;
                     }
                 }
             }
+
             return logDir;
         }
 

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -30,6 +30,8 @@ namespace Ryujinx.Common.Configuration
         public static string KeysDirPath { get; private set; }
         public static string KeysDirPathUser { get; }
 
+        public static string LogsDirPath { get; private set; }
+
         public const string DefaultNandDir = "bis";
         public const string DefaultSdcardDir = "sdcard";
         private const string DefaultModsDir = "mods";
@@ -47,14 +49,7 @@ namespace Ryujinx.Common.Configuration
         public static void Initialize(string baseDirPath)
         {
             string appDataPath;
-            if (OperatingSystem.IsMacOS())
-            {
-                appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support");
-            }
-            else
-            {
-                appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            }
+            appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
             if (appDataPath.Length == 0)
             {
@@ -118,8 +113,116 @@ namespace Ryujinx.Common.Configuration
             SetupBasePaths();
         }
 
+        private static string SetUpLogsDir()
+        {
+            string logDir = "";
+            if (Mode == LaunchMode.Portable)
+            {
+                logDir = Path.Combine(BaseDirPath, "Logs");
+                try
+                {
+                    Directory.CreateDirectory(logDir);
+                }
+                catch
+                {
+                    Logger.Warning?.Print(LogClass.Application,
+                        $"Logging directory could not be created '{logDir}'");
+                    logDir = "";
+                }
+            }
+            else
+            {
+                if (OperatingSystem.IsMacOS())
+                {
+                    //Should evaluate to ~/Library/Logs/Ryujinx/
+                    logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library",
+                        "Logs", DefaultBaseDir);
+                    try
+                    {
+                        Directory.CreateDirectory(logDir);
+                    }
+                    catch
+                    {
+                        Logger.Warning?.Print(LogClass.Application,
+                            $"Logging directory could not be created '{logDir}'");
+                        logDir = "";
+                    }
+
+                    if (logDir == "")
+                    {
+                        //Should evaluate to ~/Library/Application Support/Ryujinx/Logs
+                        logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                            DefaultBaseDir, "Logs");
+
+                        try
+                        {
+                            Directory.CreateDirectory(logDir);
+                        }
+                        catch
+                        {
+                            Logger.Warning?.Print(LogClass.Application,
+                                $"Logging directory could not be created '{logDir}'");
+                            logDir = "";
+                        }
+                    }
+                }
+                else if (OperatingSystem.IsWindows())
+                {
+                    //Should evaluate to a 'Logs' directory in whatever directory Ryujinx was launched from.
+                    logDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
+                    try
+                    {
+                        Directory.CreateDirectory(logDir);
+                    }
+                    catch
+                    {
+                        Logger.Warning?.Print(LogClass.Application,
+                            $"Logging directory could not be created '{logDir}'");
+                        logDir = "";
+                    }
+
+                    if (logDir == "")
+                    {
+                        //Should evaluate to C:\Users\user\AppData\Roaming\Ryujinx\Logs
+                        logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                            DefaultBaseDir, "Logs");
+
+                        try
+                        {
+                            Directory.CreateDirectory(logDir);
+                        }
+                        catch
+                        {
+                            Logger.Warning?.Print(LogClass.Application,
+                                $"Logging directory could not be created '{logDir}'");
+                            logDir = "";
+                        }
+                    }
+                }
+                else if (OperatingSystem.IsLinux())
+                {
+                    //Should evaluate to ~/.config/Ryujinx/Logs
+                    logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        DefaultBaseDir, "Logs");
+
+                    try
+                    {
+                        Directory.CreateDirectory(logDir);
+                    }
+                    catch
+                    {
+                        Logger.Warning?.Print(LogClass.Application,
+                            $"Logging directory could not be created '{logDir}'");
+                        logDir = "";
+                    }
+                }
+            }
+            return logDir;
+        }
+
         private static void SetupBasePaths()
         {
+            LogsDirPath = SetUpLogsDir();
             Directory.CreateDirectory(BaseDirPath);
             Directory.CreateDirectory(GamesDirPath = Path.Combine(BaseDirPath, GamesDir));
             Directory.CreateDirectory(ProfilesDirPath = Path.Combine(BaseDirPath, ProfilesDir));

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -112,6 +112,17 @@ namespace Ryujinx.Common.Configuration
             SetupBasePaths();
         }
 
+        public static string GetOrCreateLogsDir()
+        {
+            if (Directory.Exists(LogsDirPath))
+            {
+                return LogsDirPath;
+            }
+            Logger.Notice.Print(LogClass.Application, "Logging directory not found; attempting to create new logging directory.");
+            LogsDirPath = SetUpLogsDir();
+            return LogsDirPath;
+        }
+
         private static string SetUpLogsDir()
         {
             string logDir = "";

--- a/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -28,9 +28,9 @@ namespace Ryujinx.Common.Logging.Targets
             {
                 logDir = new(path);
             }
-            catch (Exception exception)
+            catch (ArgumentException exception)
             {
-                Logger.Warning?.Print(LogClass.Application, $"Logging directory path was invalid: {exception}");
+                Logger.Warning?.Print(LogClass.Application, $"Logging directory path ({path}) was invalid: {exception}");
 
                 return null;
             }

--- a/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.Common.Logging.Targets
             }
             catch (ArgumentException exception)
             {
-                Logger.Warning?.Print(LogClass.Application, $"Logging directory path ({path}) was invalid: {exception}");
+                Logger.Warning?.Print(LogClass.Application, $"Logging directory path ('{path}') was invalid: {exception}");
 
                 return null;
             }

--- a/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -23,7 +23,17 @@ namespace Ryujinx.Common.Logging.Targets
         public static FileStream PrepareLogFile(string path)
         {
             // Ensure directory is present
-            DirectoryInfo logDir = new(path);
+            DirectoryInfo logDir;
+            try
+            {
+                logDir = new(path);
+            }
+            catch (Exception exception)
+            {
+                Logger.Warning?.Print(LogClass.Application, $"Logging directory path was invalid: {exception}");
+
+                return null;
+            }
             try
             {
                 logDir.Create();

--- a/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Common.Logging.Targets
             DirectoryInfo logDir;
             try
             {
-                logDir = new(path);
+                logDir = new DirectoryInfo(path);
             }
             catch (ArgumentException exception)
             {
@@ -34,6 +34,7 @@ namespace Ryujinx.Common.Logging.Targets
 
                 return null;
             }
+
             try
             {
                 logDir.Create();

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -435,12 +435,6 @@ namespace Ryujinx.Headless.SDL2
                     logFile = FileLogTarget.PrepareLogFile(logDir);
                 }
 
-                if (logFile == null)
-                {
-                    Logger.Error?.Print(LogClass.Application,
-                        "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
-                }
-
                 if (logFile != null)
                 {
                     Logger.AddTarget(new AsyncLogTargetWrapper(
@@ -448,6 +442,10 @@ namespace Ryujinx.Headless.SDL2
                         1000,
                         AsyncLogTargetOverflowAction.Block
                     ));
+                }
+                else
+                {
+                    Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
                 }
             }
 

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -428,7 +428,12 @@ namespace Ryujinx.Headless.SDL2
             if (!option.DisableFileLog)
             {
                 string logDir = AppDataManager.LogsDirPath;
-                FileStream logFile = FileLogTarget.PrepareLogFile(logDir);
+                FileStream logFile = null;
+
+                if (!string.IsNullOrEmpty(logDir))
+                {
+                    logFile = FileLogTarget.PrepareLogFile(logDir);
+                }
 
                 if (logFile == null)
                 {

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -427,16 +427,13 @@ namespace Ryujinx.Headless.SDL2
 
             if (!option.DisableFileLog)
             {
-                FileStream logFile = FileLogTarget.PrepareLogFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs"));
+                string logDir = AppDataManager.LogsDirPath;
+                FileStream logFile = FileLogTarget.PrepareLogFile(logDir);
 
                 if (logFile == null)
                 {
-                    logFile = FileLogTarget.PrepareLogFile(Path.Combine(AppDataManager.BaseDirPath, "Logs"));
-
-                    if (logFile == null)
-                    {
-                        Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the application directory or the Ryujinx directory is writable.");
-                    }
+                    Logger.Error?.Print(LogClass.Application,
+                        "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
                 }
 
                 if (logFile != null)

--- a/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
@@ -84,22 +84,16 @@ namespace Ryujinx.Ui.Common.Configuration
         {
             if (e.NewValue)
             {
-                string logDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
+                string logDir = AppDataManager.LogsDirPath;
                 FileStream logFile = FileLogTarget.PrepareLogFile(logDir);
 
                 if (logFile == null)
                 {
-                    logDir = Path.Combine(AppDataManager.BaseDirPath, "Logs");
-                    logFile = FileLogTarget.PrepareLogFile(logDir);
+                    Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
+                    LogDirectoryPath = null;
+                    Logger.RemoveTarget("file");
 
-                    if (logFile == null)
-                    {
-                        Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the application directory or the Ryujinx directory is writable.");
-                        LogDirectoryPath = null;
-                        Logger.RemoveTarget("file");
-
-                        return;
-                    }
+                    return;
                 }
 
                 LogDirectoryPath = logDir;

--- a/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
@@ -9,7 +9,6 @@ namespace Ryujinx.Ui.Common.Configuration
 {
     public static class LoggerModule
     {
-        public static string LogDirectoryPath { get; private set; }
 
         public static void Initialize()
         {
@@ -90,13 +89,10 @@ namespace Ryujinx.Ui.Common.Configuration
                 if (logFile == null)
                 {
                     Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
-                    LogDirectoryPath = null;
                     Logger.RemoveTarget("file");
 
                     return;
                 }
-
-                LogDirectoryPath = logDir;
 
                 Logger.AddTarget(new AsyncLogTargetWrapper(
                     new FileLogTarget("file", logFile),

--- a/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
@@ -9,7 +9,6 @@ namespace Ryujinx.Ui.Common.Configuration
 {
     public static class LoggerModule
     {
-
         public static void Initialize()
         {
             ConfigurationState.Instance.Logger.EnableDebug.Event += ReloadEnableDebug;

--- a/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
@@ -84,7 +84,12 @@ namespace Ryujinx.Ui.Common.Configuration
             if (e.NewValue)
             {
                 string logDir = AppDataManager.LogsDirPath;
-                FileStream logFile = FileLogTarget.PrepareLogFile(logDir);
+                FileStream logFile = null;
+
+                if (!string.IsNullOrEmpty(logDir))
+                {
+                    logFile = FileLogTarget.PrepareLogFile(logDir);
+                }
 
                 if (logFile == null)
                 {

--- a/src/Ryujinx.Ui.Common/Helper/OpenHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/OpenHelper.cs
@@ -19,6 +19,14 @@ namespace Ryujinx.Ui.Common.Helper
 
         public static void OpenFolder(string path)
         {
+            try
+            {
+                Directory.CreateDirectory(path);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error?.Print(LogClass.Application, $"Failed to create directory at '{path}' when opening logs folder: {exception}");
+            }
             if (Directory.Exists(path))
             {
                 Process.Start(new ProcessStartInfo

--- a/src/Ryujinx.Ui.Common/Helper/OpenHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/OpenHelper.cs
@@ -19,14 +19,6 @@ namespace Ryujinx.Ui.Common.Helper
 
         public static void OpenFolder(string path)
         {
-            try
-            {
-                Directory.CreateDirectory(path);
-            }
-            catch (Exception exception)
-            {
-                Logger.Error?.Print(LogClass.Application, $"Failed to create directory at '{path}' when opening logs folder: {exception}");
-            }
             if (Directory.Exists(path))
             {
                 Process.Start(new ProcessStartInfo

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1376,16 +1376,13 @@ namespace Ryujinx.Ui
 
         private void OpenLogsFolder_Pressed(object sender, EventArgs args)
         {
-            string logPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
-
-            if (AppDataManager.LogsDirPath != null)
+            string logPath = AppDataManager.LogsDirPath;
+            if (!string.IsNullOrEmpty(logPath))
             {
-                logPath = AppDataManager.LogsDirPath;
+                new DirectoryInfo(logPath).Create();
+
+                OpenHelper.OpenFolder(logPath);
             }
-
-            new DirectoryInfo(logPath).Create();
-
-            OpenHelper.OpenFolder(logPath);
         }
 
         private void Exit_Pressed(object sender, EventArgs args)

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1379,8 +1379,6 @@ namespace Ryujinx.Ui
             string logPath = AppDataManager.LogsDirPath;
             if (!string.IsNullOrEmpty(logPath))
             {
-                new DirectoryInfo(logPath).Create();
-
                 OpenHelper.OpenFolder(logPath);
             }
         }

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1376,7 +1376,7 @@ namespace Ryujinx.Ui
 
         private void OpenLogsFolder_Pressed(object sender, EventArgs args)
         {
-            string logPath = AppDataManager.LogsDirPath;
+            string logPath = AppDataManager.GetOrCreateLogsDir();
             if (!string.IsNullOrEmpty(logPath))
             {
                 OpenHelper.OpenFolder(logPath);

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1378,9 +1378,9 @@ namespace Ryujinx.Ui
         {
             string logPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
 
-            if (LoggerModule.LogDirectoryPath != null)
+            if (AppDataManager.LogsDirPath != null)
             {
-                logPath = LoggerModule.LogDirectoryPath;
+                logPath = AppDataManager.LogsDirPath;
             }
 
             new DirectoryInfo(logPath).Create();


### PR DESCRIPTION
### Description
Unifies log directory finding and creation in `AppDataManager`, and ensures logs are created in the intended, correct places on each platform.

The preferred directory hierarchy is the following.

Windows: Prefer a 'Logs' folder in whatever directory Ryujinx was launched from; fall back to `%APPDATA%\Ryujinx\Logs`.

Mac: Prefer `~/Library/Logs/Ryujinx`. Fall back to `~/Library/Application Support/Ryujinx/Logs`.

Linux: Use `~/.config/Ryujinx/Logs`.

### Context

https://github.com/Ryujinx/Ryujinx/commit/70fcba39de34fc211d09da12783898161724b0dc had an unfortunate quality escape where logs on macOS were being written to the executable directory, which is within the .app bundle. This was invalidating the code signature of the app bundle, which can lead to various unintended side effects. This PR addresses that issue while standardizing log locations across Windows, Mac and Linux.

Fix #6252