### PR TITLE
Fix depth compare value for TLD4S shader instruction with offset

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5958;
+        private const uint CodeGenVersion = 6253;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -578,12 +578,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 type = SamplerType.Texture2D;
                 flags = TextureFlags.Gather;
 
-                if (tld4sOp.Dc)
-                {
-                    sourcesList.Add(Rb());
-
-                    type |= SamplerType.Shadow;
-                }
+                int depthCompareIndex = sourcesList.Count;
 
                 if (tld4sOp.Aoffi)
                 {
@@ -592,7 +587,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     flags |= TextureFlags.Offset;
                 }
 
-                if (!tld4sOp.Dc)
+                if (tld4sOp.Dc)
+                {
+                    sourcesList.Insert(depthCompareIndex, Rb());
+
+                    type |= SamplerType.Shadow;
+                }
+                else
                 {
                     sourcesList.Add(Const((int)tld4sOp.TexComp));
                 }


### PR DESCRIPTION
In register order, the depth compare value comes after the offset, but IR operands (and GLSL function signature/SPIR-V) expect the depth compare value to be before the offset. Fix it by inverting their order.

Fixes shadows in Hotshot Racing.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/0a6475b8-eac4-40e4-84ad-3f396906a276)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/117924ec-cd61-4152-9550-c623cd19011f)
