### PR TITLE
Force CPU copy for non-identity DMA remap

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -277,6 +277,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (ulong)srcBaseOffset, srcSize, true);
 
+                // If remapping is disabled, we always copy the components directly, in order.
+                // If it's enabled, but the mapping is just XYZW, we also copy them in order.
+                bool isIdentityRemap = !remap ||
+                    (_state.State.SetRemapComponentsDstX == SetRemapComponentsDst.SrcX &&
+                    (dstComponents < 2 || _state.State.SetRemapComponentsDstY == SetRemapComponentsDst.SrcY) &&
+                    (dstComponents < 3 || _state.State.SetRemapComponentsDstZ == SetRemapComponentsDst.SrcZ) &&
+                    (dstComponents < 4 || _state.State.SetRemapComponentsDstW == SetRemapComponentsDst.SrcW));
+
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
 
@@ -284,7 +292,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 // but only if we are doing a complete copy,
                 // and not for block linear to linear copies, since those are typically accessed from the CPU.
 
-                if (completeSource && completeDest && !(dstLinear && !srcLinear))
+                if (completeSource && completeDest && !(dstLinear && !srcLinear) && isIdentityRemap)
                 {
                     var target = memoryManager.Physical.TextureCache.FindTexture(
                         memoryManager,
@@ -352,14 +360,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 TextureParams srcParams = new(srcRegionX, srcRegionY, srcBaseOffset, srcBpp, srcLinear, srcCalculator);
                 TextureParams dstParams = new(dstRegionX, dstRegionY, dstBaseOffset, dstBpp, dstLinear, dstCalculator);
-
-                // If remapping is enabled, we always copy the components directly, in order.
-                // If it's enabled, but the mapping is just XYZW, we also copy them in order.
-                bool isIdentityRemap = !remap ||
-                    (_state.State.SetRemapComponentsDstX == SetRemapComponentsDst.SrcX &&
-                    (dstComponents < 2 || _state.State.SetRemapComponentsDstY == SetRemapComponentsDst.SrcY) &&
-                    (dstComponents < 3 || _state.State.SetRemapComponentsDstZ == SetRemapComponentsDst.SrcZ) &&
-                    (dstComponents < 4 || _state.State.SetRemapComponentsDstW == SetRemapComponentsDst.SrcW));
 
                 if (isIdentityRemap)
                 {


### PR DESCRIPTION
We can't use the direct texture upload optimisation if component remapping is enabled, and not identity (RGBA -> RGBA), because texture upload alone can't change the component order of the texture. To fix this, disable direct texture upload in this case, and do a software CPU side copy, which can perform the remapping.

Should fix some bugs with inverted RGBA components on the game 30XX (tested by Muffin, I don't have this game).