### PR TITLE
Update Avalonia About Window like requested in PR #6267

### DIFF
--- a/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
@@ -53,7 +53,7 @@
                         Height="80"
                         Source="resm:Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.Ui.Common"
                         HorizontalAlignment="Center"
-                        IsHitTestVisible="True"/>
+                        IsHitTestVisible="True" />
                     <WrapPanel
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
@@ -65,14 +65,14 @@
                             TextAlignment="Start"
                             Width="110"
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Center"/>
+                            VerticalAlignment="Center" />
                         <TextBlock
                             FontSize="11"
                             Text="(REE-YOU-JINX)"
                             TextAlignment="Start"
                             Width="110"
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Center"/>
+                            VerticalAlignment="Center" />
                     </WrapPanel></StackPanel>
                 </Grid>
                 <TextBlock

--- a/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
@@ -49,31 +49,32 @@
                         Orientation="Horizontal"
                         HorizontalAlignment="Center"
                         Spacing="10">
-                    <Image
-                        Height="80"
-                        Source="resm:Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.Ui.Common"
-                        HorizontalAlignment="Center"
-                        IsHitTestVisible="True" />
-                    <WrapPanel
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Orientation="Vertical">
-                        <TextBlock
-                            FontSize="28"
-                            FontWeight="Bold"
-                            Text="Ryujinx"
-                            TextAlignment="Start"
-                            Width="110"
+                        <Image
+                            Height="80"
+                            Source="resm:Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.Ui.Common"
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Center" />
-                        <TextBlock
-                            FontSize="11"
-                            Text="(REE-YOU-JINX)"
-                            TextAlignment="Start"
-                            Width="110"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center" />
-                    </WrapPanel></StackPanel>
+                            IsHitTestVisible="True" />
+                        <WrapPanel
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Orientation="Vertical">
+                            <TextBlock
+                                FontSize="28"
+                                FontWeight="Bold"
+                                Text="Ryujinx"
+                                TextAlignment="Start"
+                                Width="110"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center" />
+                            <TextBlock
+                                FontSize="11"
+                                Text="(REE-YOU-JINX)"
+                                TextAlignment="Start"
+                                Width="110"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center" />
+                        </WrapPanel>
+                    </StackPanel>
                 </Grid>
                 <TextBlock
                     HorizontalAlignment="Center"

--- a/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
@@ -44,31 +44,36 @@
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
+                    <StackPanel
+                        Grid.Column="1"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Spacing="10">
                     <Image
-                        Grid.Column="0"
                         Height="80"
-                        Source="resm:Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.Ui.Common" />
+                        Source="resm:Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.Ui.Common"
+                        HorizontalAlignment="Center"
+                        IsHitTestVisible="True"/>
                     <WrapPanel
-                        Grid.Column="2"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
                         Orientation="Vertical">
                         <TextBlock
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
                             FontSize="28"
                             FontWeight="Bold"
                             Text="Ryujinx"
-                            TextAlignment="Center"
-                            Width="110" />
-                        <TextBlock
+                            TextAlignment="Left"
+                            Width="110"
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
+                            VerticalAlignment="Center"/>
+                        <TextBlock
                             FontSize="11"
                             Text="(REE-YOU-JINX)"
-                            TextAlignment="Center"
-                            Width="110" />
-                    </WrapPanel>
+                            TextAlignment="Left"
+                            Width="110"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"/>
+                    </WrapPanel></StackPanel>
                 </Grid>
                 <TextBlock
                     HorizontalAlignment="Center"

--- a/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
@@ -62,14 +62,14 @@
                             FontSize="28"
                             FontWeight="Bold"
                             Text="Ryujinx"
-                            TextAlignment="Left"
+                            TextAlignment="Start"
                             Width="110"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"/>
                         <TextBlock
                             FontSize="11"
                             Text="(REE-YOU-JINX)"
-                            TextAlignment="Left"
+                            TextAlignment="Start"
                             Width="110"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"/>


### PR DESCRIPTION
Update about window to have Logo and "Ryujinx" in center and adjacent as requested in PR #6267.


---

Before:
<img width="601" alt="image" src="https://github.com/Ryujinx/Ryujinx/assets/11906669/1fd90580-582b-400b-b5f7-f0ab1bd79107">


After:
<img width="603" alt="image" src="https://github.com/Ryujinx/Ryujinx/assets/11906669/deeb94d0-02aa-47bb-bd27-b6d59363a383">
