### PR TITLE
Do not set render targets as modified for discard-only draws

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -466,6 +466,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             engine.UpdateState(ulong.MaxValue & ~(1UL << StateUpdater.ShaderStateIndex));
 
+            _channel.TextureManager.SignalRenderTargetsModifiable();
             _channel.TextureManager.UpdateRenderTargets();
 
             int textureId = _state.State.DrawTextureTextureId;
@@ -803,7 +804,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             int index = (argument >> 6) & 0xf;
             int layer = (argument >> 10) & 0x3ff;
 
-            RenderTargetUpdateFlags updateFlags = RenderTargetUpdateFlags.SingleColor;
+            RenderTargetUpdateFlags updateFlags = RenderTargetUpdateFlags.SingleColor | RenderTargetUpdateFlags.ForClear;
 
             if (layer != 0 || layerCount > 1)
             {

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/RenderTargetUpdateFlags.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/RenderTargetUpdateFlags.cs
@@ -39,6 +39,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         DiscardClip = 1 << 4,
 
         /// <summary>
+        /// Indicates that the render target will be used for a clear operation.
+        /// </summary>
+        ForClear = 1 << 5,
+
+        /// <summary>
         /// Default update flags for draw.
         /// </summary>
         UpdateAll = UseControl | UpdateDepthStencil,

--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1430,11 +1430,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="bound">True if the texture has been bound, false if it has been unbound</param>
         public void SignalModifying(bool bound)
         {
-            if (bound)
-            {
-                _scaledSetScore = Math.Max(0, _scaledSetScore - 1);
-            }
-
             if (_modifiedStale || Group.HasCopyDependencies || Group.HasFlushBuffer)
             {
                 _modifiedStale = false;
@@ -1442,9 +1437,18 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             _physicalMemory.TextureCache.Lift(this);
+        }
 
+        /// <summary>
+        /// Signals that a render target texture has been either bound or unbound.
+        /// </summary>
+        /// <param name="bound">True if the texture has been bound, false if it has been unbound</param>
+        public void SignalBindingChange(bool bound)
+        {
             if (bound)
             {
+                _scaledSetScore = Math.Max(0, _scaledSetScore - 1);
+
                 IncrementReferenceCount();
             }
             else

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -175,7 +175,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             (TexturePool texturePool, SamplerPool samplerPool) = GetPools();
 
-            return (texturePool.Get(textureId), samplerPool.Get(samplerId));
+            return (texturePool?.Get(textureId), samplerPool?.Get(samplerId));
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -18,12 +18,39 @@ namespace Ryujinx.Graphics.Gpu.Image
         private readonly TexturePoolCache _texturePoolCache;
         private readonly SamplerPoolCache _samplerPoolCache;
 
+        /// <summary>
+        /// Bound render target texture modification report state.
+        /// </summary>
+        [Flags]
+        private enum BindState : byte
+        {
+            /// <summary>
+            /// Render target texture has not been signalled for modification, and can't be modified on the next render operations.
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// Render target texture has been signalled for modification.
+            /// </summary>
+            Bound = 1 << 0,
+
+            /// <summary>
+            /// Render target texture might be modified on the next render operations.
+            /// </summary>
+            Modified = 1 << 1,
+
+            /// <summary>
+            /// Render target texture has been signalled for modification and might be modified on the next render operations.
+            /// </summary>
+            BoundModified = Bound | Modified,
+        }
+
         private readonly Texture[] _rtColors;
         private readonly ITexture[] _rtHostColors;
-        private readonly bool[] _rtColorsBound;
+        private readonly BindState[] _rtColorsBound;
         private Texture _rtDepthStencil;
         private ITexture _rtHostDs;
-        private bool _rtDsBound;
+        private BindState _rtDsBound;
 
         public int ClipRegionWidth { get; private set; }
         public int ClipRegionHeight { get; private set; }
@@ -53,7 +80,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _rtColors = new Texture[Constants.TotalRenderTargets];
             _rtHostColors = new ITexture[Constants.TotalRenderTargets];
-            _rtColorsBound = new bool[Constants.TotalRenderTargets];
+            _rtColorsBound = new BindState[Constants.TotalRenderTargets];
         }
 
         /// <summary>
@@ -149,27 +176,39 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="index">The index of the color buffer to set (up to 8)</param>
         /// <param name="color">The color buffer texture</param>
+        /// <param name="modified">Indicates if the following render operations will modidify <paramref name="color"/> contents</param>
         /// <returns>True if render target scale must be updated.</returns>
-        public bool SetRenderTargetColor(int index, Texture color)
+        public bool SetRenderTargetColor(int index, Texture color, bool modified)
         {
             bool hasValue = color != null;
             bool changesScale = (hasValue != (_rtColors[index] != null)) || (hasValue && RenderTargetScale != color.ScaleFactor);
 
             if (_rtColors[index] != color)
             {
-                if (_rtColorsBound[index])
+                Texture oldColor = _rtColors[index];
+
+                if (oldColor != null)
                 {
-                    _rtColors[index]?.SignalModifying(false);
+                    if (_rtColorsBound[index].HasFlag(BindState.Bound))
+                    {
+                        oldColor.SignalModifying(false);
+                    }
+
+                    oldColor.SignalBindingChange(false);
                 }
-                else
-                {
-                    _rtColorsBound[index] = true;
-                }
+
+                _rtColorsBound[index] = modified ? BindState.BoundModified : BindState.None;
 
                 if (color != null)
                 {
                     color.SynchronizeMemory();
-                    color.SignalModifying(true);
+
+                    if (modified)
+                    {
+                        color.SignalModifying(true);
+                    }
+
+                    color.SignalBindingChange(true);
                 }
 
                 _rtColors[index] = color;
@@ -182,27 +221,39 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Sets the render target depth-stencil buffer.
         /// </summary>
         /// <param name="depthStencil">The depth-stencil buffer texture</param>
+        /// <param name="modified">Indicates if the following render operations will modidify <paramref name="depthStencil"/> contents</param>
         /// <returns>True if render target scale must be updated.</returns>
-        public bool SetRenderTargetDepthStencil(Texture depthStencil)
+        public bool SetRenderTargetDepthStencil(Texture depthStencil, bool modified)
         {
             bool hasValue = depthStencil != null;
             bool changesScale = (hasValue != (_rtDepthStencil != null)) || (hasValue && RenderTargetScale != depthStencil.ScaleFactor);
 
             if (_rtDepthStencil != depthStencil)
             {
-                if (_rtDsBound)
+                Texture oldDepthStencil = _rtDepthStencil;
+
+                if (oldDepthStencil != null)
                 {
-                    _rtDepthStencil?.SignalModifying(false);
+                    if (_rtDsBound.HasFlag(BindState.Bound))
+                    {
+                        oldDepthStencil.SignalModifying(false);
+                    }
+
+                    oldDepthStencil.SignalBindingChange(false);
                 }
-                else
-                {
-                    _rtDsBound = true;
-                }
+
+                _rtDsBound = modified ? BindState.BoundModified : BindState.None;
 
                 if (depthStencil != null)
                 {
                     depthStencil.SynchronizeMemory();
-                    depthStencil.SignalModifying(true);
+
+                    if (modified)
+                    {
+                        depthStencil.SignalModifying(true);
+                    }
+
+                    depthStencil.SignalBindingChange(true);
                 }
 
                 _rtDepthStencil = depthStencil;
@@ -437,10 +488,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 hostDsTexture = dsTexture.HostTexture;
 
-                if (!_rtDsBound)
+                if (_rtDsBound == BindState.Modified)
                 {
                     dsTexture.SignalModifying(true);
-                    _rtDsBound = true;
+                    _rtDsBound |= BindState.Bound;
                 }
             }
 
@@ -459,10 +510,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     hostTexture = texture.HostTexture;
 
-                    if (!_rtColorsBound[index])
+                    if (_rtColorsBound[index] == BindState.Modified)
                     {
                         texture.SignalModifying(true);
-                        _rtColorsBound[index] = true;
+                        _rtColorsBound[index] |= BindState.Bound;
                     }
                 }
 
@@ -500,21 +551,34 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             Texture dsTexture = _rtDepthStencil;
 
-            if (dsTexture != null && _rtDsBound)
+            if (dsTexture != null && _rtDsBound.HasFlag(BindState.Bound))
             {
                 dsTexture.SignalModifying(false);
-                _rtDsBound = false;
+                _rtDsBound &= ~BindState.Bound;
             }
 
             for (int index = 0; index < _rtColors.Length; index++)
             {
                 Texture texture = _rtColors[index];
 
-                if (texture != null && _rtColorsBound[index])
+                if (texture != null && _rtColorsBound[index].HasFlag(BindState.Bound))
                 {
                     texture.SignalModifying(false);
-                    _rtColorsBound[index] = false;
+                    _rtColorsBound[index] &= ~BindState.Bound;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Indicates that the currently bound render targets might be modified, if they are used on the next render operation.
+        /// </summary>
+        public void SignalRenderTargetsModifiable()
+        {
+            _rtDsBound |= BindState.Modified;
+
+            for (int index = 0; index < _rtColorsBound.Length; index++)
+            {
+                _rtColorsBound[index] |= BindState.Modified;
             }
         }
 
@@ -554,19 +618,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             for (int i = 0; i < _rtColors.Length; i++)
             {
-                if (_rtColorsBound[i])
-                {
-                    _rtColors[i]?.DecrementReferenceCount();
-                }
-
+                _rtColors[i]?.DecrementReferenceCount();
                 _rtColors[i] = null;
             }
 
-            if (_rtDsBound)
-            {
-                _rtDepthStencil?.DecrementReferenceCount();
-            }
-
+            _rtDepthStencil?.DecrementReferenceCount();
             _rtDepthStencil = null;
         }
     }

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -171,6 +171,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             public bool UsesRtLayer;
 
             /// <summary>
+            /// Indicates that the fragment shader always discards the fragment, not producing any output for the bound render targets.
+            /// </summary>
+            public bool HasUnconditionalDiscard;
+
+            /// <summary>
             /// Bit mask with the clip distances written on the vertex stage.
             /// </summary>
             public byte ClipDistancesWritten;
@@ -806,6 +811,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                 dataInfo.UsesInstanceId,
                 dataInfo.UsesDrawParameters,
                 dataInfo.UsesRtLayer,
+                dataInfo.HasUnconditionalDiscard,
                 dataInfo.ClipDistancesWritten,
                 dataInfo.FragmentOutputMap);
         }
@@ -836,6 +842,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                 UsesInstanceId = info.UsesInstanceId,
                 UsesDrawParameters = info.UsesDrawParameters,
                 UsesRtLayer = info.UsesRtLayer,
+                HasUnconditionalDiscard = info.HasUnconditionalDiscard,
                 ClipDistancesWritten = info.ClipDistancesWritten,
                 FragmentOutputMap = info.FragmentOutputMap,
             };

--- a/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/BasicBlock.cs
+++ b/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/BasicBlock.cs
@@ -23,6 +23,7 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             set => _branch = AddSuccessor(_branch, value);
         }
 
+        public bool HasSuccessor => _branch != null || _next != null;
         public bool HasBranch => _branch != null;
         public bool Reachable => Index == 0 || Predecessors.Count != 0;
 

--- a/src/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
+++ b/src/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
@@ -18,6 +18,7 @@ namespace Ryujinx.Graphics.Shader
         public bool UsesInstanceId { get; }
         public bool UsesDrawParameters { get; }
         public bool UsesRtLayer { get; }
+        public bool HasUnconditionalDiscard { get; }
         public byte ClipDistancesWritten { get; }
         public int FragmentOutputMap { get; }
 
@@ -34,6 +35,7 @@ namespace Ryujinx.Graphics.Shader
             bool usesInstanceId,
             bool usesDrawParameters,
             bool usesRtLayer,
+            bool hasUnconditionalDiscard,
             byte clipDistancesWritten,
             int fragmentOutputMap)
         {
@@ -50,6 +52,7 @@ namespace Ryujinx.Graphics.Shader
             UsesInstanceId = usesInstanceId;
             UsesDrawParameters = usesDrawParameters;
             UsesRtLayer = usesRtLayer;
+            HasUnconditionalDiscard = hasUnconditionalDiscard;
             ClipDistancesWritten = clipDistancesWritten;
             FragmentOutputMap = fragmentOutputMap;
         }

--- a/src/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -26,5 +26,6 @@ namespace Ryujinx.Graphics.Shader.Translation
         SharedMemory = 1 << 11,
         Store = 1 << 12,
         VtgAsCompute = 1 << 13,
+        UnconditionalDiscard = 1 << 14,
     }
 }

--- a/src/Ryujinx.Graphics.Shader/Translation/FeatureIdentification.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/FeatureIdentification.cs
@@ -1,0 +1,38 @@
+using Ryujinx.Graphics.Shader.IntermediateRepresentation;
+
+namespace Ryujinx.Graphics.Shader.Translation
+{
+    static class FeatureIdentification
+    {
+        public static void RunPass(BasicBlock[] blocks, ShaderStage stage, ref FeatureFlags usedFeatures)
+        {
+            if (stage == ShaderStage.Fragment)
+            {
+                bool endsWithDiscardOnly = true;
+
+                for (int blockIndex = 0; blockIndex < blocks.Length; blockIndex++)
+                {
+                    BasicBlock block = blocks[blockIndex];
+
+                    if (block.HasSuccessor)
+                    {
+                        continue;
+                    }
+
+                    if (block.Operations.Count == 0 ||
+                        block.Operations.Last.Value is not Operation operation ||
+                        operation.Inst != Instruction.Discard)
+                    {
+                        endsWithDiscardOnly = false;
+                        break;
+                    }
+                }
+
+                if (endsWithDiscardOnly)
+                {
+                    usedFeatures |= FeatureFlags.UnconditionalDiscard;
+                }
+            }
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -300,6 +300,11 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                     Optimizer.RunPass(context);
                     TransformPasses.RunPass(context);
+
+                    if (i == 0)
+                    {
+                        FeatureIdentification.RunPass(cfg.Blocks, Definitions.Stage, ref usedFeatures);
+                    }
                 }
 
                 funcs[i] = new Function(cfg.Blocks, $"fun{i}", false, inArgumentsCount, outArgumentsCount);
@@ -352,6 +357,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 usedFeatures.HasFlag(FeatureFlags.InstanceId),
                 usedFeatures.HasFlag(FeatureFlags.DrawParameters),
                 usedFeatures.HasFlag(FeatureFlags.RtLayer),
+                usedFeatures.HasFlag(FeatureFlags.UnconditionalDiscard),
                 clipDistancesWritten,
                 originalDefinitions.OmapTargets);
 


### PR DESCRIPTION
Currently, we assume render targets that are bound are always going to be modified. This is often, but not always the case. For example, if a fragment shader always discards the fragment, then the render targets will never be actually modified.

This PR makes a few changes to allow render targets to be bound, but not set as modified:
- `SignalModifying` has been split to allow incrementing/decrementing reference count without setting the texture as modified.
  - A new `SignalBindingChange` method has been added for that.
- A new `BindState` enum has been added to track whether a render target has been "bound" for modification, and if said render target *can* be modified, since those are separate concerns.
  - Code has been changed to use the new enum instead of the bool.
- New `SignalRenderTargetsModifiable` added to the texture manager to allow setting render targets textures as being "modifiable" if they were not before, used if the shader changes from one that always discards to another that doesn't.

For shaders, a new pass has been added to the IR to detect if the shader is a fragment shader, and if it discards the fragment in all terminal blocks. If such a shader is bound, render targets used while it is bound won't be marked as being modified.

This change fixes a specific issue with OpenGL games that does the incompatible format/size copies. They modify the texture using `imageStore` on the fragment shader, but they also have a overlapping render target bound. This causes both the render target and the image to be marked as modified, but only the image is really modified (since the shader always discards at the end). Marking both as modified is not only inefficient, but it also causes problems for copy dependency as it might copy the wrong texture (the render target texture).

This seems to fix the remaining glitches on CEIBA and Wet Steps.
Example (CEIBA):
Before:

https://github.com/Ryujinx/Ryujinx/assets/5624669/c6dc9e93-7d95-4907-85a7-a67b00684d22

After:

https://github.com/Ryujinx/Ryujinx/assets/5624669/5cd787ed-1afb-4da1-b563-87093f637206

Might fix issues on Yokai Watch 1 too, since that game also uses OpenGL and also has the incompatible copies, but I have not tested this one.

Testing is welcome to ensure there's no regressions.

