### PR TITLE
Infra: Remove SDC

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,6 @@
     <PackageVersion Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
-    <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Management" Version="8.0.0" />
     <PackageVersion Include="UnicornEngine.Unicorn" Version="2.0.2-rc1-fb78016" />

--- a/src/Ryujinx.Ui.Common/Ryujinx.Ui.Common.csproj
+++ b/src/Ryujinx.Ui.Common/Ryujinx.Ui.Common.csproj
@@ -57,7 +57,6 @@
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" />
     <PackageReference Include="securifybv.ShellLink" />
-    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaces our one remaining use of SDC with ImageSharp. Alongside #6271, this removes SDC entirely from Ryujinx.