### PR TITLE
Increase texture cache total size limit to 1024 MB (1 GB)

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     {
         private const int MinCountForDeletion = 32;
         private const int MaxCapacity = 2048;
-        private const ulong MaxTextureSizeCapacity = 512 * 1024 * 1024; // MB;
+        private const ulong MaxTextureSizeCapacity = 1024 * 1024 * 1024; // MB;
 
         private readonly LinkedList<Texture> _textures;
         private ulong _totalSize;


### PR DESCRIPTION
The current texture cache total size limit is 512 MB as established by #4350. This change increases that limit to  1024 MB. As a result, games that previously worked before #4350 was merged are playable again. The River City Girls Zero menu still renders correctly after this change.

Affects **resolution mods** for many titles that target higher resolutions than 1080p (more often 4K mods).
Tested and fixed games include but are not limited to:

Baten Kaitos I & II HD Remaster (fixes performance)
Demon Slayer: Kimetsu no Yaiba (fixes performance)
Prince of Persia: The Lost Crown (fixes crash on the map)
Princess Peach: Showtime Demo (fixes performance)
Star Ocean The Second Story R (fixes crash)
The Legend of Zelda: Tears of the Kingdom (fixes performance)

Thanks to @GamerzHell9137 and @OldManKain for bringing the issue to my attention.

![image](https://github.com/Ryujinx/Ryujinx/assets/29932943/76060381-0e32-4c47-8019-ec89066b4d52)