### PR TITLE
Ava UI: Prevent Status Bar Backend Update

### DIFF
--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -969,7 +969,12 @@ namespace Ryujinx.Ava
         public void InitStatus()
         {
             StatusInitEvent?.Invoke(this, new StatusInitEventArgs(
-                ConfigurationState.Instance.Graphics.GraphicsBackend.Value == GraphicsBackend.Vulkan ? "Vulkan" : "OpenGL",
+                ConfigurationState.Instance.Graphics.GraphicsBackend.Value switch
+                {
+                    GraphicsBackend.Vulkan => "Vulkan",
+                    GraphicsBackend.OpenGl => "OpenGL",
+                    _ => throw new NotImplementedException()
+                },
                 $"GPU: {_renderer.GetHardwareInfo().GpuDriver}"));
         }
 

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -112,6 +112,7 @@ namespace Ryujinx.Ava
         private readonly object _lockObject = new();
 
         public event EventHandler AppExit;
+        public event EventHandler<StatusInitEventArgs> StatusInitEvent;
         public event EventHandler<StatusUpdatedEventArgs> StatusUpdatedEvent;
 
         public VirtualFileSystem VirtualFileSystem { get; }
@@ -941,6 +942,7 @@ namespace Ryujinx.Ava
                         {
                             _renderingStarted = true;
                             _viewModel.SwitchToRenderer(false);
+                            InitStatus();
                         }
 
                         Device.PresentFrame(() => (RendererHost.EmbeddedWindow as EmbeddedWindowOpenGL)?.SwapBuffers());
@@ -964,6 +966,13 @@ namespace Ryujinx.Ava
             (RendererHost.EmbeddedWindow as EmbeddedWindowOpenGL)?.MakeCurrent(true);
         }
 
+        public void InitStatus()
+        {
+            StatusInitEvent?.Invoke(this, new StatusInitEventArgs(
+                ConfigurationState.Instance.Graphics.GraphicsBackend.Value == GraphicsBackend.Vulkan ? "Vulkan" : "OpenGL",
+                $"GPU: {_renderer.GetHardwareInfo().GpuDriver}"));
+        }
+
         public void UpdateStatus()
         {
             // Run a status update only when a frame is to be drawn. This prevents from updating the ui and wasting a render when no frame is queued.
@@ -977,12 +986,10 @@ namespace Ryujinx.Ava
             StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                 Device.EnableDeviceVsync,
                 LocaleManager.Instance[LocaleKeys.VolumeShort] + $": {(int)(Device.GetVolume() * 100)}%",
-                ConfigurationState.Instance.Graphics.GraphicsBackend.Value == GraphicsBackend.Vulkan ? "Vulkan" : "OpenGL",
                 dockedMode,
                 ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                 LocaleManager.Instance[LocaleKeys.Game] + $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
-                $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %",
-                $"GPU: {_renderer.GetHardwareInfo().GpuDriver}"));
+                $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %"));
         }
 
         public async Task ShowExitPrompt()

--- a/src/Ryujinx/UI/Models/StatusInitEventArgs.cs
+++ b/src/Ryujinx/UI/Models/StatusInitEventArgs.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Ryujinx.Ava.UI.Models
+{
+    internal class StatusInitEventArgs : EventArgs
+    {
+        public string GpuBackend { get; }
+        public string GpuName { get; }
+
+        public StatusInitEventArgs(string gpuBackend, string gpuName)
+        {
+            GpuBackend = gpuBackend;
+            GpuName = gpuName;
+        }
+    }
+}

--- a/src/Ryujinx/UI/Models/StatusUpdatedEventArgs.cs
+++ b/src/Ryujinx/UI/Models/StatusUpdatedEventArgs.cs
@@ -6,23 +6,19 @@ namespace Ryujinx.Ava.UI.Models
     {
         public bool VSyncEnabled { get; }
         public string VolumeStatus { get; }
-        public string GpuBackend { get; }
         public string AspectRatio { get; }
         public string DockedMode { get; }
         public string FifoStatus { get; }
         public string GameStatus { get; }
-        public string GpuName { get; }
 
-        public StatusUpdatedEventArgs(bool vSyncEnabled, string volumeStatus, string gpuBackend, string dockedMode, string aspectRatio, string gameStatus, string fifoStatus, string gpuName)
+        public StatusUpdatedEventArgs(bool vSyncEnabled, string volumeStatus, string dockedMode, string aspectRatio, string gameStatus, string fifoStatus)
         {
             VSyncEnabled = vSyncEnabled;
             VolumeStatus = volumeStatus;
-            GpuBackend = gpuBackend;
             DockedMode = dockedMode;
             AspectRatio = aspectRatio;
             GameStatus = gameStatus;
             FifoStatus = fifoStatus;
-            GpuName = gpuName;
         }
     }
 }

--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -1164,6 +1164,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             RendererHostControl.WindowCreated += RendererHost_Created;
 
+            AppHost.StatusInitEvent += Init_StatusBar;
             AppHost.StatusUpdatedEvent += Update_StatusBar;
             AppHost.AppExit += AppHost_AppExit;
 
@@ -1190,6 +1191,18 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
         }
 
+        private void Init_StatusBar(object sender, StatusInitEventArgs args)
+        {
+            if (ShowMenuAndStatusBar && !ShowLoadProgress)
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    GpuNameText = args.GpuName;
+                    BackendText = args.GpuBackend;
+                });
+            }
+        }
+
         private void Update_StatusBar(object sender, StatusUpdatedEventArgs args)
         {
             if (ShowMenuAndStatusBar && !ShowLoadProgress)
@@ -1212,8 +1225,6 @@ namespace Ryujinx.Ava.UI.ViewModels
                     GameStatusText = args.GameStatus;
                     VolumeStatusText = args.VolumeStatus;
                     FifoStatusText = args.FifoStatus;
-                    GpuNameText = args.GpuName;
-                    BackendText = args.GpuBackend;
 
                     ShowStatusSeparator = true;
                 });


### PR DESCRIPTION
This prevents the status bar from changing the displayed backend and GPU while a game has already started.