### PR TITLE
Set PointSize in shader on OpenGL

### DIFF
--- a/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -80,9 +80,10 @@ namespace Ryujinx.Graphics.Shader.Translation
                 return;
             }
 
-            if (TranslatorContext.Definitions.Stage == ShaderStage.Vertex && TranslatorContext.Options.TargetApi == TargetApi.Vulkan)
+            // Vulkan requires the point size to be always written on the shader if the primitive topology is points.
+            // OpenGL requires the point size to be always written on the shader if PROGRAM_POINT_SIZE is set.
+            if (TranslatorContext.Definitions.Stage == ShaderStage.Vertex)
             {
-                // Vulkan requires the point size to be always written on the shader if the primitive topology is points.
                 this.Store(StorageKind.Output, IoVariable.PointSize, null, ConstF(TranslatorContext.Definitions.PointSize));
             }
 


### PR DESCRIPTION
Previously we were only doing it for Vulkan, but it turns out that not setting it when PROGRAM_POINT_SIZE is set is considered UB on OpenGL Core.