### PR TITLE
Display title name instead of build ID in CheatWindow UI

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/CheatWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/CheatWindow.cs
@@ -86,7 +86,7 @@ namespace Ryujinx.UI.Windows
                     string parentPath = currentCheatFile.Replace(titleModsPath, "");
 
                     buildId = System.IO.Path.GetFileNameWithoutExtension(currentCheatFile).ToUpper();
-                    parentIter = ((TreeStore)_cheatTreeView.Model).AppendValues(false, buildId, parentPath, "");
+                    parentIter = ((TreeStore)_cheatTreeView.Model).AppendValues(false, titleName, parentPath, "");
                 }
 
                 string cleanName = cheat.Name[1..^7];

--- a/src/Ryujinx/UI/Windows/CheatWindow.axaml
+++ b/src/Ryujinx/UI/Windows/CheatWindow.axaml
@@ -1,4 +1,4 @@
-﻿<window:StyleableWindow
+<window:StyleableWindow
     x:Class="Ryujinx.Ava.UI.Windows.CheatWindow"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -91,7 +91,7 @@
                         <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
                             <CheckBox MinWidth="20" IsChecked="{Binding IsEnabled}" />
                             <TextBlock Width="150" Text="{Binding CleanName}" IsVisible="{Binding !IsRootNode}" />
-                            <TextBlock Width="150" Text="{Binding BuildId}" IsVisible="{Binding IsRootNode}" />
+                            <TextBlock Width="150" Text="{Binding Name}" IsVisible="{Binding IsRootNode}" />
                             <TextBlock Text="{Binding Path}" IsVisible="{Binding IsRootNode}" />
                         </StackPanel>
                     </TreeDataTemplate>

--- a/src/Ryujinx/UI/Windows/CheatWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/CheatWindow.axaml.cs
@@ -72,7 +72,7 @@ namespace Ryujinx.Ava.UI.Windows
                     string parentPath = currentCheatFile.Replace(titleModsPath, "");
 
                     buildId = Path.GetFileNameWithoutExtension(currentCheatFile).ToUpper();
-                    currentGroup = new CheatNode("", buildId, parentPath, true);
+                    currentGroup = new CheatNode(titleName, buildId, parentPath, true);
 
                     LoadedCheats.Add(currentGroup);
                 }


### PR DESCRIPTION
Update the CheatWindow UI in Avalonia and Gtk3 to display the title name instead of the build ID.

Fix #5903