### PR TITLE
Clamp vertex buffer size to mapped size if too high

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public const int RenderTargetStateIndex = 27;
 
         // Vertex buffers larger than this size will be clamped to the mapped size.
-        private const ulong VertexBufferSizeToMappedSizeThreshold = 256 * 1024 * 1024; // 128 MB
+        private const ulong VertexBufferSizeToMappedSizeThreshold = 256 * 1024 * 1024; // 256 MB
 
         private readonly GpuContext _context;
         private readonly GpuChannel _channel;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -26,6 +26,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public const int PrimitiveRestartStateIndex = 12;
         public const int RenderTargetStateIndex = 27;
 
+        // Vertex buffers larger than this size will be clamped to the mapped size.
+        private const ulong VertexBufferSizeToMappedSizeThreshold = 256 * 1024 * 1024; // 128 MB
+
         private readonly GpuContext _context;
         private readonly GpuChannel _channel;
         private readonly DeviceStateWithShadow<ThreedClassState> _state;
@@ -1143,6 +1146,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                         maxVertexBufferSize *= (uint)stride;
 
                         size = Math.Min(size, maxVertexBufferSize);
+                    }
+                    else if (size > VertexBufferSizeToMappedSizeThreshold)
+                    {
+                        // Make sure we have a sane vertex buffer size, since in some cases applications
+                        // might set the "end address" of the vertex buffer to the end of the GPU address space,
+                        // which would result in a several GBs large buffer.
+
+                        size = _channel.MemoryManager.GetMappedSize(address, size);
                     }
                 }
                 else


### PR DESCRIPTION
Setting a vertex buffer size that is too high is fairly inconsequential on the Switch, as it is only used for bounds checking. However on emulator it is problematic since we use those sizes as the actual vertex buffer size. Some games set very high sizes, for this reason we have a few tricks in places to try reducing the size. This PR adds another way to reduce the size. If the size is higher than a given threshold (currently 256 MB), it will set the size to the amount of memory that is actually mapped instead. This does not work well with sparse buffers, but we currently don't support sparse vertex buffers anyway (it assumes that the vertex buffer is a single contiguous range).

Fixes Infinite Tanks World War 2 (still does not render correctly due to an unsupported render target format):
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/b566cb63-db3c-4651-9de2-bad1e4c9733d)
Fixes Blades of Time:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/b4e750f9-86ee-4e4e-99e7-1da6e8cded9c)
In both cases, they would crash with `VK_OUT_OF_DEVICE_MEMORY` error on Vulkan because the size is so high that it does not fit in a 32-bit signed integer, and when cast to `int` it would become a negative value (due to silent overflow).

Fixes #6270.
Testing is welcome. 