### PR TITLE
Ensure SM service won't listen to closed sessions

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -306,6 +306,7 @@ namespace Ryujinx.HLE.HOS.Services
         private void DestroySession(int serverSessionHandle)
         {
             _context.Syscall.CloseHandle(serverSessionHandle);
+
             if (RemoveSessionObj(serverSessionHandle, out var session))
             {
                 (session as IDisposable)?.Dispose();
@@ -373,7 +374,7 @@ namespace Ryujinx.HLE.HOS.Services
                 response.RawData = _responseDataStream.ToArray();
             }
             else if (request.Type == IpcMessageType.CmifControl ||
-                        request.Type == IpcMessageType.CmifControlWithContext)
+                     request.Type == IpcMessageType.CmifControlWithContext)
             {
 #pragma warning disable IDE0059 // Remove unnecessary value assignment
                 uint magic = (uint)_requestDataReader.ReadUInt64();

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -287,6 +287,10 @@ namespace Ryujinx.HLE.HOS.Services
                             _wakeEvent.WritableEvent.Clear();
                         }
                     }
+                    else if (rc == KernelResult.PortRemoteClosed && signaledIndex >= 0)
+                    {
+                        DestroySession(handles[signaledIndex]);
+                    }
 
                     _selfProcess.CpuMemory.Write(messagePtr + 0x0, 0);
                     _selfProcess.CpuMemory.Write(messagePtr + 0x4, 2 << 10);
@@ -297,6 +301,15 @@ namespace Ryujinx.HLE.HOS.Services
             }
 
             Dispose();
+        }
+
+        private void DestroySession(int serverSessionHandle)
+        {
+            _context.Syscall.CloseHandle(serverSessionHandle);
+            if (RemoveSessionObj(serverSessionHandle, out var session))
+            {
+                (session as IDisposable)?.Dispose();
+            }
         }
 
         private bool Process(int serverSessionHandle, ulong recvListAddr)
@@ -412,11 +425,7 @@ namespace Ryujinx.HLE.HOS.Services
             }
             else if (request.Type == IpcMessageType.CmifCloseSession || request.Type == IpcMessageType.TipcCloseSession)
             {
-                _context.Syscall.CloseHandle(serverSessionHandle);
-                if (RemoveSessionObj(serverSessionHandle, out var session))
-                {
-                    (session as IDisposable)?.Dispose();
-                }
+                DestroySession(serverSessionHandle);
                 shouldReply = false;
             }
             // If the type is past 0xF, we are using TIPC


### PR DESCRIPTION
If a port was closed, we should stop listening to it, otherwise kernel will return the `PortRemoteClosed` error non-stop and we won't be signalled when other services try to connect to SM. This is a bug that was happening if anything else tried to connect to SM after a process has exited, it started happening after #5802 because it uses SM to connect to HLE services from other HLE services. It caused everything that uses the JIT service (NSO Nintendo 64, etc) to lock up upon trying to load said service.

This should also fix the "loading an applet from another applet" scenario from locking up, for the people that was messing with that.