### PR TITLE
Ensure service init runs after Horizon constructor

### DIFF
--- a/src/Ryujinx.HLE/HOS/Horizon.cs
+++ b/src/Ryujinx.HLE/HOS/Horizon.cs
@@ -250,7 +250,6 @@ namespace Ryujinx.HLE.HOS
             SurfaceFlinger = new SurfaceFlinger(device);
 
             InitializeAudioRenderer(TickSource);
-            InitializeServices();
         }
 
         private void InitializeAudioRenderer(ITickSource tickSource)
@@ -301,7 +300,7 @@ namespace Ryujinx.HLE.HOS
             AudioManager.Start();
         }
 
-        private void InitializeServices()
+        public void InitializeServices()
         {
             SmRegistry = new SmRegistry();
             SmServer = new ServerBase(KernelContext, "SmServer", () => new IUserInterface(KernelContext, SmRegistry));

--- a/src/Ryujinx.HLE/Switch.cs
+++ b/src/Ryujinx.HLE/Switch.cs
@@ -55,6 +55,7 @@ namespace Ryujinx.HLE
             Processes         = new ProcessLoader(this);
             TamperMachine     = new TamperMachine();
 
+            System.InitializeServices();
             System.State.SetLanguage(Configuration.SystemLanguage);
             System.State.SetRegion(Configuration.Region);
 


### PR DESCRIPTION
SM `RegisterService` method accesses the `System` instance on `context.Device.System.KernelContext`. However, because services are initialized from the `Horizon` constructor, it is possible that the `System` field has no been assigned yet because the constructor has not finished running. In those cases, if a service tries to register itself before the constructor finishes running, it would cause a NRE. This change fixes the issue by only initializing services after `Horizon` constructor is done as `System` has been assigned.

This issue was manifesting itself as a rare crash when launching games, usually for he 2nd time or later.