### PR TITLE
Redact usernames from logs

### DIFF
--- a/src/Ryujinx.Common/Logging/Logger.cs
+++ b/src/Ryujinx.Common/Logging/Logger.cs
@@ -107,6 +107,7 @@ namespace Ryujinx.Common.Logging
             private static string FormatMessage(LogClass logClass, string caller, string message)
             {
                 message = message.Replace(_homeDir, _homeDirRedacted);
+
                 return $"{logClass} {caller}: {message}";
             }
         }

--- a/src/Ryujinx.Common/Logging/Logger.cs
+++ b/src/Ryujinx.Common/Logging/Logger.cs
@@ -23,8 +23,8 @@ namespace Ryujinx.Common.Logging
 
         public readonly struct Log
         {
-            internal static readonly string HomeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            internal static readonly string HomeDirRedacted = Path.Combine(new DirectoryInfo(HomeDir).Parent.FullName, "[redacted]");
+            private static readonly string _homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            private static readonly string _homeDirRedacted = Path.Combine(new DirectoryInfo(_homeDir).Parent.FullName, "[redacted]");
 
             internal readonly LogLevel Level;
 
@@ -106,7 +106,7 @@ namespace Ryujinx.Common.Logging
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static string FormatMessage(LogClass logClass, string caller, string message)
             {
-                message = message.Replace(HomeDir, HomeDirRedacted);
+                message = message.Replace(_homeDir, _homeDirRedacted);
                 return $"{logClass} {caller}: {message}";
             }
         }

--- a/src/Ryujinx.Common/Logging/Logger.cs
+++ b/src/Ryujinx.Common/Logging/Logger.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Common.Logging
         public readonly struct Log
         {
             private static readonly string _homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            private static readonly string _homeDirRedacted = Path.Combine(new DirectoryInfo(_homeDir).Parent.FullName, "[redacted]");
+            private static readonly string _homeDirRedacted = Path.Combine(Directory.GetParent(_homeDir).FullName, "[redacted]");
 
             internal readonly LogLevel Level;
 

--- a/src/Ryujinx.Common/Logging/Logger.cs
+++ b/src/Ryujinx.Common/Logging/Logger.cs
@@ -3,6 +3,7 @@ using Ryujinx.Common.SystemInterop;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -22,6 +23,9 @@ namespace Ryujinx.Common.Logging
 
         public readonly struct Log
         {
+            internal static readonly string HomeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            internal static readonly string HomeDirRedacted = Path.Combine(new DirectoryInfo(HomeDir).Parent.FullName, "[redacted]");
+
             internal readonly LogLevel Level;
 
             internal Log(LogLevel level)
@@ -100,7 +104,11 @@ namespace Ryujinx.Common.Logging
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static string FormatMessage(LogClass logClass, string caller, string message) => $"{logClass} {caller}: {message}";
+            private static string FormatMessage(LogClass logClass, string caller, string message)
+            {
+                message = message.Replace(HomeDir, HomeDirRedacted);
+                return $"{logClass} {caller}: {message}";
+            }
         }
 
         public static Log? Debug { get; private set; }


### PR DESCRIPTION
These changes cover all logging methods except for `PrintRawMsg` since that doesn't use `FormatMessage`, where the actual redaction happens. I don't *think* user directory paths ever pass through `PrintRawMsg` so this should be fine.

In my testing, this properly replaced the substring `C:\Users\myusernamehere\` with `C:\Users\[redacted]\`.
I couldn't test this on macOS or Linux, but the special folder tables for those systems I found online suggest that it would Just Work(tm):
* for macOS: https://johnkoerner.com/csharp/special-folder-values-on-windows-versus-mac/
* for Linux (Red Hat specifically, but it should be the same elsewhere): https://developers.redhat.com/blog/2018/11/07/dotnet-special-folder-api-linux#environment_getfolderpath

I chose to replace whole path segments instead of *just* the username because otherwise, things we wouldn't want replaced would get replaced. Quoting myself from the Discord server:
> that might get awkward if someone named mario uploads a log
and people are left wondering what game "Super  Wonder" is