### PR TITLE
Vulkan: Properly reset barrier batch when splitting due to mismatching flags

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
@@ -144,6 +144,7 @@ namespace Ryujinx.Graphics.Vulkan
                                     i -= deleteCount;
 
                                     firstMatch = -1;
+                                    end = list.Count;
                                 }
                             }
                         }


### PR DESCRIPTION
Forgot to set the end variable here. Should stop it from crashing when this path is taken.