### PR TITLE
Passthrough mouse for win32

### DIFF
--- a/src/Ryujinx/UI/Helpers/Win32NativeInterop.cs
+++ b/src/Ryujinx/UI/Helpers/Win32NativeInterop.cs
@@ -31,22 +31,6 @@ namespace Ryujinx.Ava.UI.Helpers
         [SuppressMessage("Design", "CA1069: Enums values should not be duplicated")]
         public enum WindowsMessages : uint
         {
-            Mousemove = 0x0200,
-            Lbuttondown = 0x0201,
-            Lbuttonup = 0x0202,
-            Lbuttondblclk = 0x0203,
-            Rbuttondown = 0x0204,
-            Rbuttonup = 0x0205,
-            Rbuttondblclk = 0x0206,
-            Mbuttondown = 0x0207,
-            Mbuttonup = 0x0208,
-            Mbuttondblclk = 0x0209,
-            Mousewheel = 0x020A,
-            Xbuttondown = 0x020B,
-            Xbuttonup = 0x020C,
-            Xbuttondblclk = 0x020D,
-            Mousehwheel = 0x020E,
-            Mouselast = 0x020E,
             NcHitTest = 0x0084,
         }
 

--- a/src/Ryujinx/UI/Helpers/Win32NativeInterop.cs
+++ b/src/Ryujinx/UI/Helpers/Win32NativeInterop.cs
@@ -8,6 +8,8 @@ namespace Ryujinx.Ava.UI.Helpers
     [SupportedOSPlatform("windows")]
     internal partial class Win32NativeInterop
     {
+        internal const int GWLP_WNDPROC = -4;
+
         [Flags]
         public enum ClassStyles : uint
         {
@@ -45,6 +47,7 @@ namespace Ryujinx.Ava.UI.Helpers
             Xbuttondblclk = 0x020D,
             Mousehwheel = 0x020E,
             Mouselast = 0x020E,
+            NcHitTest = 0x0084,
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
@@ -121,5 +124,11 @@ namespace Ryujinx.Ava.UI.Helpers
            IntPtr hMenu,
            IntPtr hInstance,
            IntPtr lpParam);
+
+        [LibraryImport("user32.dll", SetLastError = true)]
+        public static partial IntPtr SetWindowLongPtrW(IntPtr hWnd, int nIndex, IntPtr value);
+
+        [LibraryImport("user32.dll", SetLastError = true)]
+        public static partial IntPtr SetWindowLongW(IntPtr hWnd, int nIndex, int value);
     }
 }

--- a/src/Ryujinx/UI/Renderer/EmbeddedWindow.cs
+++ b/src/Ryujinx/UI/Renderer/EmbeddedWindow.cs
@@ -141,80 +141,10 @@ namespace Ryujinx.Ava.UI.Renderer
 
             _wndProcDelegate = delegate (IntPtr hWnd, WindowsMessages msg, IntPtr wParam, IntPtr lParam)
             {
-                if (VisualRoot != null)
+                switch (msg)
                 {
-                    if (msg == WindowsMessages.Lbuttondown ||
-                        msg == WindowsMessages.Rbuttondown ||
-                        msg == WindowsMessages.Lbuttonup ||
-                        msg == WindowsMessages.Rbuttonup ||
-                        msg == WindowsMessages.Mousemove)
-                    {
-                        Point rootVisualPosition = this.TranslatePoint(new Point((long)lParam & 0xFFFF, (long)lParam >> 16 & 0xFFFF), this).Value;
-                        Pointer pointer = new(0, PointerType.Mouse, true);
-
-#pragma warning disable CS0618 // Type or member is obsolete (As of Avalonia 11, the constructors for PointerPressedEventArgs & PointerEventArgs are marked as obsolete)
-                        switch (msg)
-                        {
-                            case WindowsMessages.Lbuttondown:
-                            case WindowsMessages.Rbuttondown:
-                                {
-                                    bool isLeft = msg == WindowsMessages.Lbuttondown;
-                                    RawInputModifiers pointerPointModifier = isLeft ? RawInputModifiers.LeftMouseButton : RawInputModifiers.RightMouseButton;
-                                    PointerPointProperties properties = new(pointerPointModifier, isLeft ? PointerUpdateKind.LeftButtonPressed : PointerUpdateKind.RightButtonPressed);
-
-                                    var evnt = new PointerPressedEventArgs(
-                                        this,
-                                        pointer,
-                                        this,
-                                        rootVisualPosition,
-                                        (ulong)Environment.TickCount64,
-                                        properties,
-                                        KeyModifiers.None);
-
-                                    RaiseEvent(evnt);
-
-                                    break;
-                                }
-                            case WindowsMessages.Lbuttonup:
-                            case WindowsMessages.Rbuttonup:
-                                {
-                                    bool isLeft = msg == WindowsMessages.Lbuttonup;
-                                    RawInputModifiers pointerPointModifier = isLeft ? RawInputModifiers.LeftMouseButton : RawInputModifiers.RightMouseButton;
-                                    PointerPointProperties properties = new(pointerPointModifier, isLeft ? PointerUpdateKind.LeftButtonReleased : PointerUpdateKind.RightButtonReleased);
-
-                                    var evnt = new PointerReleasedEventArgs(
-                                        this,
-                                        pointer,
-                                        this,
-                                        rootVisualPosition,
-                                        (ulong)Environment.TickCount64,
-                                        properties,
-                                        KeyModifiers.None,
-                                        isLeft ? MouseButton.Left : MouseButton.Right);
-
-                                    RaiseEvent(evnt);
-
-                                    break;
-                                }
-                            case WindowsMessages.Mousemove:
-                                {
-                                    var evnt = new PointerEventArgs(
-                                        PointerMovedEvent,
-                                        this,
-                                        pointer,
-                                        this,
-                                        rootVisualPosition,
-                                        (ulong)Environment.TickCount64,
-                                        new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
-                                        KeyModifiers.None);
-
-                                    RaiseEvent(evnt);
-
-                                    break;
-                                }
-                        }
-#pragma warning restore CS0618
-                    }
+                    case WindowsMessages.NcHitTest:
+                        return -1;
                 }
 
                 return DefWindowProc(hWnd, msg, wParam, lParam);
@@ -233,6 +163,8 @@ namespace Ryujinx.Ava.UI.Renderer
             RegisterClassEx(ref wndClassEx);
 
             WindowHandle = CreateWindowEx(0, _className, "NativeWindow", WindowStyles.WsChild, 0, 0, 640, 480, control.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+
+            SetWindowLongPtrW(control.Handle, GWLP_WNDPROC, wndClassEx.lpfnWndProc);
 
             Marshal.FreeHGlobal(wndClassEx.lpszClassName);
 


### PR DESCRIPTION
Passthough mouse input for win32 embedded windows. Removes the need for rerouting native pointer events as avalonia pointer events.