### PR TITLE
Updaters: Fix ARM Linux Updater

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -333,8 +333,6 @@
   "DialogUpdaterAddingFilesMessage": "Adding New Update...",
   "DialogUpdaterCompleteMessage": "Update Complete!",
   "DialogUpdaterRestartMessage": "Do you want to restart Ryujinx now?",
-  "DialogUpdaterArchNotSupportedMessage": "You are not running a supported system architecture!",
-  "DialogUpdaterArchNotSupportedSubMessage": "(Only x64 systems are supported!)",
   "DialogUpdaterNoInternetMessage": "You are not connected to the Internet!",
   "DialogUpdaterNoInternetSubMessage": "Please verify that you have a working Internet connection!",
   "DialogUpdaterDirtyBuildMessage": "You Cannot update a Dirty build of Ryujinx!",

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -68,7 +68,8 @@ namespace Ryujinx.Modules
             }
             else if (OperatingSystem.IsLinux())
             {
-                _platformExt = "linux_x64.tar.gz";
+                var arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+                _platformExt = $"linux_{arch}.tar.gz";
             }
 
             Version newVersion;

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -637,20 +637,6 @@ namespace Ryujinx.Modules
         public static bool CanUpdate(bool showWarnings)
         {
 #if !DISABLE_UPDATER
-            if (RuntimeInformation.OSArchitecture != Architecture.X64 && !OperatingSystem.IsMacOS())
-            {
-                if (showWarnings)
-                {
-                    Dispatcher.UIThread.InvokeAsync(() =>
-                        ContentDialogHelper.CreateWarningDialog(
-                            LocaleManager.Instance[LocaleKeys.DialogUpdaterArchNotSupportedMessage],
-                            LocaleManager.Instance[LocaleKeys.DialogUpdaterArchNotSupportedSubMessage])
-                    );
-                }
-
-                return false;
-            }
-
             if (!NetworkInterface.GetIsNetworkAvailable())
             {
                 if (showWarnings)

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -78,7 +78,8 @@ namespace Ryujinx.Modules
             }
             else if (OperatingSystem.IsLinux())
             {
-                _platformExt = "linux_x64.tar.gz";
+                var arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+                _platformExt = $"linux_{arch}.tar.gz";
                 artifactIndex = 0;
             }
 

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -512,16 +512,6 @@ namespace Ryujinx.Modules
         public static bool CanUpdate(bool showWarnings)
         {
 #if !DISABLE_UPDATER
-            if (RuntimeInformation.OSArchitecture != Architecture.X64)
-            {
-                if (showWarnings)
-                {
-                    GtkDialog.CreateWarningDialog("You are not running a supported system architecture!", "(Only x64 systems are supported!)");
-                }
-
-                return false;
-            }
-
             if (!NetworkInterface.GetIsNetworkAvailable())
             {
                 if (showWarnings)


### PR DESCRIPTION
Removes x86 Architecture checks from Ava and GTK updaters. Since the release on Linux ARM builds, this check is now causing problems.

Also adds a check to select the correct archive depending on architecture.