### PR TITLE
Make IOpenGLContext.HasContext context dependent

### DIFF
--- a/src/Ryujinx.Ava/UI/Renderer/SPBOpenGLContext.cs
+++ b/src/Ryujinx.Ava/UI/Renderer/SPBOpenGLContext.cs
@@ -29,6 +29,8 @@ namespace Ryujinx.Ava.UI.Renderer
             _context.MakeCurrent(_window);
         }
 
+        public bool HasContext() => _context.IsCurrent;
+
         public static SPBOpenGLContext CreateBackgroundContext(OpenGLContextBase sharedContext)
         {
             OpenGLContextBase context = PlatformHelper.CreateOpenGLContext(FramebufferFormat.Default, 3, 3, OpenGLContextFlags.Compat, true, sharedContext);

--- a/src/Ryujinx.Graphics.OpenGL/BackgroundContextWorker.cs
+++ b/src/Ryujinx.Graphics.OpenGL/BackgroundContextWorker.cs
@@ -30,6 +30,8 @@ namespace Ryujinx.Graphics.OpenGL
             _thread.Start();
         }
 
+        public bool HasContext() => _backgroundContext.HasContext();
+
         private void Run()
         {
             InBackground = true;

--- a/src/Ryujinx.Graphics.OpenGL/IOpenGLContext.cs
+++ b/src/Ryujinx.Graphics.OpenGL/IOpenGLContext.cs
@@ -7,21 +7,6 @@ namespace Ryujinx.Graphics.OpenGL
     {
         void MakeCurrent();
 
-        // TODO: Support more APIs per platform.
-        static bool HasContext()
-        {
-            if (OperatingSystem.IsWindows())
-            {
-                return WGLHelper.GetCurrentContext() != IntPtr.Zero;
-            }
-            else if (OperatingSystem.IsLinux())
-            {
-                return GLXHelper.GetCurrentContext() != IntPtr.Zero;
-            }
-            else
-            {
-                return false;
-            }
-        }
+        bool HasContext();
     }
 }

--- a/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -248,7 +248,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             // alwaysBackground is ignored, since we cannot switch from the current context.
 
-            if (IOpenGLContext.HasContext())
+            if (_window.BackgroundContext.HasContext())
             {
                 action(); // We have a context already - use that (assuming it is the main one).
             }

--- a/src/Ryujinx.Headless.SDL2/OpenGL/OpenGLWindow.cs
+++ b/src/Ryujinx.Headless.SDL2/OpenGL/OpenGLWindow.cs
@@ -96,6 +96,8 @@ namespace Ryujinx.Headless.SDL2.OpenGL
                 }
             }
 
+            public bool HasContext() => SDL_GL_GetCurrentContext() != IntPtr.Zero;
+
             public void Dispose()
             {
                 SDL_GL_DeleteContext(_context);

--- a/src/Ryujinx/Ui/SPBOpenGLContext.cs
+++ b/src/Ryujinx/Ui/SPBOpenGLContext.cs
@@ -29,6 +29,8 @@ namespace Ryujinx.Ui
             _context.MakeCurrent(_window);
         }
 
+        public bool HasContext() => _context.IsCurrent;
+
         public static SPBOpenGLContext CreateBackgroundContext(OpenGLContextBase sharedContext)
         {
             OpenGLContextBase context = PlatformHelper.CreateOpenGLContext(FramebufferFormat.Default, 3, 3, OpenGLContextFlags.Compat, true, sharedContext);


### PR DESCRIPTION
This makes IOpenGLContext.HasContext not static and be implementable.

By doing this, we can support more than WGL and WGL.

This also allows the SDL2 headless version to run under Wayland.