### PR TITLE
IPC code gen improvements

### DIFF
--- a/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
+++ b/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
@@ -233,7 +233,7 @@ namespace Ryujinx.Horizon.Generators.Hipc
 
                 if (buffersCount != 0)
                 {
-                    generator.AppendLine($"bool[] {IsBufferMapAliasVariableName} = new bool[{method.ParameterList.Parameters.Count}];");
+                    generator.AppendLine($"Span<bool> {IsBufferMapAliasVariableName} = stackalloc bool[{method.ParameterList.Parameters.Count}];");
                     generator.AppendLine();
 
                     generator.AppendLine($"{ResultVariableName} = processor.ProcessBuffers(ref context, {IsBufferMapAliasVariableName}, runtimeMetadata);");

--- a/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
+++ b/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
@@ -74,6 +74,7 @@ namespace Ryujinx.Horizon.Generators.Hipc
                 generator.AppendLine("using Ryujinx.Horizon.Sdk.Sf.Cmif;");
                 generator.AppendLine("using Ryujinx.Horizon.Sdk.Sf.Hipc;");
                 generator.AppendLine("using System;");
+                generator.AppendLine("using System.Collections.Frozen;");
                 generator.AppendLine("using System.Collections.Generic;");
                 generator.AppendLine("using System.Runtime.CompilerServices;");
                 generator.AppendLine("using System.Runtime.InteropServices;");
@@ -171,7 +172,7 @@ namespace Ryujinx.Horizon.Generators.Hipc
                 }
             }
 
-            generator.LeaveScope(";");
+            generator.LeaveScope(".ToFrozenDictionary();");
             generator.LeaveScope();
         }
 

--- a/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
+++ b/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.Horizon.Generators.Hipc
 
             foreach (var method in commandInterface.CommandImplementations)
             {
-                foreach (var commandId in GetAttributeAguments(compilation, method, TypeCommandAttribute, 0))
+                foreach (var commandId in GetAttributeArguments(compilation, method, TypeCommandAttribute, 0))
                 {
                     string[] args = new string[method.ParameterList.Parameters.Count];
 
@@ -140,8 +140,8 @@ namespace Ryujinx.Horizon.Generators.Hipc
 
                             if (argType == CommandArgType.Buffer)
                             {
-                                string bufferFlags = GetFirstAttributeAgument(compilation, parameter, TypeBufferAttribute, 0);
-                                string bufferFixedSize = GetFirstAttributeAgument(compilation, parameter, TypeBufferAttribute, 1);
+                                string bufferFlags = GetFirstAttributeArgument(compilation, parameter, TypeBufferAttribute, 0);
+                                string bufferFixedSize = GetFirstAttributeArgument(compilation, parameter, TypeBufferAttribute, 1);
 
                                 if (bufferFixedSize != null)
                                 {
@@ -175,7 +175,7 @@ namespace Ryujinx.Horizon.Generators.Hipc
             generator.LeaveScope();
         }
 
-        private static IEnumerable<string> GetAttributeAguments(Compilation compilation, SyntaxNode syntaxNode, string attributeName, int argIndex)
+        private static IEnumerable<string> GetAttributeArguments(Compilation compilation, SyntaxNode syntaxNode, string attributeName, int argIndex)
         {
             ISymbol symbol = compilation.GetSemanticModel(syntaxNode.SyntaxTree).GetDeclaredSymbol(syntaxNode);
 
@@ -188,9 +188,9 @@ namespace Ryujinx.Horizon.Generators.Hipc
             }
         }
 
-        private static string GetFirstAttributeAgument(Compilation compilation, SyntaxNode syntaxNode, string attributeName, int argIndex)
+        private static string GetFirstAttributeArgument(Compilation compilation, SyntaxNode syntaxNode, string attributeName, int argIndex)
         {
-            return GetAttributeAguments(compilation, syntaxNode, attributeName, argIndex).FirstOrDefault();
+            return GetAttributeArguments(compilation, syntaxNode, attributeName, argIndex).FirstOrDefault();
         }
 
         private static void GenerateMethod(CodeGenerator generator, Compilation compilation, MethodDeclarationSyntax method)

--- a/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
+++ b/src/Ryujinx.Horizon.Generators/Hipc/HipcGenerator.cs
@@ -719,7 +719,9 @@ namespace Ryujinx.Horizon.Generators.Hipc
 
         private static string GenerateSpanCast(string targetType, string input)
         {
-            return $"MemoryMarshal.Cast<byte, {targetType}>({input})";
+            return targetType == "byte"
+                ? input
+                : $"MemoryMarshal.Cast<byte, {targetType}>({input})";
         }
 
         private static bool HasAttribute(Compilation compilation, ParameterSyntax parameterSyntax, string fullAttributeName)

--- a/src/Ryujinx.Horizon/Sdk/Sf/HipcCommandProcessor.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/HipcCommandProcessor.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Horizon.Sdk.Sf
             return _bufferRanges[argIndex];
         }
 
-        public Result ProcessBuffers(ref ServiceDispatchContext context, bool[] isBufferMapAlias, ServerMessageRuntimeMetadata runtimeMetadata)
+        public Result ProcessBuffers(ref ServiceDispatchContext context, scoped Span<bool> isBufferMapAlias, ServerMessageRuntimeMetadata runtimeMetadata)
         {
             bool mapAliasBuffersValid = true;
 
@@ -246,7 +246,7 @@ namespace Ryujinx.Horizon.Sdk.Sf
             return mode == HipcBufferMode.Normal;
         }
 
-        public void SetOutBuffers(HipcMessageData response, bool[] isBufferMapAlias)
+        public void SetOutBuffers(HipcMessageData response, ReadOnlySpan<bool> isBufferMapAlias)
         {
             int recvPointerIndex = 0;
 


### PR DESCRIPTION
Changes to the `HipcGenerator` source generator that improve the generated code.

Changes to generated code:
- avoid making do-nothing calls to `MemoryMarshal.Cast<byte, byte>()`
- generated methods with a `bool[] isBufferMapAlias` now create it as a `Span<byte>` via `stackalloc` instead of as  heap array.
- `IReadOnlyDictionary<int, CommandHandler> GetCommandHandlers()` no longer returns a `Dictionary`, instead it returns a `FrozenDictionary` which is optimized for lookup performance (and is actually read-only).


Changes to the generator:
- fix a couple private method name typos