### PR TITLE
Ava UI: Content Dialog Fixes

### DIFF
--- a/src/Ryujinx/UI/Windows/ContentDialogOverlayWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/ContentDialogOverlayWindow.axaml.cs
@@ -9,7 +9,6 @@ namespace Ryujinx.Ava.UI.Windows
         {
             InitializeComponent();
 
-            ExtendClientAreaToDecorationsHint = true;
             TransparencyLevelHint = new[] { WindowTransparencyLevel.Transparent };
             WindowStartupLocation = WindowStartupLocation.Manual;
             SystemDecorations = SystemDecorations.None;

--- a/src/Ryujinx/UI/Windows/DownloadableContentManagerWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/DownloadableContentManagerWindow.axaml.cs
@@ -47,7 +47,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             contentDialog.Styles.Add(bottomBorder);
 
-            await ContentDialogHelper.ShowAsync(contentDialog);
+            await contentDialog.ShowAsync();
         }
 
         private void SaveAndClose(object sender, RoutedEventArgs routedEventArgs)

--- a/src/Ryujinx/UI/Windows/TitleUpdateWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/TitleUpdateWindow.axaml.cs
@@ -47,7 +47,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             contentDialog.Styles.Add(bottomBorder);
 
-            await ContentDialogHelper.ShowAsync(contentDialog);
+            await contentDialog.ShowAsync();
         }
 
         private void Close(object sender, RoutedEventArgs e)


### PR DESCRIPTION
`ContentDialogHelper` is used when a dialogue needs to be displayed as an external window. This is necessary when it should be shown over the embedded window, like the quit dialogue or the about window.

This PR removes `ContentDialogHelper` uses in the DLC manager and title update manager, as both cannot be opened while the game is open, so there is no risk of a soft lock.

This PR also removes `ExtendClientAreaToDecorationsHint` in `ContentDialogOverlayWindow`, which was responsible for this annoying error on macOS:
`ERROR: Can't have a toolbar in a window with <NSNextStepFrame: 0x4835f5670> as its borderView`