### PR TITLE
Handle exceptions when checking user data directory for symlink

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -233,8 +233,15 @@ namespace Ryujinx.Common.Configuration
         // Should be removed, when the existence of the old directory isn't checked anymore.
         private static bool IsPathSymlink(string path)
         {
-            FileAttributes attributes = File.GetAttributes(path);
-            return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            try
+            {
+                FileAttributes attributes = File.GetAttributes(path);
+                return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         [SupportedOSPlatform("macos")]


### PR DESCRIPTION
Version 1191 (#6241) began checking if the users data directory is a symlink on all operating systems, which resulted in an uncaught exception if the user data directory did not exist. This PR surrounds the symlink checking function in a try catch.

Resolves #6303.