### PR TITLE
Change packed aliasing formats to UInt

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
@@ -674,9 +674,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     1 => new FormatInfo(Format.R8Unorm, 1, 1, 1, 1),
                     2 => new FormatInfo(Format.R16Unorm, 1, 1, 2, 1),
-                    4 => new FormatInfo(Format.R32Float, 1, 1, 4, 1),
-                    8 => new FormatInfo(Format.R32G32Float, 1, 1, 8, 2),
-                    16 => new FormatInfo(Format.R32G32B32A32Float, 1, 1, 16, 4),
+                    4 => new FormatInfo(Format.R32Uint, 1, 1, 4, 1),
+                    8 => new FormatInfo(Format.R32G32Uint, 1, 1, 8, 2),
+                    16 => new FormatInfo(Format.R32G32B32A32Uint, 1, 1, 16, 4),
                     _ => format,
                 };
             }


### PR DESCRIPTION
There is some precision error on AMD when using float formats for this, which causes images to be glitched when they are accessed on the shader. Using UInt formats fixes the issue. Other vendors don't seem to have a issue with either float or UInt formats.

Fixes a few OpenGL games that depend on different size aliasing, such as Wet Steps, CEIBA and Yokai Watch 1.

Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/80364e23-b3f1-4674-8b34-b27bba6b501a)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/ab357a97-4b2c-4fa7-bc0e-4583b500dbde)
