### PR TITLE
Ava UI: Bump Version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,11 +3,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.0.7" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.7" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.0.7" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.7" />
-    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.0.7" />
+    <PackageVersion Include="Avalonia" Version="11.0.8" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.8" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.0.8" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.8" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.0.8" />
     <PackageVersion Include="Avalonia.Svg" Version="11.0.0.13" />
     <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.0.13" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />

--- a/src/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/src/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -57,9 +57,6 @@
     <PackageReference Include="SPB" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="SixLabors.ImageSharp" />
-
-    <!--NOTE: DO NOT REMOVE, THIS IS REQUIRED AS A RESULT OF A TRIMMING ISSUE IN AVALONIA -->
-    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This bumps Avalonia to 11.0.8, including the fix for Steam Deck window.

With this version, Ava is getting closer to become the default on all platforms.

This update also removes a dependency on SDC, which means we can remove it from the Ava project, ~~but it persists in UI.Common for now.~~ Removed from UI.Common in #6275