### PR TITLE
Consider Polygon as unsupported if triangle fans are unsupported on Vulkan

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -781,7 +781,9 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 PrimitiveTopology.Quads => PrimitiveTopology.Triangles,
                 PrimitiveTopology.QuadStrip => PrimitiveTopology.TriangleStrip,
-                PrimitiveTopology.TriangleFan => Capabilities.PortabilitySubset.HasFlag(PortabilitySubsetFlags.NoTriangleFans) ? PrimitiveTopology.Triangles : topology,
+                PrimitiveTopology.TriangleFan or PrimitiveTopology.Polygon => Capabilities.PortabilitySubset.HasFlag(PortabilitySubsetFlags.NoTriangleFans)
+                    ? PrimitiveTopology.Triangles
+                    : topology,
                 _ => topology,
             };
         }
@@ -791,7 +793,7 @@ namespace Ryujinx.Graphics.Vulkan
             return topology switch
             {
                 PrimitiveTopology.Quads => true,
-                PrimitiveTopology.TriangleFan => Capabilities.PortabilitySubset.HasFlag(PortabilitySubsetFlags.NoTriangleFans),
+                PrimitiveTopology.TriangleFan or PrimitiveTopology.Polygon => Capabilities.PortabilitySubset.HasFlag(PortabilitySubsetFlags.NoTriangleFans),
                 _ => false,
             };
         }


### PR DESCRIPTION
On Vulkan (and OpenGL) backends, the Polygon primitve topology is implemented with trinagle fans. Since macOS does not support triangle fans, we need to do the same conversion that we would do for triangle fans if the Polygon topology is used. This change updates `TopologyUnsupported` to consider the `Polygon` topology as unsupported too, and updates `TopologyRemap` to "remap" it.

This fixes an error I noticed while testing Penny's Big Breakaway on macOS (game is still not playable without other changes), Should also fix the same things fixed by #3932 on macOS in theory.