### PR TITLE
Limit remote closed session removal to SM service

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -287,7 +287,7 @@ namespace Ryujinx.HLE.HOS.Services
                             _wakeEvent.WritableEvent.Clear();
                         }
                     }
-                    else if (rc == KernelResult.PortRemoteClosed && signaledIndex >= 0)
+                    else if (rc == KernelResult.PortRemoteClosed && signaledIndex >= 0 && SmObjectFactory != null)
                     {
                         DestroySession(handles[signaledIndex]);
                     }


### PR DESCRIPTION
#6246 caused a regression on "multi-program" games (those that have multiple program NCAs inside and needs relaunch). This is working around the issue by only enabling the new behaviour for SM, while keeping what we did before the linked change for other services. This still works for games using the JIT service while not regressing multiple program applications.

Ultimately this code should be deleted and fully replaced by new IPC code, so I think this solution is good enough for now.