### PR TITLE
Fixing graphical issues in Ryujinx's Discord implementation

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 6253;
+        private const uint CodeGenVersion = 6455;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/PhiFunctions.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/PhiFunctions.cs
@@ -24,17 +24,21 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                         continue;
                     }
 
+                    Operand temp = OperandHelper.Local();
+
                     for (int index = 0; index < phi.SourcesCount; index++)
                     {
                         Operand src = phi.GetSource(index);
-
                         BasicBlock srcBlock = phi.GetBlock(index);
 
-                        Operation copyOp = new(Instruction.Copy, phi.Dest, src);
+                        Operation copyOp = new(Instruction.Copy, temp, src);
 
                         srcBlock.Append(copyOp);
                     }
 
+                    Operation copyOp2 = new(Instruction.Copy, phi.Dest, temp);
+
+                    nextNode = block.Operations.AddAfter(node, copyOp2).Next;
                     block.Operations.Remove(node);
 
                     node = nextNode;


### PR DESCRIPTION
(Addressing Issue #4916)
The Ryujinx logo is now grabbed from the official GitHub page which fixes the visuals. I believe introducing this dependency is appropriate because in the circumstance that the GitHub page was forced to be taken down, so would the Discord client currently hosting the broken image.

The old implementation using the assets uploaded to Discord
![Screenshot (14)](https://github.com/Ryujinx/Ryujinx/assets/134745254/1c08131b-606c-4a0a-962f-cf4ca1c021fa)

The new implementation using assets from the official Ryujinx GitHub page
![Screenshot (13)](https://github.com/Ryujinx/Ryujinx/assets/134745254/8a444383-d4ca-4983-ba5e-e936458e4d85)

I love feedback on improvement, so if there are any problems let me know. Thanks for reviewing my first contribution!