### PR TITLE
Increase the limit of the total size of textures in the texture cache

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     {
         private const int MinCountForDeletion = 32;
         private const int MaxCapacity = 2048;
-        private const ulong MaxTextureSizeCapacity = 512 * 1024 * 1024; // MB;
+        private const ulong MaxTextureSizeCapacity = 1024 * 1024 * 1024; // MB;
 
         private readonly LinkedList<Texture> _textures;
         private ulong _totalSize;


### PR DESCRIPTION
At the moment the size limit of textures that trigger the texture cache to delete them is set to 512 MB.
With this change the size is changed to 1024 MB which makes games that previously worked playable again.
This was introduced in https://github.com/Ryujinx/Ryujinx/pull/4350
This mostly affects 4K mods of UE titles but it might potentially make resolution mods of other titles playable again (Xenoblade series)

I don't take credit for this, this is mostly explained by GDK to me but I've tested couple of UE games and read comments from others/mod makers and they confirmed that this fixes slowdowns and crashes with mods that target higher resolutions than 1080p.

Games that were tested and fixed are:

Star Ocean 2 (fixes crash)
Prince of Persia: The Lost Crown (fixes crash on the map) Demon Slayer (fixes performance)
Baten Kaitos I & II HD Remaster (fixes performance)
Princess Pach: Showtime Demo (fixes performance)

Before:

![image-6](https://github.com/Ryujinx/Ryujinx/assets/2002038/b85f12c5-b757-40f2-995f-fe9235e03c34)

After:

![image-7](https://github.com/Ryujinx/Ryujinx/assets/2002038/09a26023-c687-44f9-bd99-0e4ae7dd4ad8)
