### PR TITLE
Fix lost copy and swap problem on shader SSA deconstruction

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 6253;
+        private const uint CodeGenVersion = 6455;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/PhiFunctions.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/PhiFunctions.cs
@@ -24,17 +24,21 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                         continue;
                     }
 
+                    Operand temp = OperandHelper.Local();
+
                     for (int index = 0; index < phi.SourcesCount; index++)
                     {
                         Operand src = phi.GetSource(index);
-
                         BasicBlock srcBlock = phi.GetBlock(index);
 
-                        Operation copyOp = new(Instruction.Copy, phi.Dest, src);
+                        Operation copyOp = new(Instruction.Copy, temp, src);
 
                         srcBlock.Append(copyOp);
                     }
 
+                    Operation copyOp2 = new(Instruction.Copy, phi.Dest, temp);
+
+                    nextNode = block.Operations.AddAfter(node, copyOp2).Next;
                     block.Operations.Remove(node);
 
                     node = nextNode;


### PR DESCRIPTION
This fixes one problem that is usually called "swap problem" in the literature for Phi elimination. It is possible for some phi sources to also be the destination of another phi node in the same block. In this case, if the copies are done in the wrong order, the variable will have the wrong value (for example, it can do the copy after tha variable has already been overwritten with a newer value).

It also fixes the lost copy problem, which happens when we have a critical edge with a distinct version of a variable. We can't simply insert a single copy at the predecessor block in this case, as it might copy the wrong version of the variable if other copies have already been inserted there.

This is the most simple fix of the problem, it inserts a temporary variable, does a copy to the temp in the predecessor block, and inserts a copy from the temp to the phi destination at the start of the block. This does generate new copies, there are other algorithms for Phi removal with a lower amount of copy, but those are more complex to implement and its not the goal of this change.

Fixes fog on Princess Peach: Showtime! Demo.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/a5ffde35-21fc-403e-a68d-661ec5048fed)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/3deb1959-8412-4eb6-a81f-d69657719679)
Testing is welcome to ensure there's no regressions.

Fixes #5138.