### PR TITLE
infra: Fix updater for old Ava users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-          
+
       - name: Overwrite csc problem matcher
         run: echo "::add-matcher::.github/csc.json"
 
@@ -104,16 +104,13 @@ jobs:
         if: matrix.platform.os == 'windows-latest'
         run: |
           pushd publish_ava
+          cp publish/Ryujinx.exe publish/Ryujinx.Ava.exe
           7z a ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip publish
+          7z a ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip publish
           popd
 
           pushd publish_sdl2_headless
           7z a ../release_output/sdl2-ryujinx-headless-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip publish
-          popd
-
-          pushd publish_ava
-          cp publish/Ryujinx.exe publish/Ryujinx.Ava.exe
-          7z a ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip publish
           popd
         shell: bash
 
@@ -121,19 +118,15 @@ jobs:
         if: matrix.platform.os == 'ubuntu-latest'
         run: |
           pushd publish_ava
-          chmod +x publish/Ryujinx.sh publish/Ryujinx
+          cp publish/Ryujinx publish/Ryujinx.Ava
+          chmod +x publish/Ryujinx.sh publish/Ryujinx.Ava publish/Ryujinx
           tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz publish
+          tar -czvf ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz publish
           popd
 
           pushd publish_sdl2_headless
           chmod +x publish/Ryujinx.sh publish/Ryujinx.Headless.SDL2
           tar -czvf ../release_output/sdl2-ryujinx-headless-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz publish
-          popd
-
-          pushd publish_ava
-          cp publish/Ryujinx publish/Ryujinx.Ava
-          chmod +x publish/Ryujinx.sh publish/Ryujinx.Ava publish/Ryujinx
-          tar -czvf ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz publish
           popd
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           popd
 
           pushd publish_ava
-          mv publish/Ryujinx.exe publish/Ryujinx.Ava.exe
+          cp publish/Ryujinx.exe publish/Ryujinx.Ava.exe
           7z a ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip publish
           popd
         shell: bash
@@ -131,8 +131,8 @@ jobs:
           popd
 
           pushd publish_ava
-          mv publish/Ryujinx publish/Ryujinx.Ava
-          chmod +x publish/Ryujinx.sh publish/Ryujinx.Ava
+          cp publish/Ryujinx publish/Ryujinx.Ava
+          chmod +x publish/Ryujinx.sh publish/Ryujinx.Ava publish/Ryujinx
           tar -czvf ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz publish
           popd
         shell: bash

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -298,7 +298,14 @@ namespace Ryujinx.Modules
                     else
                     {
                         // Find the process name.
-                        string ryuName = Path.GetFileName(Environment.ProcessPath);
+                        string ryuName = Path.GetFileName(Environment.ProcessPath) ?? string.Empty;
+
+                        // Migration: Start the updated binary.
+                        // TODO: Remove this in a future update.
+                        if (ryuName.StartsWith("Ryujinx.Ava"))
+                        {
+                            ryuName = ryuName.Replace(".Ava", "");
+                        }
 
                         // Some operating systems can see the renamed executable, so strip off the .ryuold if found.
                         if (ryuName.EndsWith(".ryuold"))
@@ -307,7 +314,7 @@ namespace Ryujinx.Modules
                         }
 
                         // Fallback if the executable could not be found.
-                        if (!Path.Exists(Path.Combine(executableDirectory, ryuName)))
+                        if (ryuName.Length == 0 || !Path.Exists(Path.Combine(executableDirectory, ryuName)))
                         {
                             ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
                         }
@@ -758,6 +765,43 @@ namespace Ryujinx.Modules
             foreach (string file in Directory.GetFiles(_homeDir, "*.ryuold", SearchOption.AllDirectories))
             {
                 File.Delete(file);
+            }
+
+            // Migration: Delete old Ryujinx binary.
+            // TODO: Remove this in a future update.
+            if (!OperatingSystem.IsMacOS())
+            {
+                string[] oldRyuFiles = Directory.GetFiles(_homeDir, "Ryujinx.Ava*", SearchOption.TopDirectoryOnly);
+                // Assume we are running the new one if the process path is not available.
+                // This helps to prevent an infinite loop of restarts.
+                string currentRyuName = Path.GetFileName(Environment.ProcessPath) ?? (OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx");
+
+                string newRyuName = Path.Combine(_homeDir, currentRyuName.Replace(".Ava", ""));
+                if (!currentRyuName.Contains("Ryujinx.Ava"))
+                {
+                    foreach (string oldRyuFile in oldRyuFiles)
+                    {
+                        File.Delete(oldRyuFile);
+                    }
+                }
+                // Should we be running the old binary, start the new one if possible.
+                else if (File.Exists(newRyuName))
+                {
+                    ProcessStartInfo processStart = new(newRyuName)
+                    {
+                        UseShellExecute = true,
+                        WorkingDirectory = _homeDir,
+                    };
+
+                    foreach (string argument in CommandLineState.Arguments)
+                    {
+                        processStart.ArgumentList.Add(argument);
+                    }
+
+                    Process.Start(processStart);
+
+                    Environment.Exit(0);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue where old "test" Avalonia users were stuck on 1.1.1217 even after successfully applying the new update.

We now provide both "Ryujinx" and "Ryujinx.Ava" binaries for the old test release and make sure we migrate to the new release binary.

In a few weeks we should be able to remove the migration code and the old test-ava release again.