### PR TITLE
Vulkan: Fix barrier batching past limit

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
@@ -95,6 +95,7 @@ namespace Ryujinx.Graphics.Vulkan
                     List<BarrierWithStageFlags<T>> list) where T : unmanaged
                 {
                     int firstMatch = -1;
+                    int end = list.Count;
 
                     for (int i = 0; i < list.Count; i++)
                     {
@@ -111,6 +112,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                             if (count >= target.Length)
                             {
+                                end = i + 1;
                                 break;
                             }
                         }
@@ -128,6 +130,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                                 if (count >= target.Length)
                                 {
+                                    end = i + 1;
                                     break;
                                 }
                             }
@@ -146,13 +149,13 @@ namespace Ryujinx.Graphics.Vulkan
                         }
                     }
 
-                    if (firstMatch == 0)
+                    if (firstMatch == 0 && end == list.Count)
                     {
                         list.Clear();
                     }
                     else if (firstMatch != -1)
                     {
-                        int deleteCount = list.Count - firstMatch;
+                        int deleteCount = end - firstMatch;
 
                         list.RemoveRange(firstMatch, deleteCount);
                     }


### PR DESCRIPTION
If more than 16 barriers were queued at one time, the _queuedBarrierCount would no longer match the number of remaining barriers, because when breaking out of the loop consuming them it deleted all queued barriers, not just the 16 that were consumed.

Should fix freezes that started occurring with #6240. Fixes issue #6338.