### PR TITLE
Vulkan: Fix swapchain image view leak

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
@@ -122,7 +122,6 @@ namespace Ryujinx.Graphics.Vulkan
 
                 gd.Api.CreateRenderPass(device, renderPassCreateInfo, null, out var renderPass).ThrowOnError();
 
-                _renderPass?.Dispose();
                 _renderPass = new Auto<DisposableRenderPass>(new DisposableRenderPass(gd.Api, device, renderPass));
             }
 
@@ -162,7 +161,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Dispose()
         {
-            // Dispose all framebuffers
+            // Dispose all framebuffers.
 
             foreach (var fb in _framebuffers.Values)
             {
@@ -175,6 +174,10 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 texture.RemoveRenderPass(_key);
             }
+
+            // Dispose render pass.
+
+            _renderPass.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes two regressions from #6182.

- Render passes were never being disposed, causing a render pass leak.
- Swapchain image views were not disposed due to the `_gd.Textures.Remove(this)` check. Those textures are never added to the textures set, so that would be always false preventing them from being disposed.

Might be worth some testing since the fact that the render pass was not disposed before could be hiding some bugs.