### PR TITLE
Add the option to close Ryujinx on emulation stop

### DIFF
--- a/src/Ryujinx.Gtk3/UI/MainWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/MainWindow.cs
@@ -1,4 +1,3 @@
-using Avalonia.Controls;
 using Gtk;
 using LibHac.Common;
 using LibHac.Common.Keys;
@@ -1444,18 +1443,7 @@ namespace Ryujinx.UI
             _resumeEmulation.Sensitive = false;
             UpdateMenuItem.Sensitive = true;
 
-            Logger.Warning?.Print(LogClass.Emulation, "afgadfgasgfgsjhfgdsjfgds" + ConfigurationState.Instance.CloseOnEmulatorStop.Value);
-            //Shutdown if "Close Ryujinx on Emulator Stop" is enabled
-            if (ConfigurationState.Instance.CloseOnEmulatorStop.Value)
-            {
-                Logger.Warning?.Print(LogClass.Emulation, "Shut Ryujinx down" + ConfigurationState.Instance.CloseOnEmulatorStop.Value);
-                UserControl.CloseWindow();
-            }
-            else
-            {
-                Logger.Warning?.Print(LogClass.Emulation, "Don't shut Ryujinx down" + ConfigurationState.Instance.CloseOnEmulatorStop.Value);
-                RendererWidget?.Exit();
-            }
+            RendererWidget?.Exit();
         }
 
         private void PauseEmulation_Pressed(object sender, EventArgs args)
@@ -1464,7 +1452,7 @@ namespace Ryujinx.UI
             _resumeEmulation.Sensitive = true;
             _emulationContext.System.TogglePauseEmulation(true);
             Title = TitleHelper.ActiveApplicationTitle(_emulationContext.Processes.ActiveApplication, Program.Version, "Paused");
-            Logger.Info?.Print(LogClass.Emulation, "Emulation was dinkleberry");
+            Logger.Info?.Print(LogClass.Emulation, "Emulation was paused");
         }
 
         private void ResumeEmulation_Pressed(object sender, EventArgs args)

--- a/src/Ryujinx.Gtk3/UI/MainWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/MainWindow.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Gtk;
 using LibHac.Common;
 using LibHac.Common.Keys;
@@ -1442,7 +1443,19 @@ namespace Ryujinx.UI
             _pauseEmulation.Sensitive = false;
             _resumeEmulation.Sensitive = false;
             UpdateMenuItem.Sensitive = true;
-            RendererWidget?.Exit();
+
+            Logger.Warning?.Print(LogClass.Emulation, "afgadfgasgfgsjhfgdsjfgds" + ConfigurationState.Instance.CloseOnEmulatorStop.Value);
+            //Shutdown if "Close Ryujinx on Emulator Stop" is enabled
+            if (ConfigurationState.Instance.CloseOnEmulatorStop.Value)
+            {
+                Logger.Warning?.Print(LogClass.Emulation, "Shut Ryujinx down" + ConfigurationState.Instance.CloseOnEmulatorStop.Value);
+                UserControl.CloseWindow();
+            }
+            else
+            {
+                Logger.Warning?.Print(LogClass.Emulation, "Don't shut Ryujinx down" + ConfigurationState.Instance.CloseOnEmulatorStop.Value);
+                RendererWidget?.Exit();
+            }
         }
 
         private void PauseEmulation_Pressed(object sender, EventArgs args)
@@ -1451,7 +1464,7 @@ namespace Ryujinx.UI
             _resumeEmulation.Sensitive = true;
             _emulationContext.System.TogglePauseEmulation(true);
             Title = TitleHelper.ActiveApplicationTitle(_emulationContext.Processes.ActiveApplication, Program.Version, "Paused");
-            Logger.Info?.Print(LogClass.Emulation, "Emulation was paused");
+            Logger.Info?.Print(LogClass.Emulation, "Emulation was dinkleberry");
         }
 
         private void ResumeEmulation_Pressed(object sender, EventArgs args)

--- a/src/Ryujinx.Gtk3/UI/MainWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/MainWindow.cs
@@ -1442,7 +1442,6 @@ namespace Ryujinx.UI
             _pauseEmulation.Sensitive = false;
             _resumeEmulation.Sensitive = false;
             UpdateMenuItem.Sensitive = true;
-
             RendererWidget?.Exit();
         }
 

--- a/src/Ryujinx.Gtk3/UI/Windows/SettingsWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/SettingsWindow.cs
@@ -53,6 +53,7 @@ namespace Ryujinx.UI.Windows
         [GUI] CheckButton _discordToggle;
         [GUI] CheckButton _checkUpdatesToggle;
         [GUI] CheckButton _showConfirmExitToggle;
+        [GUI] CheckButton _closeOnEmulatorStopToggle;
         [GUI] RadioButton _hideCursorNever;
         [GUI] RadioButton _hideCursorOnIdle;
         [GUI] RadioButton _hideCursorAlways;
@@ -228,6 +229,11 @@ namespace Ryujinx.UI.Windows
             if (ConfigurationState.Instance.ShowConfirmExit)
             {
                 _showConfirmExitToggle.Click();
+            }
+
+            if (ConfigurationState.Instance.CloseOnEmulatorStop)
+            {
+                _closeOnEmulatorStopToggle.Click();
             }
 
             switch (ConfigurationState.Instance.HideCursor.Value)
@@ -627,6 +633,7 @@ namespace Ryujinx.UI.Windows
             ConfigurationState.Instance.EnableDiscordIntegration.Value = _discordToggle.Active;
             ConfigurationState.Instance.CheckUpdatesOnStart.Value = _checkUpdatesToggle.Active;
             ConfigurationState.Instance.ShowConfirmExit.Value = _showConfirmExitToggle.Active;
+            ConfigurationState.Instance.CloseOnEmulatorStop.Value = _closeOnEmulatorStopToggle.Active;
             ConfigurationState.Instance.HideCursor.Value = hideCursor;
             ConfigurationState.Instance.Graphics.EnableVsync.Value = _vSyncToggle.Active;
             ConfigurationState.Instance.Graphics.EnableShaderCache.Value = _shaderCacheToggle.Active;

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -1,4 +1,3 @@
-using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Multiplayer;

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Multiplayer;
@@ -161,6 +162,11 @@ namespace Ryujinx.UI.Common.Configuration
         /// Show "Confirm Exit" Dialog
         /// </summary>
         public bool ShowConfirmExit { get; set; }
+
+        /// <summary>
+        /// Close Ryujinx on Emulator Stop
+        /// </summary>
+        public bool CloseOnEmulatorStop { get; set; }
 
         /// <summary>
         /// Whether to hide cursor on idle, always or never

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -627,6 +627,11 @@ namespace Ryujinx.UI.Common.Configuration
         public ReactiveObject<bool> ShowConfirmExit { get; private set; }
 
         /// <summary>
+        /// Close Ryujinx on Emulator Stop
+        /// </summary>
+        public ReactiveObject<bool> CloseOnEmulatorStop { get; private set; }
+
+        /// <summary>
         /// Hide Cursor on Idle
         /// </summary>
         public ReactiveObject<HideCursorMode> HideCursor { get; private set; }
@@ -642,6 +647,7 @@ namespace Ryujinx.UI.Common.Configuration
             EnableDiscordIntegration = new ReactiveObject<bool>();
             CheckUpdatesOnStart = new ReactiveObject<bool>();
             ShowConfirmExit = new ReactiveObject<bool>();
+            CloseOnEmulatorStop = new ReactiveObject<bool>();
             HideCursor = new ReactiveObject<HideCursorMode>();
         }
 
@@ -678,6 +684,7 @@ namespace Ryujinx.UI.Common.Configuration
                 EnableDiscordIntegration = EnableDiscordIntegration,
                 CheckUpdatesOnStart = CheckUpdatesOnStart,
                 ShowConfirmExit = ShowConfirmExit,
+                CloseOnEmulatorStop = CloseOnEmulatorStop,
                 HideCursor = HideCursor,
                 EnableVsync = Graphics.EnableVsync,
                 EnableShaderCache = Graphics.EnableShaderCache,
@@ -785,6 +792,7 @@ namespace Ryujinx.UI.Common.Configuration
             EnableDiscordIntegration.Value = true;
             CheckUpdatesOnStart.Value = true;
             ShowConfirmExit.Value = true;
+            CloseOnEmulatorStop.Value = false;
             HideCursor.Value = HideCursorMode.OnIdle;
             Graphics.EnableVsync.Value = true;
             Graphics.EnableShaderCache.Value = true;
@@ -1055,6 +1063,8 @@ namespace Ryujinx.UI.Common.Configuration
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 20.");
 
                 configurationFileFormat.ShowConfirmExit = true;
+
+                configurationFileFormat.CloseOnEmulatorStop = false;
 
                 configurationFileUpdated = true;
             }
@@ -1472,6 +1482,7 @@ namespace Ryujinx.UI.Common.Configuration
             EnableDiscordIntegration.Value = configurationFileFormat.EnableDiscordIntegration;
             CheckUpdatesOnStart.Value = configurationFileFormat.CheckUpdatesOnStart;
             ShowConfirmExit.Value = configurationFileFormat.ShowConfirmExit;
+            CloseOnEmulatorStop.Value = configurationFileFormat.CloseOnEmulatorStop;
             HideCursor.Value = configurationFileFormat.HideCursor;
             Graphics.EnableVsync.Value = configurationFileFormat.EnableVsync;
             Graphics.EnableShaderCache.Value = configurationFileFormat.EnableShaderCache;

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -1004,7 +1004,16 @@ namespace Ryujinx.Ava
 
             if (shouldExit)
             {
-                Stop();
+                //if (ConfigurationState.Instance.CloseOnEmulatorStop)
+                //{
+                   // Console.WriteLine("quitting");
+                    //Console.WriteLine("still quitting");
+                //}
+                //else
+                //{
+                    Stop();
+                //}
+                
             }
         }
 

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -1006,8 +1006,6 @@ namespace Ryujinx.Ava
             {
                 if (ConfigurationState.Instance.CloseOnEmulatorStop)
                 {
-                    Console.WriteLine("quitting");
-                    Console.WriteLine("still quitting");
                     if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime app)
                     {
                         app.MainWindow.Close();

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -1008,6 +1008,10 @@ namespace Ryujinx.Ava
                 {
                     Console.WriteLine("quitting");
                     Console.WriteLine("still quitting");
+                    if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime app)
+                    {
+                        app.MainWindow.Close();
+                    }
                 }
                 else
                 {

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -736,6 +736,14 @@ namespace Ryujinx.Ava
             Logger.Info?.Print(LogClass.Emulation, "Emulation was paused");
         }
 
+        internal void Close()
+        {
+            if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime app)
+            {
+                app.MainWindow.Close();
+            }
+        }
+
         private void InitializeSwitchInstance()
         {
             // Initialize KeySet.
@@ -1006,10 +1014,7 @@ namespace Ryujinx.Ava
             {
                 if (ConfigurationState.Instance.CloseOnEmulatorStop)
                 {
-                    if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime app)
-                    {
-                        app.MainWindow.Close();
-                    }
+                    Close();
                 }
                 else
                 {

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -1004,16 +1004,16 @@ namespace Ryujinx.Ava
 
             if (shouldExit)
             {
-                //if (ConfigurationState.Instance.CloseOnEmulatorStop)
-                //{
-                   // Console.WriteLine("quitting");
-                    //Console.WriteLine("still quitting");
-                //}
-                //else
-                //{
+                if (ConfigurationState.Instance.CloseOnEmulatorStop)
+                {
+                    Console.WriteLine("quitting");
+                    Console.WriteLine("still quitting");
+                }
+                else
+                {
                     Stop();
-                //}
-                
+                }
+
             }
         }
 

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -92,6 +92,7 @@
   "SettingsTabGeneralEnableDiscordRichPresence": "Enable Discord Rich Presence",
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Check for Updates on Launch",
   "SettingsTabGeneralShowConfirmExitDialog": "Show \"Confirm Exit\" Dialog",
+  "SettingsTabGeneralCloseOnEmulatorStop": "Close Ryujinx on Emulator Stop",
   "SettingsTabGeneralHideCursor": "Hide Cursor:",
   "SettingsTabGeneralHideCursorNever": "Never",
   "SettingsTabGeneralHideCursorOnIdle": "On Idle",

--- a/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
@@ -132,6 +132,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool EnableDiscordIntegration { get; set; }
         public bool CheckUpdatesOnStart { get; set; }
         public bool ShowConfirmExit { get; set; }
+        public bool CloseOnEmulatorStop { get; set; }
         public int HideCursor { get; set; }
         public bool EnableDockedMode { get; set; }
         public bool EnableKeyboard { get; set; }
@@ -405,6 +406,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             EnableDiscordIntegration = config.EnableDiscordIntegration;
             CheckUpdatesOnStart = config.CheckUpdatesOnStart;
             ShowConfirmExit = config.ShowConfirmExit;
+            CloseOnEmulatorStop = config.CloseOnEmulatorStop;
             HideCursor = (int)config.HideCursor.Value;
 
             GameDirectories.Clear();
@@ -489,6 +491,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             config.EnableDiscordIntegration.Value = EnableDiscordIntegration;
             config.CheckUpdatesOnStart.Value = CheckUpdatesOnStart;
             config.ShowConfirmExit.Value = ShowConfirmExit;
+            config.CloseOnEmulatorStop.Value = CloseOnEmulatorStop;
             config.HideCursor.Value = (HideCursorMode)HideCursor;
 
             if (_directoryChanged)

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Ryujinx.Ava.UI.Views.Settings.SettingsUiView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -35,6 +35,9 @@
                     </CheckBox>
                     <CheckBox IsChecked="{Binding ShowConfirmExit}">
                         <TextBlock Text="{locale:Locale SettingsTabGeneralShowConfirmExitDialog}" />
+                    </CheckBox>
+                    <CheckBox IsChecked="{Binding CloseOnEmulatorStop}">
+                        <TextBlock Text="{locale:Locale SettingsTabGeneralCloseOnEmulatorStop}" />
                     </CheckBox>
                     <StackPanel Margin="0, 15, 0, 0" Orientation="Horizontal">
                         <TextBlock VerticalAlignment="Center"

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
@@ -1,4 +1,4 @@
-<UserControl 
+<UserControl
     x:Class="Ryujinx.Ava.UI.Views.Settings.SettingsUiView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
@@ -1,4 +1,4 @@
-<UserControl
+<UserControl 
     x:Class="Ryujinx.Ava.UI.Views.Settings.SettingsUiView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"


### PR DESCRIPTION
(Addressing Issue #4929)

Updated settings UI
![image](https://github.com/Ryujinx/Ryujinx/assets/134745254/0511c5cd-a850-42fa-9b46-4916e434b00a)

This will also make it easier for handheld console users who could now just have a button mapped to ESC and close Ryujinx that way.