### PR TITLE
Ava UI: Fix Title Update Manager not refreshing app list

### DIFF
--- a/src/Ryujinx/UI/Windows/TitleUpdateWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/TitleUpdateWindow.axaml.cs
@@ -1,4 +1,6 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
 using Avalonia.Styling;
 using FluentAvalonia.UI.Controls;
@@ -59,9 +61,15 @@ namespace Ryujinx.Ava.UI.Windows
         {
             ViewModel.Save();
 
-            if (VisualRoot is MainWindow window)
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime al)
             {
-                window.LoadApplications();
+                foreach (Window window in al.Windows)
+                {
+                    if (window is MainWindow mainWindow)
+                    {
+                        mainWindow.LoadApplications();
+                    }
+                }
             }
 
             ((ContentDialog)Parent).Hide();


### PR DESCRIPTION
Fixes the title update manager, who fails to find the main window and is unable to refresh the application list. This would leave the selected title update version visual unchanged.