### PR TITLE
Refactor memory managers to a common base class, consolidate Read() method logic

### DIFF
--- a/src/Ryujinx.Cpu/AppleHv/HvMemoryManager.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvMemoryManager.cs
@@ -16,12 +16,8 @@ namespace Ryujinx.Cpu.AppleHv
     /// Represents a CPU memory manager which maps guest virtual memory directly onto the Hypervisor page table.
     /// </summary>
     [SupportedOSPlatform("macos")]
-    public class HvMemoryManager : MemoryManagerBase, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
+    public class HvMemoryManager : VirtualMemoryManagerRefCountedBase<ulong, ulong>, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
     {
-        public const int PageBits = 12;
-        public const int PageSize = 1 << PageBits;
-        public const int PageMask = PageSize - 1;
-
         public const int PageToPteShift = 5; // 32 pages (2 bits each) in one ulong page table entry.
         public const ulong BlockMappedMask = 0x5555555555555555; // First bit of each table entry set.
 
@@ -38,8 +34,6 @@ namespace Ryujinx.Cpu.AppleHv
         }
 
         private readonly InvalidAccessHandler _invalidAccessHandler;
-
-        private readonly ulong _addressSpaceSize;
 
         private readonly HvAddressSpace _addressSpace;
 
@@ -73,7 +67,7 @@ namespace Ryujinx.Cpu.AppleHv
             _backingMemory = backingMemory;
             _pageTable = new PageTable<ulong>();
             _invalidAccessHandler = invalidAccessHandler;
-            _addressSpaceSize = addressSpaceSize;
+            AddressSpaceSize = addressSpaceSize;
 
             ulong asSize = PageSize;
             int asBits = PageBits;
@@ -90,42 +84,6 @@ namespace Ryujinx.Cpu.AppleHv
 
             _pageBitmap = new ulong[1 << (AddressSpaceBits - (PageBits + PageToPteShift))];
             Tracking = new MemoryTracking(this, PageSize, invalidAccessHandler);
-        }
-
-        /// <summary>
-        /// Checks if the virtual address is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address</param>
-        /// <returns>True if the virtual address is part of the addressable space</returns>
-        private bool ValidateAddress(ulong va)
-        {
-            return va < _addressSpaceSize;
-        }
-
-        /// <summary>
-        /// Checks if the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <returns>True if the combination of virtual address and size is part of the addressable space</returns>
-        private bool ValidateAddressAndSize(ulong va, ulong size)
-        {
-            ulong endVa = va + size;
-            return endVa >= va && endVa >= size && endVa <= _addressSpaceSize;
-        }
-
-        /// <summary>
-        /// Ensures the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <exception cref="InvalidMemoryRegionException">Throw when the memory region specified outside the addressable space</exception>
-        private void AssertValidAddressAndSize(ulong va, ulong size)
-        {
-            if (!ValidateAddressAndSize(va, size))
-            {
-                throw new InvalidMemoryRegionException($"va=0x{va:X16}, size=0x{size:X16}");
-            }
         }
 
         /// <inheritdoc/>
@@ -209,9 +167,19 @@ namespace Ryujinx.Cpu.AppleHv
         }
 
         /// <inheritdoc/>
-        public void Read(ulong va, Span<byte> data)
+        public override void Read(ulong va, Span<byte> data)
         {
-            ReadImpl(va, data);
+            try
+            {
+                base.Read(va, data);
+            }
+            catch (InvalidMemoryRegionException)
+            {
+                if (_invalidAccessHandler == null || !_invalidAccessHandler(va))
+                {
+                    throw;
+                }
+            }
         }
 
         /// <inheritdoc/>
@@ -340,7 +308,7 @@ namespace Ryujinx.Cpu.AppleHv
             {
                 Span<byte> data = new byte[size];
 
-                ReadImpl(va, data);
+                base.Read(va, data);
 
                 return data;
             }
@@ -367,7 +335,7 @@ namespace Ryujinx.Cpu.AppleHv
             {
                 Memory<byte> memory = new byte[size];
 
-                ReadImpl(va, memory.Span);
+                base.Read(va, memory.Span);
 
                 return new WritableRegion(this, va, memory);
             }
@@ -574,48 +542,6 @@ namespace Ryujinx.Cpu.AppleHv
             regions.Add(new MemoryRange(regionStart, regionSize));
 
             return regions;
-        }
-
-        private void ReadImpl(ulong va, Span<byte> data)
-        {
-            if (data.Length == 0)
-            {
-                return;
-            }
-
-            try
-            {
-                AssertValidAddressAndSize(va, (ulong)data.Length);
-
-                int offset = 0, size;
-
-                if ((va & PageMask) != 0)
-                {
-                    ulong pa = GetPhysicalAddressChecked(va);
-
-                    size = Math.Min(data.Length, PageSize - (int)(va & PageMask));
-
-                    _backingMemory.GetSpan(pa, size).CopyTo(data[..size]);
-
-                    offset += size;
-                }
-
-                for (; offset < data.Length; offset += size)
-                {
-                    ulong pa = GetPhysicalAddressChecked(va + (ulong)offset);
-
-                    size = Math.Min(data.Length - offset, PageSize);
-
-                    _backingMemory.GetSpan(pa, size).CopyTo(data.Slice(offset, size));
-                }
-            }
-            catch (InvalidMemoryRegionException)
-            {
-                if (_invalidAccessHandler == null || !_invalidAccessHandler(va))
-                {
-                    throw;
-                }
-            }
         }
 
         /// <inheritdoc/>
@@ -936,6 +862,12 @@ namespace Ryujinx.Cpu.AppleHv
             _addressSpace.Dispose();
         }
 
-        private static void ThrowInvalidMemoryRegionException(string message) => throw new InvalidMemoryRegionException(message);
+        protected override ulong AddressSpaceSize { get; }
+
+        protected override Span<byte> GetPhysicalAddressSpan(ulong pa, int size)
+            => _backingMemory.GetSpan(pa, size);
+
+        protected override ulong TranslateVirtualAddressForRead(ulong va)
+            => GetPhysicalAddressChecked(va);
     }
 }

--- a/src/Ryujinx.Cpu/AppleHv/HvMemoryManager.cs
+++ b/src/Ryujinx.Cpu/AppleHv/HvMemoryManager.cs
@@ -56,6 +56,8 @@ namespace Ryujinx.Cpu.AppleHv
 
         public event Action<ulong, ulong> UnmapEvent;
 
+        protected override ulong AddressSpaceSize { get; }
+
         /// <summary>
         /// Creates a new instance of the Hypervisor memory manager.
         /// </summary>
@@ -861,8 +863,6 @@ namespace Ryujinx.Cpu.AppleHv
         {
             _addressSpace.Dispose();
         }
-
-        protected override ulong AddressSpaceSize { get; }
 
         protected override Span<byte> GetPhysicalAddressSpan(ulong pa, int size)
             => _backingMemory.GetSpan(pa, size);

--- a/src/Ryujinx.Cpu/Jit/MemoryManager.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManager.cs
@@ -14,12 +14,8 @@ namespace Ryujinx.Cpu.Jit
     /// <summary>
     /// Represents a CPU memory manager.
     /// </summary>
-    public sealed class MemoryManager : MemoryManagerBase, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
+    public sealed class MemoryManager : VirtualMemoryManagerRefCountedBase<ulong, ulong>, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
     {
-        public const int PageBits = 12;
-        public const int PageSize = 1 << PageBits;
-        public const int PageMask = PageSize - 1;
-
         private const int PteSize = 8;
 
         private const int PointerTagBit = 62;
@@ -34,8 +30,6 @@ namespace Ryujinx.Cpu.Jit
         /// Address space width in bits.
         /// </summary>
         public int AddressSpaceBits { get; }
-
-        private readonly ulong _addressSpaceSize;
 
         private readonly MemoryBlock _pageTable;
 
@@ -71,7 +65,7 @@ namespace Ryujinx.Cpu.Jit
             }
 
             AddressSpaceBits = asBits;
-            _addressSpaceSize = asSize;
+            AddressSpaceSize = asSize;
             _pageTable = new MemoryBlock((asSize / PageSize) * PteSize);
 
             Tracking = new MemoryTracking(this, PageSize);
@@ -153,9 +147,19 @@ namespace Ryujinx.Cpu.Jit
         }
 
         /// <inheritdoc/>
-        public void Read(ulong va, Span<byte> data)
+        public override void Read(ulong va, Span<byte> data)
         {
-            ReadImpl(va, data);
+            try
+            {
+                base.Read(va, data);
+            }
+            catch (InvalidMemoryRegionException)
+            {
+                if (_invalidAccessHandler == null || !_invalidAccessHandler(va))
+                {
+                    throw;
+                }
+            }
         }
 
         /// <inheritdoc/>
@@ -290,7 +294,7 @@ namespace Ryujinx.Cpu.Jit
             {
                 Span<byte> data = new byte[size];
 
-                ReadImpl(va, data);
+                base.Read(va, data);
 
                 return data;
             }
@@ -462,48 +466,6 @@ namespace Ryujinx.Cpu.Jit
             return regions;
         }
 
-        private void ReadImpl(ulong va, Span<byte> data)
-        {
-            if (data.Length == 0)
-            {
-                return;
-            }
-
-            try
-            {
-                AssertValidAddressAndSize(va, (ulong)data.Length);
-
-                int offset = 0, size;
-
-                if ((va & PageMask) != 0)
-                {
-                    ulong pa = GetPhysicalAddressInternal(va);
-
-                    size = Math.Min(data.Length, PageSize - (int)(va & PageMask));
-
-                    _backingMemory.GetSpan(pa, size).CopyTo(data[..size]);
-
-                    offset += size;
-                }
-
-                for (; offset < data.Length; offset += size)
-                {
-                    ulong pa = GetPhysicalAddressInternal(va + (ulong)offset);
-
-                    size = Math.Min(data.Length - offset, PageSize);
-
-                    _backingMemory.GetSpan(pa, size).CopyTo(data.Slice(offset, size));
-                }
-            }
-            catch (InvalidMemoryRegionException)
-            {
-                if (_invalidAccessHandler == null || !_invalidAccessHandler(va))
-                {
-                    throw;
-                }
-            }
-        }
-
         /// <inheritdoc/>
         public bool IsRangeMapped(ulong va, ulong size)
         {
@@ -542,37 +504,6 @@ namespace Ryujinx.Cpu.Jit
             }
 
             return _pageTable.Read<ulong>((va / PageSize) * PteSize) != 0;
-        }
-
-        private bool ValidateAddress(ulong va)
-        {
-            return va < _addressSpaceSize;
-        }
-
-        /// <summary>
-        /// Checks if the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <returns>True if the combination of virtual address and size is part of the addressable space</returns>
-        private bool ValidateAddressAndSize(ulong va, ulong size)
-        {
-            ulong endVa = va + size;
-            return endVa >= va && endVa >= size && endVa <= _addressSpaceSize;
-        }
-
-        /// <summary>
-        /// Ensures the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <exception cref="InvalidMemoryRegionException">Throw when the memory region specified outside the addressable space</exception>
-        private void AssertValidAddressAndSize(ulong va, ulong size)
-        {
-            if (!ValidateAddressAndSize(va, size))
-            {
-                throw new InvalidMemoryRegionException($"va=0x{va:X16}, size=0x{size:X16}");
-            }
         }
 
         private ulong GetPhysicalAddressInternal(ulong va)
@@ -691,5 +622,13 @@ namespace Ryujinx.Cpu.Jit
         /// Disposes of resources used by the memory manager.
         /// </summary>
         protected override void Destroy() => _pageTable.Dispose();
+
+        protected override ulong AddressSpaceSize { get; }
+
+        protected override Span<byte> GetPhysicalAddressSpan(ulong pa, int size)
+            => _backingMemory.GetSpan(pa, size);
+
+        protected override ulong TranslateVirtualAddressForRead(ulong va)
+            => GetPhysicalAddressInternal(va);
     }
 }

--- a/src/Ryujinx.Cpu/Jit/MemoryManager.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManager.cs
@@ -44,6 +44,8 @@ namespace Ryujinx.Cpu.Jit
 
         public event Action<ulong, ulong> UnmapEvent;
 
+        protected override ulong AddressSpaceSize { get; }
+
         /// <summary>
         /// Creates a new instance of the memory manager.
         /// </summary>
@@ -622,8 +624,6 @@ namespace Ryujinx.Cpu.Jit
         /// Disposes of resources used by the memory manager.
         /// </summary>
         protected override void Destroy() => _pageTable.Dispose();
-
-        protected override ulong AddressSpaceSize { get; }
 
         protected override Span<byte> GetPhysicalAddressSpan(ulong pa, int size)
             => _backingMemory.GetSpan(pa, size);

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
@@ -13,12 +13,8 @@ namespace Ryujinx.Cpu.Jit
     /// <summary>
     /// Represents a CPU memory manager which maps guest virtual memory directly onto a host virtual region.
     /// </summary>
-    public sealed class MemoryManagerHostMapped : MemoryManagerBase, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
+    public sealed class MemoryManagerHostMapped : VirtualMemoryManagerRefCountedBase<ulong, ulong>, IMemoryManager, IVirtualMemoryManagerTracked, IWritableBlock
     {
-        public const int PageBits = 12;
-        public const int PageSize = 1 << PageBits;
-        public const int PageMask = PageSize - 1;
-
         public const int PageToPteShift = 5; // 32 pages (2 bits each) in one ulong page table entry.
         public const ulong BlockMappedMask = 0x5555555555555555; // First bit of each table entry set.
 
@@ -38,8 +34,6 @@ namespace Ryujinx.Cpu.Jit
         private readonly bool _unsafeMode;
 
         private readonly AddressSpace _addressSpace;
-
-        public ulong AddressSpaceSize { get; }
 
         private readonly PageTable<ulong> _pageTable;
 
@@ -89,42 +83,6 @@ namespace Ryujinx.Cpu.Jit
 
             Tracking = new MemoryTracking(this, (int)MemoryBlock.GetPageSize(), invalidAccessHandler);
             _memoryEh = new MemoryEhMeilleure(_addressSpace.Base, _addressSpace.Mirror, Tracking);
-        }
-
-        /// <summary>
-        /// Checks if the virtual address is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address</param>
-        /// <returns>True if the virtual address is part of the addressable space</returns>
-        private bool ValidateAddress(ulong va)
-        {
-            return va < AddressSpaceSize;
-        }
-
-        /// <summary>
-        /// Checks if the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <returns>True if the combination of virtual address and size is part of the addressable space</returns>
-        private bool ValidateAddressAndSize(ulong va, ulong size)
-        {
-            ulong endVa = va + size;
-            return endVa >= va && endVa >= size && endVa <= AddressSpaceSize;
-        }
-
-        /// <summary>
-        /// Ensures the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <exception cref="InvalidMemoryRegionException">Throw when the memory region specified outside the addressable space</exception>
-        private void AssertValidAddressAndSize(ulong va, ulong size)
-        {
-            if (!ValidateAddressAndSize(va, size))
-            {
-                throw new InvalidMemoryRegionException($"va=0x{va:X16}, size=0x{size:X16}");
-            }
         }
 
         /// <summary>
@@ -235,7 +193,7 @@ namespace Ryujinx.Cpu.Jit
         }
 
         /// <inheritdoc/>
-        public void Read(ulong va, Span<byte> data)
+        public override void Read(ulong va, Span<byte> data)
         {
             try
             {
@@ -816,6 +774,12 @@ namespace Ryujinx.Cpu.Jit
             _memoryEh.Dispose();
         }
 
-        private static void ThrowInvalidMemoryRegionException(string message) => throw new InvalidMemoryRegionException(message);
+        protected override ulong AddressSpaceSize { get; }
+
+        protected override Span<byte> GetPhysicalAddressSpan(ulong pa, int size)
+            => _addressSpace.Mirror.GetSpan(pa, size);
+
+        protected override ulong TranslateVirtualAddressForRead(ulong va)
+            => va;
     }
 }

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
@@ -54,6 +54,8 @@ namespace Ryujinx.Cpu.Jit
 
         public event Action<ulong, ulong> UnmapEvent;
 
+        protected override ulong AddressSpaceSize { get; }
+
         /// <summary>
         /// Creates a new instance of the host mapped memory manager.
         /// </summary>
@@ -773,8 +775,6 @@ namespace Ryujinx.Cpu.Jit
             _addressSpace.Dispose();
             _memoryEh.Dispose();
         }
-
-        protected override ulong AddressSpaceSize { get; }
 
         protected override Span<byte> GetPhysicalAddressSpan(ulong pa, int size)
             => _addressSpace.Mirror.GetSpan(pa, size);

--- a/src/Ryujinx.Cpu/VirtualMemoryManagerRefCountedBase.cs
+++ b/src/Ryujinx.Cpu/VirtualMemoryManagerRefCountedBase.cs
@@ -1,10 +1,13 @@
 using Ryujinx.Memory;
 using System.Diagnostics;
+using System.Numerics;
 using System.Threading;
 
 namespace Ryujinx.Cpu
 {
-    public abstract class MemoryManagerBase : IRefCounted
+    public abstract class VirtualMemoryManagerRefCountedBase<TVirtual, TPhysical> : VirtualMemoryManagerBase<TVirtual, TPhysical>, IRefCounted
+        where TVirtual : IBinaryInteger<TVirtual>
+        where TPhysical : IBinaryInteger<TPhysical>
     {
         private int _referenceCount;
 

--- a/src/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/src/Ryujinx.Memory/AddressSpaceManager.cs
@@ -11,12 +11,8 @@ namespace Ryujinx.Memory
     /// Represents a address space manager.
     /// Supports virtual memory region mapping, address translation and read/write access to mapped regions.
     /// </summary>
-    public sealed class AddressSpaceManager : IVirtualMemoryManager, IWritableBlock
+    public sealed class AddressSpaceManager : VirtualMemoryManagerBase<ulong, nuint>, IVirtualMemoryManager, IWritableBlock
     {
-        public const int PageBits = PageTable<nuint>.PageBits;
-        public const int PageSize = PageTable<nuint>.PageSize;
-        public const int PageMask = PageTable<nuint>.PageMask;
-
         /// <inheritdoc/>
         public bool Supports4KBPages => true;
 
@@ -24,8 +20,6 @@ namespace Ryujinx.Memory
         /// Address space width in bits.
         /// </summary>
         public int AddressSpaceBits { get; }
-
-        private readonly ulong _addressSpaceSize;
 
         private readonly MemoryBlock _backingMemory;
         private readonly PageTable<nuint> _pageTable;
@@ -47,7 +41,7 @@ namespace Ryujinx.Memory
             }
 
             AddressSpaceBits = asBits;
-            _addressSpaceSize = asSize;
+            AddressSpaceSize = asSize;
             _backingMemory = backingMemory;
             _pageTable = new PageTable<nuint>();
         }
@@ -100,12 +94,6 @@ namespace Ryujinx.Memory
         public T Read<T>(ulong va) where T : unmanaged
         {
             return MemoryMarshal.Cast<byte, T>(GetSpan(va, Unsafe.SizeOf<T>()))[0];
-        }
-
-        /// <inheritdoc/>
-        public void Read(ulong va, Span<byte> data)
-        {
-            ReadImpl(va, data);
         }
 
         /// <inheritdoc/>
@@ -174,7 +162,7 @@ namespace Ryujinx.Memory
             {
                 Span<byte> data = new byte[size];
 
-                ReadImpl(va, data);
+                Read(va, data);
 
                 return data;
             }
@@ -346,34 +334,6 @@ namespace Ryujinx.Memory
             return regions;
         }
 
-        private void ReadImpl(ulong va, Span<byte> data)
-        {
-            if (data.Length == 0)
-            {
-                return;
-            }
-
-            AssertValidAddressAndSize(va, (ulong)data.Length);
-
-            int offset = 0, size;
-
-            if ((va & PageMask) != 0)
-            {
-                size = Math.Min(data.Length, PageSize - (int)(va & PageMask));
-
-                GetHostSpanContiguous(va, size).CopyTo(data[..size]);
-
-                offset += size;
-            }
-
-            for (; offset < data.Length; offset += size)
-            {
-                size = Math.Min(data.Length - offset, PageSize);
-
-                GetHostSpanContiguous(va + (ulong)offset, size).CopyTo(data.Slice(offset, size));
-            }
-        }
-
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsMapped(ulong va)
@@ -414,37 +374,6 @@ namespace Ryujinx.Memory
             return true;
         }
 
-        private bool ValidateAddress(ulong va)
-        {
-            return va < _addressSpaceSize;
-        }
-
-        /// <summary>
-        /// Checks if the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <returns>True if the combination of virtual address and size is part of the addressable space</returns>
-        private bool ValidateAddressAndSize(ulong va, ulong size)
-        {
-            ulong endVa = va + size;
-            return endVa >= va && endVa >= size && endVa <= _addressSpaceSize;
-        }
-
-        /// <summary>
-        /// Ensures the combination of virtual address and size is part of the addressable space.
-        /// </summary>
-        /// <param name="va">Virtual address of the range</param>
-        /// <param name="size">Size of the range in bytes</param>
-        /// <exception cref="InvalidMemoryRegionException">Throw when the memory region specified outside the addressable space</exception>
-        private void AssertValidAddressAndSize(ulong va, ulong size)
-        {
-            if (!ValidateAddressAndSize(va, size))
-            {
-                throw new InvalidMemoryRegionException($"va=0x{va:X16}, size=0x{size:X16}");
-            }
-        }
-
         private unsafe Span<byte> GetHostSpanContiguous(ulong va, int size)
         {
             return new Span<byte>((void*)GetHostAddress(va), size);
@@ -471,5 +400,13 @@ namespace Ryujinx.Memory
         {
             // Only the ARM Memory Manager has tracking for now.
         }
+
+        protected override ulong AddressSpaceSize { get; }
+
+        protected override unsafe Span<byte> GetPhysicalAddressSpan(nuint pa, int size)
+            => new((void*)pa, size);
+
+        protected override nuint TranslateVirtualAddressForRead(ulong va)
+            => GetHostAddress(va);
     }
 }

--- a/src/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/src/Ryujinx.Memory/AddressSpaceManager.cs
@@ -24,6 +24,8 @@ namespace Ryujinx.Memory
         private readonly MemoryBlock _backingMemory;
         private readonly PageTable<nuint> _pageTable;
 
+        protected override ulong AddressSpaceSize { get; }
+
         /// <summary>
         /// Creates a new instance of the memory manager.
         /// </summary>
@@ -400,8 +402,6 @@ namespace Ryujinx.Memory
         {
             // Only the ARM Memory Manager has tracking for now.
         }
-
-        protected override ulong AddressSpaceSize { get; }
 
         protected override unsafe Span<byte> GetPhysicalAddressSpan(nuint pa, int size)
             => new((void*)pa, size);

--- a/src/Ryujinx.Memory/VirtualMemoryManagerBase.cs
+++ b/src/Ryujinx.Memory/VirtualMemoryManagerBase.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Numerics;
+
+namespace Ryujinx.Memory
+{
+    public abstract class VirtualMemoryManagerBase<TVirtual, TPhysical>
+        where TVirtual : IBinaryInteger<TVirtual>
+        where TPhysical : IBinaryInteger<TPhysical>
+    {
+        public const int PageBits = 12;
+        public const int PageSize = 1 << PageBits;
+        public const int PageMask = PageSize - 1;
+
+        protected abstract TVirtual AddressSpaceSize { get; }
+
+        public virtual void Read(TVirtual va, Span<byte> data)
+        {
+            if (data.Length == 0)
+            {
+                return;
+            }
+
+            AssertValidAddressAndSize(va, TVirtual.CreateChecked(data.Length));
+
+            int offset = 0, size;
+
+            if ((int.CreateTruncating(va) & PageMask) != 0)
+            {
+                TPhysical pa = TranslateVirtualAddressForRead(va);
+
+                size = Math.Min(data.Length, PageSize - ((int.CreateTruncating(va) & PageMask)));
+
+                GetPhysicalAddressSpan(pa, size).CopyTo(data[..size]);
+
+                offset += size;
+            }
+
+            for (; offset < data.Length; offset += size)
+            {
+                TPhysical pa = TranslateVirtualAddressForRead(va + TVirtual.CreateChecked(offset));
+
+                size = Math.Min(data.Length - offset, PageSize);
+
+                GetPhysicalAddressSpan(pa, size).CopyTo(data.Slice(offset, size));
+            }
+        }
+
+        /// <summary>
+        /// Ensures the combination of virtual address and size is part of the addressable space.
+        /// </summary>
+        /// <param name="va">Virtual address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        /// <exception cref="InvalidMemoryRegionException">Throw when the memory region specified outside the addressable space</exception>
+        protected void AssertValidAddressAndSize(TVirtual va, TVirtual size)
+        {
+            if (!ValidateAddressAndSize(va, size))
+            {
+                throw new InvalidMemoryRegionException($"va=0x{va:X16}, size=0x{size:X16}");
+            }
+        }
+
+        protected abstract Span<byte> GetPhysicalAddressSpan(TPhysical pa, int size);
+
+        protected abstract TPhysical TranslateVirtualAddressForRead(TVirtual va);
+
+        /// <summary>
+        /// Checks if the virtual address is part of the addressable space.
+        /// </summary>
+        /// <param name="va">Virtual address</param>
+        /// <returns>True if the virtual address is part of the addressable space</returns>
+        protected bool ValidateAddress(TVirtual va)
+        {
+            return va < AddressSpaceSize;
+        }
+
+        /// <summary>
+        /// Checks if the combination of virtual address and size is part of the addressable space.
+        /// </summary>
+        /// <param name="va">Virtual address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        /// <returns>True if the combination of virtual address and size is part of the addressable space</returns>
+        protected bool ValidateAddressAndSize(TVirtual va, TVirtual size)
+        {
+            TVirtual endVa = va + size;
+            return endVa >= va && endVa >= size && endVa <= AddressSpaceSize;
+        }
+
+        protected static void ThrowInvalidMemoryRegionException(string message)
+            => throw new InvalidMemoryRegionException(message);
+    }
+}


### PR DESCRIPTION
This PR refactors the various memory managers to share a common abstract base class for the purpose of improving code reuse and consolidating similar implementations of algorithms like virtual-to-physical memory mapping.

In particular it consolidates the `void Read(ulong va, Span<byte> data)` implementations. There is much more that could be done, but I didn't want to do all that without gauging interest first.

This approach is an alternative to the `PagedMemoryRangeEnumerator` in pending PR #6251, which was added after @gdkchan mentioned it'd be desirable to consolidate the many implementations of that page mapping logic.  @riperiperi  raised performance concerns with the enumerator so I began exploring this common base class approach. I haven't benchmarked it but I expect this to perform better than the enumerators - virtual method calls add some overhead, but they're still significantly faster than calling delegates (which the enumerators depend on).

If this PR is merged, I would back out the new enumerator types in pending PR #6251, which was outside of the initial goal of that PR anyway.

Summary of changes:
- add new abstract class `VirtualMemoryManagerBase`
- rename `MemoryManagerBase` to `VirtualMemoryManagerRefCountedBase` and derive from `VirtualMemoryManagerBase`
- change `AddressSpaceManager`, `HvMemoryManager`, `MemoryManager`, and `MemoryManagerHostMapped` to implement abstract members and use the inherited `void VirtualMemoryManagerBase.Read(TVirtual va, Span<byte> data)` implementation.
