### PR TITLE
LightningJit: Reduce stack usage for Arm32 code

### DIFF
--- a/src/Ryujinx.Cpu/LightningJit/Arm32/Block.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/Block.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
         public readonly List<InstInfo> Instructions;
         public readonly bool EndsWithBranch;
         public readonly bool HasHostCall;
+        public readonly bool HasHostCallSkipContext;
         public readonly bool IsTruncated;
         public readonly bool IsLoopEnd;
         public readonly bool IsThumb;
@@ -20,6 +21,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
             List<InstInfo> instructions,
             bool endsWithBranch,
             bool hasHostCall,
+            bool hasHostCallSkipContext,
             bool isTruncated,
             bool isLoopEnd,
             bool isThumb)
@@ -31,6 +33,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
             Instructions = instructions;
             EndsWithBranch = endsWithBranch;
             HasHostCall = hasHostCall;
+            HasHostCallSkipContext = hasHostCallSkipContext;
             IsTruncated = isTruncated;
             IsLoopEnd = isLoopEnd;
             IsThumb = isThumb;
@@ -57,6 +60,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
                 Instructions.GetRange(0, splitIndex),
                 false,
                 HasHostCall,
+                HasHostCallSkipContext,
                 false,
                 false,
                 IsThumb);
@@ -67,6 +71,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
                 Instructions.GetRange(splitIndex, splitCount),
                 EndsWithBranch,
                 HasHostCall,
+                HasHostCallSkipContext,
                 IsTruncated,
                 IsLoopEnd,
                 IsThumb);

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/MultiBlock.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/MultiBlock.cs
@@ -6,6 +6,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
     {
         public readonly List<Block> Blocks;
         public readonly bool HasHostCall;
+        public readonly bool HasHostCallSkipContext;
         public readonly bool IsTruncated;
 
         public MultiBlock(List<Block> blocks)
@@ -15,12 +16,14 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
             Block block = blocks[0];
 
             HasHostCall = block.HasHostCall;
+            HasHostCallSkipContext = block.HasHostCallSkipContext;
 
             for (int index = 1; index < blocks.Count; index++)
             {
                 block = blocks[index];
 
                 HasHostCall |= block.HasHostCall;
+                HasHostCallSkipContext |= block.HasHostCallSkipContext;
             }
 
             block = blocks[^1];

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/RegisterAllocator.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/RegisterAllocator.cs
@@ -106,6 +106,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32
                 if ((regMask & AbiConstants.ReservedRegsMask) == 0)
                 {
                     _gprMask |= regMask;
+                    UsedGprsMask |= regMask;
 
                     return firstCalleeSaved;
                 }

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/Compiler.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/Compiler.cs
@@ -607,7 +607,8 @@ namespace Ryujinx.Cpu.LightningJit.Arm32.Target.Arm64
                 name == InstName.Ldm ||
                 name == InstName.Ldmda ||
                 name == InstName.Ldmdb ||
-                name == InstName.Ldmib)
+                name == InstName.Ldmib ||
+                name == InstName.Pop)
             {
                 // Arm32 does not have a return instruction, instead returns are implemented
                 // either using BX LR (for leaf functions), or POP { ... PC }.

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
@@ -199,12 +199,12 @@ namespace Ryujinx.Cpu.LightningJit.Arm32.Target.Arm64
             }
         }
 
-        private static void WriteSpillSkipContext(ref Assembler asm, RegisterAllocator regAlloc, int spillOffset)
+        public static void WriteSpillSkipContext(ref Assembler asm, RegisterAllocator regAlloc, int spillOffset)
         {
             WriteSpillOrFillSkipContext(ref asm, regAlloc, spillOffset, spill: true);
         }
 
-        private static void WriteFillSkipContext(ref Assembler asm, RegisterAllocator regAlloc, int spillOffset)
+        public static void WriteFillSkipContext(ref Assembler asm, RegisterAllocator regAlloc, int spillOffset)
         {
             WriteSpillOrFillSkipContext(ref asm, regAlloc, spillOffset, spill: false);
         }


### PR DESCRIPTION
When we do a managed call on JIT generated code, we need to place all caller saved registers somewhere, since the managed function might overwrite their values. Normally we store them on the stack, however for guest state, we can store them in the context struct, and avoid using the stack this way. This PR changes the "sync point"/interrupt check to use the guest context to store the guest register values, instead of the stack. Then, it changes the stack reservation size calculation to account for the cases where we store the guest states to context, in those cases we only need to reserve 16 bytes as we will only store 2 pointers, the context pointer and the guest address space base pointer.

This reduces the stack usage by a lot in some cases, and notably fixes #6236 which is caused by a stack overflow.
<img width="1392" alt="301745199-c4e271be-e9a2-42ae-8650-32091e942934" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/032a3194-09f6-41c0-a2ca-a877111a6651">
With the default macOS stack size (512KB), it crashes almost right away. With this change, it goes to menu but has another stack overflow when trying to go in-game. With the increased stack size (2MB) which is what we use, it can go in-game and I did not get any stack overflow, at least as far as I have tested.

Testing is welcome. It should be tested with 32-bit games on Arm platforms, it should not really affect anything else.