### PR TITLE
Replace Flex Panels in favor of Wrap Panels for Avalonia

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="FluentAvaloniaUI" Version="2.0.5" />
     <PackageVersion Include="GtkSharp.Dependencies" Version="1.1.1" />
     <PackageVersion Include="GtkSharp.Dependencies.osx" Version="0.0.5" />
-    <PackageVersion Include="jp2masa.Avalonia.Flexbox" Version="0.3.0-beta.4" />
     <PackageVersion Include="LibHac" Version="0.19.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />

--- a/src/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/src/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -43,7 +43,6 @@
     <PackageReference Include="Avalonia.Markup.Xaml.Loader" />
     <PackageReference Include="Avalonia.Svg" />
     <PackageReference Include="Avalonia.Svg.Skia" />
-    <PackageReference Include="jp2masa.Avalonia.Flexbox" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
 

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationGridView.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationGridView.axaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Ryujinx.Ava.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:flex="clr-namespace:Avalonia.Flexbox;assembly=Avalonia.Flexbox"
     xmlns:helpers="clr-namespace:Ryujinx.Ava.UI.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationGridView.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationGridView.axaml
@@ -33,11 +33,10 @@
             SelectionChanged="GameList_SelectionChanged">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <flex:FlexPanel
+                    <WrapPanel
                         HorizontalAlignment="Center"
-                        VerticalAlignment="Stretch"
-                        AlignContent="FlexStart"
-                        JustifyContent="FlexStart" />
+                        VerticalAlignment="Top"
+                        Orientation="Horizontal" />
                 </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
             <ListBox.Styles>

--- a/src/Ryujinx.Ava/UI/Views/User/UserSelectorView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/User/UserSelectorView.axaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:locale="clr-namespace:Ryujinx.Ava.Common.Locale"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:flex="clr-namespace:Avalonia.Flexbox;assembly=Avalonia.Flexbox"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="clr-namespace:Ryujinx.Ava.UI.Helpers"
     xmlns:models="clr-namespace:Ryujinx.Ava.UI.Models"
@@ -40,11 +39,10 @@
                 ItemsSource="{Binding Profiles}">
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <flex:FlexPanel
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            AlignContent="FlexStart"
-                            JustifyContent="FlexStart" />
+                        <WrapPanel
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Orientation="Horizontal"/>
                     </ItemsPanelTemplate>
                 </ListBox.ItemsPanel>
                 <ListBox.Styles>

--- a/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
@@ -3,7 +3,6 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:flex="clr-namespace:Avalonia.Flexbox;assembly=Avalonia.Flexbox"
     xmlns:locale="clr-namespace:Ryujinx.Ava.Common.Locale"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
@@ -49,13 +48,11 @@
                         Grid.Column="0"
                         Height="80"
                         Source="resm:Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.Ui.Common" />
-                    <flex:FlexPanel
+                    <WrapPanel
                         Grid.Column="2"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        Direction="Column"
-                        JustifyContent="SpaceAround"
-                        RowSpacing="2">
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Orientation="Vertical">
                         <TextBlock
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
@@ -71,7 +68,7 @@
                             Text="(REE-YOU-JINX)"
                             TextAlignment="Center"
                             Width="110" />
-                    </flex:FlexPanel>
+                    </WrapPanel>
                 </Grid>
                 <TextBlock
                     HorizontalAlignment="Center"


### PR DESCRIPTION
This PR changes Grid View, User Profile Selector and About window to use a Wrap Panel instead of a Flex Panel. Closes Feature Request #5055. Allows consistency between List view and Grid view and removes dependency. Changing size and showing names works as usual. Below are comparisons vs Master.

-------------------------------------------------------------------------------------------------
Master Grid View:
![image](https://github.com/Ryujinx/Ryujinx/assets/11906669/2c4ba0cc-aaa1-4a52-9efd-14ac66749ac2)

PR Grid View:
![image](https://github.com/Ryujinx/Ryujinx/assets/11906669/b865d9ad-813b-47f5-925a-94b0ff934c86)

-------------------------------------------------------------------------------------------------

Master About Window:
![image](https://github.com/Ryujinx/Ryujinx/assets/11906669/0a8b6c5e-7bca-4083-9c7d-f36521bb212d)

PR About Window:
![image](https://github.com/Ryujinx/Ryujinx/assets/11906669/c83a4ba4-023a-4001-9ca6-862b6be4b0ed)

-------------------------------------------------------------------------------------------------

Testing:
People with many games and profiles should test this to compare to behavior in master and please report here. 