### PR TITLE
Remove component operand for texture gather with depth compare

### DIFF
--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -592,7 +592,10 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     flags |= TextureFlags.Offset;
                 }
 
-                sourcesList.Add(Const((int)tld4sOp.TexComp));
+                if (!tld4sOp.Dc)
+                {
+                    sourcesList.Add(Const((int)tld4sOp.TexComp));
+                }
             }
             else
             {


### PR DESCRIPTION
Yet another case of redundant operands being added to the list, and it causing problems later on. Texture gather with depth compare does not need a RGBA component being specified, because what is being sampled is a depth texture, so there is only the depth to select.

This fixes a crash translating shaders on the game Hotshot Racing on Vulkan.
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/8d1619aa-e3ac-4809-9a06-59b69c327505)
Testing is welcome.