### PR TITLE
Fix PermissionLocked check on UnmapProcessCodeMemory

### DIFF
--- a/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
@@ -673,9 +673,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
                     MemoryState.UnmapProcessCodeMemoryAllowed,
                     KMemoryPermission.None,
                     KMemoryPermission.None,
-                    MemoryAttribute.Mask,
+                    MemoryAttribute.Mask & ~MemoryAttribute.PermissionLocked,
                     MemoryAttribute.None,
-                    MemoryAttribute.IpcAndDeviceMapped | MemoryAttribute.PermissionLocked,
+                    MemoryAttribute.IpcAndDeviceMapped,
                     out MemoryState state,
                     out _,
                     out _);


### PR DESCRIPTION
The check was wrong before, which caused `UnloadRo` on the RO service to return an error, since unmapping the memory would fail, which in turn causes the games using this service and targeting firmware 17.0.0 or newer to crash.
Allows the other games to work on Tomb Raider I-III Remastered Starring Lara Croft (still requires ignore missing service).
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/19f272a8-0621-4a08-ab17-b2a4d1212b8a)
Depends on #6313 (just for testing purposes).