### PR TITLE
Revert change to skip flush when range size is 0

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1630,12 +1630,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return;
             }
 
-            // If size is zero, we have nothing to flush.
-            if (size == 0)
-            {
-                return;
-            }
-
             // There is a small gap here where the action is removed but _actionRegistered is still 1.
             // In this case it will skip registering the action, but here we are already handling it,
             // so there shouldn't be any issue as it's the same handler for all actions.


### PR DESCRIPTION
Reverts change introduced on #5755. I incorrectly assumed there is no need to flush a texture if the overlap size is 0, but that is not the case since the `RegionHandle` will remove the flush action for the entire page at least, so it could cause flush for some textures to be lost. The fact that the size can be 0 (or potentially "negative") is in itself an issue, but I don't think it will cause problems right now.

Fixes #6244.