### PR TITLE
AccountService: Cache token data

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -27,6 +27,9 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             _userId = userId;
         }
 
+        private byte[] CachedTokenData;
+        private DateTime CachedTokenExpiry;
+
         private static string GenerateIdToken()
         {
             using RSA provider = RSA.Create(2048);
@@ -144,7 +147,13 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             }
             */
 
-            byte[] tokenData = Encoding.ASCII.GetBytes(GenerateIdToken());
+            if (CachedTokenData == null || DateTime.UtcNow > CachedTokenExpiry)
+            {
+                CachedTokenExpiry = DateTime.UtcNow + TimeSpan.FromHours(3);
+                CachedTokenData = Encoding.ASCII.GetBytes(GenerateIdToken());
+            }
+
+            byte[] tokenData = CachedTokenData;
 
             context.Memory.Write(bufferPosition, tokenData);
             context.ResponseData.Write(tokenData.Length);

--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -22,13 +22,13 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
         private readonly UserId _userId;
 #pragma warning restore IDE0052
 
+        private byte[] _cachedTokenData;
+        private DateTime _cachedTokenExpiry;
+
         public ManagerServer(UserId userId)
         {
             _userId = userId;
         }
-
-        private byte[] CachedTokenData;
-        private DateTime CachedTokenExpiry;
 
         private static string GenerateIdToken()
         {
@@ -147,13 +147,13 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             }
             */
 
-            if (CachedTokenData == null || DateTime.UtcNow > CachedTokenExpiry)
+            if (_cachedTokenData == null || DateTime.UtcNow > _cachedTokenExpiry)
             {
-                CachedTokenExpiry = DateTime.UtcNow + TimeSpan.FromHours(3);
-                CachedTokenData = Encoding.ASCII.GetBytes(GenerateIdToken());
+                _cachedTokenExpiry = DateTime.UtcNow + TimeSpan.FromHours(3);
+                _cachedTokenData = Encoding.ASCII.GetBytes(GenerateIdToken());
             }
 
-            byte[] tokenData = CachedTokenData;
+            byte[] tokenData = _cachedTokenData;
 
             context.Memory.Write(bufferPosition, tokenData);
             context.ResponseData.Write(tokenData.Length);


### PR DESCRIPTION
This method appears to indicate that the token returned should be cached. I've made it so that it generates a token that lasts until its expiration time, and reuses it on subsequent calls. I'm not sure why this was so slow before.

This should fix an issue where Monopoly for Nintendo Switch tanks its framerate by asking for a token very frequently.