### PR TITLE
Fix mip offset/size for full 3D texture upload on Vulkan

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -839,7 +839,9 @@ namespace Ryujinx.Graphics.Vulkan
 
             for (int level = 0; level < levels; level++)
             {
-                int mipSize = GetBufferDataLength(Info.GetMipSize2D(dstLevel + level) * dstLayers);
+                int mipSize = GetBufferDataLength(is3D && !singleSlice
+                    ? Info.GetMipSize(dstLevel + level)
+                    : Info.GetMipSize2D(dstLevel + level) * dstLayers);
 
                 int endOffset = offset + mipSize;
 


### PR DESCRIPTION
Currently we only support setting/getting a single slice of a 3D texture, or the whole texture (controlled by the `singleSlice` parameter). Since #4401, this was no longer taken into account, and it would effectively calculate the mip size as if the texture only had one slice (because `dstLayers` will be always 1 for 3D textures). This causes problem for full texture uploads if the 3D texture depth is > 1, it will calculate the wrong size which causes all mip levels other than the base level to be copied from the wrong input offset.

This change fixes the issue by using the full texture size is we are doing a 3D copy and `singleSlice` is false, rather than the size of a single slice. Similar logic is already used to calculate texture depth:
```cs
int depth = is3D && !singleSlice ? Math.Max(1, Info.Depth >> dstLevel) : 1;
```

Should fix #5170 (would be nice to get confirmation).