### PR TITLE
macOS: Stop storing user data in Documents for some users; fix symlinks

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -95,18 +95,9 @@ namespace Ryujinx.Common.Configuration
 
             BaseDirPath = Path.GetFullPath(BaseDirPath); // convert relative paths
 
-            // NOTE: Moves the Ryujinx folder in `~/.config` to `~/Library/Application Support` if one is found
-            // and a Ryujinx folder does not already exist in Application Support.
-            // Also creates a symlink from `~/.config/Ryujinx` to `~/Library/Application Support/Ryujinx` to preserve backwards compatibility.
-            // This should be removed in the future.
-            if (OperatingSystem.IsMacOS() && Mode == LaunchMode.UserProfile)
+            if (IsPathSymlink(BaseDirPath))
             {
-                string oldConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir);
-                if (Path.Exists(oldConfigPath) && !IsPathSymlink(oldConfigPath) && !Path.Exists(BaseDirPath))
-                {
-                    FileSystemUtils.MoveDirectory(oldConfigPath, BaseDirPath);
-                    Directory.CreateSymbolicLink(oldConfigPath, BaseDirPath);
-                }
+                Logger.Error?.Print(LogClass.Application, $"Application data directory is a symlink. This may be unintended.");
             }
 
             SetupBasePaths();
@@ -243,6 +234,62 @@ namespace Ryujinx.Common.Configuration
         {
             FileAttributes attributes = File.GetAttributes(path);
             return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+
+        public static void FixMacOSConfigurationFolders()
+        {
+            if (OperatingSystem.IsMacOS())
+            {
+                string oldConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".config", DefaultBaseDir);
+                if (Path.Exists(oldConfigPath) && !IsPathSymlink(oldConfigPath) && !Path.Exists(BaseDirPath))
+                {
+                    FileSystemUtils.MoveDirectory(oldConfigPath, BaseDirPath);
+                    Directory.CreateSymbolicLink(oldConfigPath, BaseDirPath);
+                }
+
+                string correctApplicationDataDirectoryPath =
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir);
+                if (IsPathSymlink(correctApplicationDataDirectoryPath))
+                {
+                    //copy the files somewhere temporarily
+                    string tempPath = Path.Combine(Path.GetTempPath(), DefaultBaseDir);
+                    try
+                    {
+                        FileSystemUtils.CopyDirectory(correctApplicationDataDirectoryPath, tempPath, true);
+                    }
+                    catch
+                    {
+                        Logger.Error?.Print(LogClass.Application,
+                            $"Critical error copying Ryujinx application data into the temp folder. Please manually move your application data to the correct folder.");
+                        return;
+                    }
+
+                    //delete the symlink
+                    try
+                    {
+                        //This will fail if this is an actual directory, so there is no way we can actually delete user data here.
+                        File.Delete(correctApplicationDataDirectoryPath);
+                    }
+                    catch
+                    {
+                        Logger.Error?.Print(LogClass.Application,
+                            $"Critical error deleting the Ryujinx application data folder symlink. Please manually move your application data to the correct location.");
+                        return;
+                    }
+
+                    //put the files back
+                    try
+                    {
+                        FileSystemUtils.CopyDirectory(tempPath, correctApplicationDataDirectoryPath, true);
+                    }
+                    catch
+                    {
+                        Logger.Error?.Print(LogClass.Application,
+                            $"Critical error copying Ryujinx application data into the correct location. Please manually move your application data to the correct folder.");
+                    }
+                }
+            }
         }
 
         public static string GetModsPath() => CustomModsPath ?? Directory.CreateDirectory(Path.Combine(BaseDirPath, DefaultModsDir)).FullName;

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -261,7 +261,18 @@ namespace Ryujinx.Common.Configuration
                 catch (Exception exception)
                 {
                     Logger.Error?.Print(LogClass.Application,
-                        $"Critical error copying Ryujinx application data into the temp folder. Please manually move your application data to the correct folder. {exception}");
+                        $"Critical error copying Ryujinx application data into the temp folder. {exception}");
+                    try
+                    {
+                        FileSystemInfo resolvedDirectoryInfo =
+                            Directory.ResolveLinkTarget(correctApplicationDataDirectoryPath, true);
+                        string resolvedPath = resolvedDirectoryInfo.FullName;
+                        Logger.Error?.Print(LogClass.Application, $"Please manually move your Ryujinx data from {resolvedPath} to {correctApplicationDataDirectoryPath}, and remove the symlink.");
+                    }
+                    catch (Exception symlinkException)
+                    {
+                        Logger.Error?.Print(LogClass.Application, $"Unable to resolve the symlink for Ryujinx application data: {symlinkException}. Follow the symlink at {correctApplicationDataDirectoryPath} and move your data back to the Application Support folder.");
+                    }
                     return;
                 }
 
@@ -274,7 +285,18 @@ namespace Ryujinx.Common.Configuration
                 catch (Exception exception)
                 {
                     Logger.Error?.Print(LogClass.Application,
-                        $"Critical error deleting the Ryujinx application data folder symlink. Please manually move your application data to the correct location. {exception}");
+                        $"Critical error deleting the Ryujinx application data folder symlink at {correctApplicationDataDirectoryPath}. {exception}");
+                    try
+                    {
+                        FileSystemInfo resolvedDirectoryInfo =
+                            Directory.ResolveLinkTarget(correctApplicationDataDirectoryPath, true);
+                        string resolvedPath = resolvedDirectoryInfo.FullName;
+                        Logger.Error?.Print(LogClass.Application, $"Please manually move your Ryujinx data from {resolvedPath} to {correctApplicationDataDirectoryPath}, and remove the symlink.");
+                    }
+                    catch (Exception symlinkException)
+                    {
+                        Logger.Error?.Print(LogClass.Application, $"Unable to resolve the symlink for Ryujinx application data: {symlinkException}. Follow the symlink at {correctApplicationDataDirectoryPath} and move your data back to the Application Support folder.");
+                    }
                     return;
                 }
 
@@ -286,7 +308,7 @@ namespace Ryujinx.Common.Configuration
                 catch (Exception exception)
                 {
                     Logger.Error?.Print(LogClass.Application,
-                        $"Critical error copying Ryujinx application data into the correct location. Please manually move your application data to the correct folder. {exception}");
+                        $"Critical error copying Ryujinx application data into the correct location. {exception}. Please manually move your application data from {tempPath} to {correctApplicationDataDirectoryPath}.");
                 }
             }
         }

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.UI.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 48;
+        public const int CurrentVersion = 49;
 
         /// <summary>
         /// Version of the configuration file format

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1438,6 +1438,8 @@ namespace Ryujinx.UI.Common.Configuration
                 {
                     AppDataManager.FixMacOSConfigurationFolders();
                 }
+
+                configurationFileUpdated = true;
             }
 
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1430,6 +1430,16 @@ namespace Ryujinx.UI.Common.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 49)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 49.");
+
+                if (OperatingSystem.IsMacOS())
+                {
+                    AppDataManager.FixMacOSConfigurationFolders();
+                }
+            }
+
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value = configurationFileFormat.ResScaleCustom;


### PR DESCRIPTION
### Context

When .NET 8 was merged, there were some breaking changes to `Environment.SpecialFolder` values on macOS. One was immediately noticed, the change of `SpecialFolder.Personal` from `~/` to `~/Documents/`. This was addressed by https://github.com/Ryujinx/Ryujinx/pull/5941. Another important change was that of `SpecialFolder.ApplicationData` from `~/.config/` to `~/Library/Application Support`, correcting a longstanding discrepancy between macOS and Linux.

Now let's briefly go back in time to a commit dating from 2020 in `AppDataManager`, which got ahead of .NET, moving Mac configuration files from `~/.config/Ryujinx/` to `~/Library/Application Support/Ryujinx` to fix this discrepancy. The code block that does this is partially excerpted below:

```c#
if (OperatingSystem.IsMacOS() && Mode == LaunchMode.UserProfile)
{
    if (Path.Exists(oldConfigPath) && !IsPathSymlink(oldConfigPath) && !Path.Exists(BaseDirPath))
    {
        FileSystemUtils.MoveDirectory(oldConfigPath, BaseDirPath);
        Directory.CreateSymbolicLink(oldConfigPath, BaseDirPath);
    }
}
```

Here, on every startup, the existence of configuration files at the old config path, `~/.config/Ryujinx/`, is checked, and, if detected, they are moved to the new area, creating a symlink that links `~/.config/Ryujinx` to `~/Library/Application Support/Ryujinx` in the process.

Unfortunately, the key it used to describe the folder when checking for the existence of old configuration files was `SpecialFolder.ApplicationData`. Perhaps you can see where this is going.

When .NET 8 landed, `oldConfigPath` started evaluating to what should be *correct* directory, and the new, "correct" directory was an entirely incorrect one in `~/Documents`. The above code block, however, was still happily running, and moving all user files to the nonsensical folder `~/Documents/Library/Application Support/Ryujinx`, with a symlink being created at` ~/Library/Application Support/Ryujinx`.

Once https://github.com/Ryujinx/Ryujinx/pull/5941 was committed, Ryujinx began looking in the correct location for user data once more, and found it, but only because this directory was a symlink leading to ~/Documents.

This was actively noticed by both users and developers of Ryujinx, but was for some reason unaddressed. This is an editorial aside, but this represents a fairly large testing and process failure in my opinion. Not noticing this issue ahead of time is, of course, excusable, but noticing it and failing to fix it is less so. Because:

> [!IMPORTANT]
> Any person that updated and ran Ryujinx in the two days between 1084 and 1088 has had their saves and application data stored in this nonsensical folder ever since, vulnerable to wipes, iCloud or Dropbox shenanigans, or simply being cleaned out by a reasonable person wondering why `~/Documents/Library` exists.

### Now

This PR addresses all of the above.

* Config version is incremented, though no file format changes are made.
* The original code designed to migrate from `~/.config` to `~/Library/Application Support/` has been changed to run exactly once, on config update, and now uses a more explicit path to target the long-deprecated config path.
* On config update we will also run, exactly once, a check to see if the correct configuration directory, `~/Library/Application Support/Ryujinx`, is a symlink, and if so, we will remove it, and copy the files from the resolved path to the original path. 

### Testing

This has been tested locally on my Mac machine and verified to fix the symlink issue. It should be tested by other Mac users, especially those with the symlink resident in their Application Support folders.

There is some chance for this process to fail, if for some strange reason the Application Support directory isn't writable. However, I do not see a particularly good way around this externality. I would prefer not to run this code every time Ryujinx starts up. If this fails on a user's machine that has the symlink in their Application Support folder, they may just be stuck with it unless they manually resolve the situation. I added a log statement to `AppDataManager` to report if the user's data directory is a symlink, so that this circumstance will at least be apparent via support channels.

Please leave any feedback if anyone sees a better way to handle any aspect of this.