### PR TITLE
Vulkan: Skip draws for patches topology without a tessellation shader

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -981,6 +981,7 @@ namespace Ryujinx.Graphics.Vulkan
             _bindingBarriersDirty = true;
 
             _newState.PipelineLayout = internalProgram.PipelineLayout;
+            _newState.HasTessellationControlShader = internalProgram.HasTessellationControlShader;
             _newState.StagesCount = (uint)stages.Length;
 
             stages.CopyTo(_newState.Stages.AsSpan()[..stages.Length]);

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -21,6 +21,7 @@ namespace Ryujinx.Graphics.Vulkan
         public bool HasMinimalLayout { get; }
         public bool UsePushDescriptors { get; }
         public bool IsCompute { get; }
+        public bool HasTessellationControlShader => (Stages & (1u << 3)) != 0;
 
         public uint Stages { get; }
 
@@ -455,6 +456,7 @@ namespace Ryujinx.Graphics.Vulkan
                 stages[i] = _shaders[i].GetInfo();
             }
 
+            pipeline.HasTessellationControlShader = HasTessellationControlShader;
             pipeline.StagesCount = (uint)_shaders.Length;
             pipeline.PipelineLayout = PipelineLayout;
 


### PR DESCRIPTION
Drawing using patches topology without a tessellation shader is invalid according to the Vulkan spec. It crashes on AMD, I'm not sure what the behaviour is on NVIDIA, but it does not crash.

This change skips draws if topology is patches and there's no tessellation control shader.

It fixes a crash on Luigi's Mansion 3 on the floor with sand.
Before:

https://github.com/Ryujinx/Ryujinx/assets/5624669/db9cc165-5a34-42b8-a29b-a66a8b52a633

After:

https://github.com/Ryujinx/Ryujinx/assets/5624669/398e5298-5a63-4b29-9b29-cf41c6fdfb3d

The black triangle flickering seems to be caused by the fact that it only writes `gl_TessOuterLevel` when `gl_InvocationID` is 0 (instead of doing so for all of them). It seems a bit more complicated to fix.
