### PR TITLE
Remove Vulkan SubgroupSizeControl enablement code

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -486,20 +486,6 @@ namespace Ryujinx.Graphics.Vulkan
                 pExtendedFeatures = &featuresFragmentShaderInterlock;
             }
 
-            PhysicalDeviceSubgroupSizeControlFeaturesEXT featuresSubgroupSizeControl;
-
-            if (physicalDevice.IsDeviceExtensionPresent("VK_EXT_subgroup_size_control"))
-            {
-                featuresSubgroupSizeControl = new PhysicalDeviceSubgroupSizeControlFeaturesEXT
-                {
-                    SType = StructureType.PhysicalDeviceSubgroupSizeControlFeaturesExt,
-                    PNext = pExtendedFeatures,
-                    SubgroupSizeControl = true,
-                };
-
-                pExtendedFeatures = &featuresSubgroupSizeControl;
-            }
-
             PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColor;
 
             if (physicalDevice.IsDeviceExtensionPresent("VK_EXT_custom_border_color") &&


### PR DESCRIPTION
There's no point in enabling that as we don't use the subgroup size extension anymore, so this is just a leftover.
This actually causes problem for Dozen since it apparently does expose the extension, but does not actually support it, so it would  fail to create the device if we enable it. Thanks to @jduncanator for finding the issue.