### PR TITLE
Vulkan: Disable push descriptors on older NVIDIA GPUs

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -299,13 +299,6 @@ namespace Ryujinx.Graphics.Vulkan
                 // When the pipeline layout changes, push descriptor bindings are invalidated.
 
                 AdvancePdSequence();
-
-                if (_gd.IsNvidiaPreTuring && !program.UsePushDescriptors && _program?.UsePushDescriptors == true && isBound)
-                {
-                    // On older nvidia GPUs, we need to clear out the active push descriptor bindings when switching
-                    // to normal descriptors. Keeping them bound can prevent buffers from binding properly in future.
-                    ClearAndBindUniformBufferPd(cbs);
-                }
             }
 
             _program = program;
@@ -796,35 +789,6 @@ namespace Ryujinx.Graphics.Vulkan
 
                         writer.Push(MemoryMarshal.CreateReadOnlySpan(ref _uniformBuffers[index], 1));
                     }
-                }
-            }
-
-            if (updatedBindings > 0)
-            {
-                DescriptorSetTemplate template = _program.GetPushDescriptorTemplate(updatedBindings);
-                _templateUpdater.CommitPushDescriptor(_gd, cbs, template, _program.PipelineLayout);
-            }
-        }
-
-        private void ClearAndBindUniformBufferPd(CommandBufferScoped cbs)
-        {
-            var bindingSegments = _program.BindingSegments[PipelineBase.UniformSetIndex];
-
-            long updatedBindings = 0;
-            DescriptorSetTemplateWriter writer = _templateUpdater.Begin(32 * Unsafe.SizeOf<DescriptorBufferInfo>());
-
-            foreach (ResourceBindingSegment segment in bindingSegments)
-            {
-                int binding = segment.Binding;
-                int count = segment.Count;
-
-                for (int i = 0; i < count; i++)
-                {
-                    int index = binding + i;
-                    updatedBindings |= 1L << index;
-
-                    var bufferInfo = new DescriptorBufferInfo();
-                    writer.Push(MemoryMarshal.CreateReadOnlySpan(ref bufferInfo, 1));
                 }
             }
 

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -111,6 +111,7 @@ namespace Ryujinx.Graphics.Vulkan
             bool usePushDescriptors = !isMinimal &&
                 VulkanConfiguration.UsePushDescriptors &&
                 _gd.Capabilities.SupportsPushDescriptors &&
+                !_gd.IsNvidiaPreTuring &&
                 !IsCompute &&
                 CanUsePushDescriptors(gd, resourceLayout, IsCompute);
 


### PR DESCRIPTION
Disables push descriptors on older NVIDIA GPUs (10xx and below), since it is clearly broken beyond comprehension. The existing workaround wasn't good enough and a more thorough one will probably cost more performance than the feature gains. The workaround has been removed.

Fixes #6331.