### PR TITLE
LightningJit: Return for some LDR (immediate) cases

### DIFF
--- a/src/Ryujinx.Cpu/LightningJit/Arm32/CodeGenContext.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/CodeGenContext.cs
@@ -83,9 +83,9 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
             RegisterAllocator.MarkGprAsUsed(RegisterUtils.LrRegister);
         }
 
-        public void AddPendingIndirectBranch(InstName name, uint targetRegister)
+        public void AddPendingIndirectBranch(InstName name, uint targetRegister, uint rnRegister)
         {
-            _pendingBranches.Add(new(BranchType.IndirectBranch, targetRegister, 0u, name, CodeWriter.InstructionPointer));
+            _pendingBranches.Add(new(BranchType.IndirectBranch, targetRegister, rnRegister, name, CodeWriter.InstructionPointer));
 
             RegisterAllocator.MarkGprAsUsed((int)targetRegister);
         }

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
@@ -67,7 +67,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32.Target.Arm64
 
             InstEmitCommon.SetThumbFlag(context, rmOperand);
 
-            context.AddPendingIndirectBranch(InstName.Bx, rm);
+            context.AddPendingIndirectBranch(InstName.Bx, rm, 0u);
 
             context.Arm64Assembler.B(0);
         }


### PR DESCRIPTION
This change extends the cases that are considered a return on the new JIT for Arm32. The general problem is that Arm32 allows pretty much any instruction to write to the PC register, so its not easy to know what is supposed to be a regular jump, and what is a return. There is no harm in assuming that something is a return (even if it isn't) other than performance, but the opposite (missing returns) can cause a stack overflow.

This change fixes a stack overflow on the game Gothic on macOS. Oddly enough, it does not happen on the old JIT.

<img width="1392" alt="Captura de Tela 2024-02-02 às 02 57 50" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/c4e271be-e9a2-42ae-8650-32091e942934">

Fixes #6236.
The new condition is also triggering on Mario Kart 8 and likely other 32-bit games, so it's worth checking if there is any performance regression.
Also maybe there is a better way to do this, but from what I tested so far, the only thing that fixed the stack overflow on this game was returning for LDR from R12...