### PR TITLE
Load custom SDL mappings from application data folder

### DIFF
--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using System;
 using System.Collections.Concurrent;
@@ -93,7 +94,7 @@ namespace Ryujinx.SDL2.Common
 
                 SDL_EventState(SDL_EventType.SDL_CONTROLLERSENSORUPDATE, SDL_DISABLE);
 
-                string gamepadDbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SDL_GameControllerDB.txt");
+                string gamepadDbPath = Path.Combine(AppDataManager.BaseDirPath, "SDL_GameControllerDB.txt");
 
                 if (File.Exists(gamepadDbPath))
                 {


### PR DESCRIPTION
The SDL driver was loading custom mappings from the directory alongside the application binary. This was improper and would lead to code signature issues on macOS and other possible issues for other platforms. Not to mention being wiped along with every Ryujinx update.

This PR changes the driver to look inside `AppDataManager`'s `BaseDirPath` instead, which is already initialized to point toward the correct configuration directory for the instance of Ryujinx being run.

Address some comments on https://github.com/Ryujinx/Ryujinx/issues/4053 and possibly others.