### PR TITLE
Update dependencies from SixLabors to the latest version before the license change 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,8 +42,8 @@
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.7" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.2" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,8 +42,8 @@
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
-    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.7" />
+    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.2" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRendererBase.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRendererBase.cs
@@ -44,10 +44,10 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         private readonly Color _textSelectedColor;
         private readonly Color _textOverCursorColor;
 
-        private readonly IBrush _panelBrush;
-        private readonly IBrush _disabledBrush;
-        private readonly IBrush _cursorBrush;
-        private readonly IBrush _selectionBoxBrush;
+        private readonly Brush _panelBrush;
+        private readonly Brush _disabledBrush;
+        private readonly Brush _cursorBrush;
+        private readonly Brush _selectionBoxBrush;
 
         private readonly Pen _textBoxOutlinePen;
         private readonly Pen _cursorPen;
@@ -97,10 +97,10 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             _cursorBrush = new SolidBrush(_textNormalColor);
             _selectionBoxBrush = new SolidBrush(selectionBackgroundColor);
 
-            _textBoxOutlinePen = new Pen(borderColor, _textBoxOutlineWidth);
-            _cursorPen = new Pen(_textNormalColor, cursorWidth);
-            _selectionBoxPen = new Pen(selectionBackgroundColor, cursorWidth);
-            _padPressedPen = new Pen(borderColor, _padPressedPenWidth);
+            _textBoxOutlinePen = Pens.Solid(borderColor, _textBoxOutlineWidth);
+            _cursorPen = Pens.Solid(_textNormalColor, cursorWidth);
+            _selectionBoxPen = Pens.Solid(selectionBackgroundColor, cursorWidth);
+            _padPressedPen = Pens.Solid(borderColor, _padPressedPenWidth);
 
             _inputTextFontSize = 20;
 
@@ -178,7 +178,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         private static void SetGraphicsOptions(IImageProcessingContext context)
         {
             context.GetGraphicsOptions().Antialias = true;
-            context.GetShapeGraphicsOptions().GraphicsOptions.Antialias = true;
+            context.GetDrawingOptions().GraphicsOptions.Antialias = true;
         }
 
         private void DrawImmutableElements()
@@ -293,31 +293,31 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         }
         private static RectangleF MeasureString(string text, Font font)
         {
-            RendererOptions options = new(font);
+            TextOptions options = new(font);
 
             if (text == "")
             {
-                FontRectangle emptyRectangle = TextMeasurer.Measure(" ", options);
+                FontRectangle emptyRectangle = TextMeasurer.MeasureSize(" ", options);
 
                 return new RectangleF(0, emptyRectangle.Y, 0, emptyRectangle.Height);
             }
 
-            FontRectangle rectangle = TextMeasurer.Measure(text, options);
+            FontRectangle rectangle = TextMeasurer.MeasureSize(text, options);
 
             return new RectangleF(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
         }
 
         private static RectangleF MeasureString(ReadOnlySpan<char> text, Font font)
         {
-            RendererOptions options = new(font);
+            TextOptions options = new(font);
 
             if (text == "")
             {
-                FontRectangle emptyRectangle = TextMeasurer.Measure(" ", options);
+                FontRectangle emptyRectangle = TextMeasurer.MeasureSize(" ", options);
                 return new RectangleF(0, emptyRectangle.Y, 0, emptyRectangle.Height);
             }
 
-            FontRectangle rectangle = TextMeasurer.Measure(text, options);
+            FontRectangle rectangle = TextMeasurer.MeasureSize(text, options);
 
             return new RectangleF(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
         }
@@ -350,7 +350,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             // Draw the cursor on top of the text and redraw the text with a different color if necessary.
 
             Color cursorTextColor;
-            IBrush cursorBrush;
+            Brush cursorBrush;
             Pen cursorPen;
 
             float cursorPositionYTop = inputTextY + 1;
@@ -435,7 +435,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
                         new PointF(cursorPositionXLeft, cursorPositionYBottom),
                     };
 
-                    context.DrawLines(cursorPen, points);
+                    context.DrawLine(cursorPen, points);
                 }
                 else
                 {

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRendererBase.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRendererBase.cs
@@ -562,12 +562,12 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
                 // Convert the pixel format used in the image to the one used in the Switch surface.
 
-                if (!_surface.TryGetSinglePixelSpan(out Span<Argb32> pixels))
+                if (!_surface.DangerousTryGetSinglePixelMemory(out Memory<Argb32> pixels))
                 {
                     return;
                 }
 
-                _bufferData = MemoryMarshal.AsBytes(pixels).ToArray();
+                _bufferData = MemoryMarshal.AsBytes(pixels.Span).ToArray();
                 Span<uint> dataConvert = MemoryMarshal.Cast<byte, uint>(_bufferData);
 
                 Debug.Assert(_bufferData.Length == _surfaceInfo.Size);

--- a/src/Ryujinx/UI/Windows/IconColorPicker.cs
+++ b/src/Ryujinx/UI/Windows/IconColorPicker.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         public static Bgra32[] GetBuffer(Image<Bgra32> image)
         {
-            return image.TryGetSinglePixelSpan(out var data) ? data.ToArray() : Array.Empty<Bgra32>();
+            return image.DangerousTryGetSinglePixelMemory(out var data) ? data.ToArray() : Array.Empty<Bgra32>();
         }
 
         private static int GetColorScore(Dictionary<int, int> dominantColorBin, int maxHitCount, PaletteColor color)


### PR DESCRIPTION
This PR updates `SixLabors.ImageSharp` and `SixLabors.ImageSharp.Drawing` to the latest available versions before the license change.

> [!Caution]
> The license change for `SixLabors.ImageSharp` was introduced with `v3.0.0` and was added to `SixLabors.ImageSharp.Drawing` with `v2.0.0`.

---

Fixes GHSA-65x7-c272-7g7r