### PR TITLE
Add a changeable idle timeout for the cursor CursorHideIdleTime

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.UI.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 49;
+        public const int CurrentVersion = 50;
 
         /// <summary>
         /// Version of the configuration file format
@@ -166,6 +166,11 @@ namespace Ryujinx.UI.Common.Configuration
         /// Whether to hide cursor on idle, always or never
         /// </summary>
         public HideCursorMode HideCursor { get; set; }
+
+        /// <summary>
+        /// Amount of seconds needed by the mouse to be spent idle for cursor to hide.
+        /// </summary>
+         public int CursorHideIdleTime { get; set; }
 
         /// <summary>
         /// Enables or disables Vertical Sync

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -423,6 +423,7 @@ namespace Ryujinx.UI.Common.Configuration
             /// </summary>
             public ReactiveObject<List<InputConfig>> InputConfig { get; private set; }
 
+
             public HidSection()
             {
                 EnableKeyboard = new ReactiveObject<bool>();
@@ -631,6 +632,11 @@ namespace Ryujinx.UI.Common.Configuration
         /// </summary>
         public ReactiveObject<HideCursorMode> HideCursor { get; private set; }
 
+        /// <summary>
+        /// Amount of seconds needed by the mouse to be spent idle to hide the cursor.
+        /// </summary>
+        public ReactiveObject<int> CursorHideIdleTime {get; private set; }
+
         private ConfigurationState()
         {
             UI = new UISection();
@@ -643,6 +649,7 @@ namespace Ryujinx.UI.Common.Configuration
             CheckUpdatesOnStart = new ReactiveObject<bool>();
             ShowConfirmExit = new ReactiveObject<bool>();
             HideCursor = new ReactiveObject<HideCursorMode>();
+            CursorHideIdleTime = new ReactiveObject<int>();
         }
 
         public ConfigurationFileFormat ToFileFormat()
@@ -679,6 +686,7 @@ namespace Ryujinx.UI.Common.Configuration
                 CheckUpdatesOnStart = CheckUpdatesOnStart,
                 ShowConfirmExit = ShowConfirmExit,
                 HideCursor = HideCursor,
+                CursorHideIdleTime = CursorHideIdleTime,
                 EnableVsync = Graphics.EnableVsync,
                 EnableShaderCache = Graphics.EnableShaderCache,
                 EnableTextureRecompression = Graphics.EnableTextureRecompression,
@@ -843,6 +851,7 @@ namespace Ryujinx.UI.Common.Configuration
             UI.WindowStartup.WindowMaximized.Value = false;
             Hid.EnableKeyboard.Value = false;
             Hid.EnableMouse.Value = false;
+            CursorHideIdleTime.Value = 5;
             Hid.Hotkeys.Value = new KeyboardHotkeys
             {
                 ToggleVsync = Key.F1,
@@ -1442,6 +1451,15 @@ namespace Ryujinx.UI.Common.Configuration
                 configurationFileUpdated = true;
             }
 
+            if(configurationFileFormat.Version < 50)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 50.");
+
+                configurationFileFormat.CursorHideIdleTime = 5;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value = configurationFileFormat.ResScaleCustom;
@@ -1473,6 +1491,7 @@ namespace Ryujinx.UI.Common.Configuration
             CheckUpdatesOnStart.Value = configurationFileFormat.CheckUpdatesOnStart;
             ShowConfirmExit.Value = configurationFileFormat.ShowConfirmExit;
             HideCursor.Value = configurationFileFormat.HideCursor;
+            CursorHideIdleTime.Value = configurationFileFormat.CursorHideIdleTime;
             Graphics.EnableVsync.Value = configurationFileFormat.EnableVsync;
             Graphics.EnableShaderCache.Value = configurationFileFormat.EnableShaderCache;
             Graphics.EnableTextureRecompression.Value = configurationFileFormat.EnableTextureRecompression;
@@ -1527,6 +1546,7 @@ namespace Ryujinx.UI.Common.Configuration
             Hid.EnableMouse.Value = configurationFileFormat.EnableMouse;
             Hid.Hotkeys.Value = configurationFileFormat.Hotkeys;
             Hid.InputConfig.Value = configurationFileFormat.InputConfig;
+            
 
             if (Hid.InputConfig.Value == null)
             {

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -65,7 +65,6 @@ namespace Ryujinx.Ava
 {
     internal class AppHost
     {
-        private const int CursorHideIdleTime = 5; // Hide Cursor seconds.
         private const float MaxResolutionScale = 4.0f; // Max resolution hotkeys can scale to before wrapping.
         private const int TargetFps = 60;
         private const float VolumeDelta = 0.05f;
@@ -125,6 +124,7 @@ namespace Ryujinx.Ava
         public bool ScreenshotRequested { get; set; }
 
         public AppHost(
+            
             RendererHost renderer,
             InputManager inputManager,
             string applicationPath,
@@ -1029,7 +1029,7 @@ namespace Ryujinx.Ava
                                 ShowCursor();
                                 break;
                             case HideCursorMode.OnIdle:
-                                if (Stopwatch.GetTimestamp() - _lastCursorMoveTime >= CursorHideIdleTime * Stopwatch.Frequency)
+                                if (Stopwatch.GetTimestamp() - _lastCursorMoveTime >= ConfigurationState.Instance.CursorHideIdleTime.Value * Stopwatch.Frequency)
                                 {
                                     HideCursor();
                                 }

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -96,6 +96,8 @@
   "SettingsTabGeneralHideCursorNever": "Never",
   "SettingsTabGeneralHideCursorOnIdle": "On Idle",
   "SettingsTabGeneralHideCursorAlways": "Always",
+  "SettingsTabGeneralCursorHideIdleTime": "Seconds:",
+  "SettingsTabGeneralCursorHideIdleTimeTooltip": "Amount of seconds needed by the mouse to be spent idle to hide the cursor.",
   "SettingsTabGeneralGameDirectories": "Game Directories",
   "SettingsTabGeneralAdd": "Add",
   "SettingsTabGeneralRemove": "Remove",

--- a/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
@@ -133,6 +133,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool CheckUpdatesOnStart { get; set; }
         public bool ShowConfirmExit { get; set; }
         public int HideCursor { get; set; }
+        public int CursorHideIdleTime { get; set; }
         public bool EnableDockedMode { get; set; }
         public bool EnableKeyboard { get; set; }
         public bool EnableMouse { get; set; }
@@ -406,6 +407,9 @@ namespace Ryujinx.Ava.UI.ViewModels
             CheckUpdatesOnStart = config.CheckUpdatesOnStart;
             ShowConfirmExit = config.ShowConfirmExit;
             HideCursor = (int)config.HideCursor.Value;
+            CursorHideIdleTime = config.CursorHideIdleTime.Value;
+            
+
 
             GameDirectories.Clear();
             GameDirectories.AddRange(config.UI.GameDirs.Value);
@@ -490,6 +494,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             config.CheckUpdatesOnStart.Value = CheckUpdatesOnStart;
             config.ShowConfirmExit.Value = ShowConfirmExit;
             config.HideCursor.Value = (HideCursorMode)HideCursor;
+            config.CursorHideIdleTime.Value = CursorHideIdleTime;
 
             if (_directoryChanged)
             {

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
     xmlns:locale="clr-namespace:Ryujinx.Ava.Common.Locale"
     xmlns:viewModels="clr-namespace:Ryujinx.Ava.UI.ViewModels"
     mc:Ignorable="d"
@@ -53,6 +54,20 @@
                                 <TextBlock Text="{locale:Locale SettingsTabGeneralHideCursorAlways}" />
                             </ComboBoxItem>
                         </ComboBox>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="{locale:Locale SettingsTabGeneralCursorHideIdleTime}"
+                            Width="150"
+                            Margin="10,0,0,0"/>
+                        <ui:NumberBox
+                            MinWidth="100"
+                            SmallChange="1"
+                            LargeChange="5"
+                            SimpleNumberFormat="F0"
+                            Maximum="100"
+                            Minimum="1"
+                            ToolTip.Tip="{locale:Locale SettingsTabGeneralCursorHideIdleTimeTooltip}"
+                            Value="{Binding CursorHideIdleTime}" />
                     </StackPanel>
                     <StackPanel Margin="0, 15, 0, 10" Orientation="Horizontal">
                         <TextBlock


### PR DESCRIPTION
Added feature request: https://github.com/Ryujinx/Ryujinx/issues/4930 on the Avalonia UI.

Updated ConfigurationState, Settings UI, and other relevant configuration files to add a modifiable idle timeout for the cursor
The logic targets the OnIdle case AppHost where it now calls ConfigurationState to check how much time it should wait for HideCursor()