### PR TITLE
Avalonia: Fix gamescope once and for all

### DIFF
--- a/src/Ryujinx.Ava/Program.cs
+++ b/src/Ryujinx.Ava/Program.cs
@@ -59,6 +59,7 @@ namespace Ryujinx.Ava
                 {
                     EnableMultiTouch = true,
                     EnableIme = true,
+                    EnableInputFocusProxy = true,
                     RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Software },
                 })
                 .With(new Win32PlatformOptions


### PR DESCRIPTION
Enable input focus proxy, makes WM_TAKE_FOCUS capability to be exposed.

This fix menu on gamescope, for real this time....