### PR TITLE
OpenGL: Mask out all color outputs with no fragment shader

### DIFF
--- a/src/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1117,7 +1117,7 @@ namespace Ryujinx.Graphics.OpenGL
                 prg.Bind();
             }
 
-            if (prg.HasFragmentShader && _fragmentOutputMap != (uint)prg.FragmentOutputMap)
+            if (_fragmentOutputMap != (uint)prg.FragmentOutputMap)
             {
                 _fragmentOutputMap = (uint)prg.FragmentOutputMap;
 

--- a/src/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Program.cs
@@ -71,7 +71,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.LinkProgram(Handle);
 
-            FragmentOutputMap = fragmentOutputMap;
+            FragmentOutputMap = HasFragmentShader ? fragmentOutputMap : 0;
         }
 
         public Program(ReadOnlySpan<byte> code, bool hasFragmentShader, int fragmentOutputMap)
@@ -92,7 +92,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             HasFragmentShader = hasFragmentShader;
-            FragmentOutputMap = fragmentOutputMap;
+            FragmentOutputMap = HasFragmentShader ? fragmentOutputMap : 0;
         }
 
         public void Bind()

--- a/src/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Program.cs
@@ -30,7 +30,6 @@ namespace Ryujinx.Graphics.OpenGL
         private ProgramLinkStatus _status = ProgramLinkStatus.Incomplete;
         private int[] _shaderHandles;
 
-        public bool HasFragmentShader;
         public int FragmentOutputMap { get; }
 
         public Program(ShaderSource[] shaders, int fragmentOutputMap)
@@ -40,6 +39,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ProgramParameter(Handle, ProgramParameterName.ProgramBinaryRetrievableHint, 1);
 
             _shaderHandles = new int[shaders.Length];
+            bool hasFragmentShader = false;
 
             for (int index = 0; index < shaders.Length; index++)
             {
@@ -47,7 +47,7 @@ namespace Ryujinx.Graphics.OpenGL
 
                 if (shader.Stage == ShaderStage.Fragment)
                 {
-                    HasFragmentShader = true;
+                    hasFragmentShader = true;
                 }
 
                 int shaderHandle = GL.CreateShader(shader.Stage.Convert());
@@ -71,7 +71,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.LinkProgram(Handle);
 
-            FragmentOutputMap = HasFragmentShader ? fragmentOutputMap : 0;
+            FragmentOutputMap = hasFragmentShader ? fragmentOutputMap : 0;
         }
 
         public Program(ReadOnlySpan<byte> code, bool hasFragmentShader, int fragmentOutputMap)
@@ -91,8 +91,7 @@ namespace Ryujinx.Graphics.OpenGL
                 }
             }
 
-            HasFragmentShader = hasFragmentShader;
-            FragmentOutputMap = HasFragmentShader ? fragmentOutputMap : 0;
+            FragmentOutputMap = hasFragmentShader ? fragmentOutputMap : 0;
         }
 
         public void Bind()


### PR DESCRIPTION
This appears to match Vulkan's behaviour, which is needed for stencil shadows in Penny's Big Breakaway. It's far from the only issue, you can try the Full Bindless PR if you want to see it in a more intact state.

It's possible there's more to this, there's a constant color rendering register which could enable the color output without a fragment shader, but I don't think it will be used for anything nowadays, and it doesn't seem to support different values for different attachments. All the cases I've seen just want depth only draws, anyways.

https://github.com/NVIDIA/open-gpu-doc/blob/master/classes/3d/clb197.h#L1230