### PR TITLE
Fix geometry shader passthrough issue

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 6455;
+        private const uint CodeGenVersion = 6462;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -422,6 +422,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             context.MemberDecorate(perVertexStructType, 2, Decoration.BuiltIn, (LiteralInteger)BuiltIn.ClipDistance);
             context.MemberDecorate(perVertexStructType, 3, Decoration.BuiltIn, (LiteralInteger)BuiltIn.CullDistance);
 
+            if (context.Definitions.Stage == ShaderStage.Geometry 
+                && context.Definitions.GpPassthrough 
+                && context.HostCapabilities.SupportsGeometryShaderPassthrough)
+            {
+                context.MemberDecorate(perVertexStructType, 0, Decoration.PassthroughNV);
+                context.MemberDecorate(perVertexStructType, 1, Decoration.PassthroughNV);
+                context.MemberDecorate(perVertexStructType, 2, Decoration.PassthroughNV);
+                context.MemberDecorate(perVertexStructType, 3, Decoration.PassthroughNV);
+            }
+
             return perVertexStructType;
         }
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -422,9 +422,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             context.MemberDecorate(perVertexStructType, 2, Decoration.BuiltIn, (LiteralInteger)BuiltIn.ClipDistance);
             context.MemberDecorate(perVertexStructType, 3, Decoration.BuiltIn, (LiteralInteger)BuiltIn.CullDistance);
 
-            if (context.Definitions.Stage == ShaderStage.Geometry
-                && context.Definitions.GpPassthrough
-                && context.HostCapabilities.SupportsGeometryShaderPassthrough)
+            if (context.Definitions.Stage == ShaderStage.Geometry &&
+                context.Definitions.GpPassthrough &&
+                context.HostCapabilities.SupportsGeometryShaderPassthrough)
             {
                 context.MemberDecorate(perVertexStructType, 0, Decoration.PassthroughNV);
                 context.MemberDecorate(perVertexStructType, 1, Decoration.PassthroughNV);

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -422,8 +422,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             context.MemberDecorate(perVertexStructType, 2, Decoration.BuiltIn, (LiteralInteger)BuiltIn.ClipDistance);
             context.MemberDecorate(perVertexStructType, 3, Decoration.BuiltIn, (LiteralInteger)BuiltIn.CullDistance);
 
-            if (context.Definitions.Stage == ShaderStage.Geometry 
-                && context.Definitions.GpPassthrough 
+            if (context.Definitions.Stage == ShaderStage.Geometry
+                && context.Definitions.GpPassthrough
                 && context.HostCapabilities.SupportsGeometryShaderPassthrough)
             {
                 context.MemberDecorate(perVertexStructType, 0, Decoration.PassthroughNV);

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -356,6 +356,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
                     context.AddGlobalVariable(perVertexInputVariable);
                     context.Inputs.Add(new IoDefinition(StorageKind.Input, IoVariable.Position), perVertexInputVariable);
+
+                    if (context.Definitions.Stage == ShaderStage.Geometry &&
+                        context.Definitions.GpPassthrough &&
+                        context.HostCapabilities.SupportsGeometryShaderPassthrough)
+                    {
+                        context.MemberDecorate(perVertexInputStructType, 0, Decoration.PassthroughNV);
+                        context.MemberDecorate(perVertexInputStructType, 1, Decoration.PassthroughNV);
+                        context.MemberDecorate(perVertexInputStructType, 2, Decoration.PassthroughNV);
+                        context.MemberDecorate(perVertexInputStructType, 3, Decoration.PassthroughNV);
+                    }
                 }
 
                 var perVertexOutputStructType = CreatePerVertexStructType(context);
@@ -421,16 +431,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             context.MemberDecorate(perVertexStructType, 1, Decoration.BuiltIn, (LiteralInteger)BuiltIn.PointSize);
             context.MemberDecorate(perVertexStructType, 2, Decoration.BuiltIn, (LiteralInteger)BuiltIn.ClipDistance);
             context.MemberDecorate(perVertexStructType, 3, Decoration.BuiltIn, (LiteralInteger)BuiltIn.CullDistance);
-
-            if (context.Definitions.Stage == ShaderStage.Geometry &&
-                context.Definitions.GpPassthrough &&
-                context.HostCapabilities.SupportsGeometryShaderPassthrough)
-            {
-                context.MemberDecorate(perVertexStructType, 0, Decoration.PassthroughNV);
-                context.MemberDecorate(perVertexStructType, 1, Decoration.PassthroughNV);
-                context.MemberDecorate(perVertexStructType, 2, Decoration.PassthroughNV);
-                context.MemberDecorate(perVertexStructType, 3, Decoration.PassthroughNV);
-            }
 
             return perVertexStructType;
         }


### PR DESCRIPTION
Adds the `PassthroughNV` decorator to geometry shader vertex struct types when GpPassthrough is enabled.

Reported by kakasita on discord, introduced by https://github.com/Ryujinx/Ryujinx/pull/5576 

Before:
![imagen](https://github.com/Ryujinx/Ryujinx/assets/24706838/fbd936a4-32c7-48f5-a48c-dc8a4a4401a7)

After:
![imagen](https://github.com/Ryujinx/Ryujinx/assets/24706838/37931e4b-369e-495a-8758-ec9dd42565a9)
