### PR TITLE
misc: Add ANGLE configuration option to JSON and CLI

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.UI.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 49;
+        public const int CurrentVersion = 50;
 
         /// <summary>
         /// Version of the configuration file format
@@ -161,6 +161,11 @@ namespace Ryujinx.UI.Common.Configuration
         /// Show "Confirm Exit" Dialog
         /// </summary>
         public bool ShowConfirmExit { get; set; }
+
+        /// <summary>
+        /// Checks for updates when Ryujinx starts when enabled
+        /// </summary>
+        public bool EnableHardwareAcceleration { get; set; }
 
         /// <summary>
         /// Whether to hide cursor on idle, always or never

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.UI.Common.Configuration
         public bool ShowConfirmExit { get; set; }
 
         /// <summary>
-        /// Checks for updates when Ryujinx starts when enabled
+        /// Enables ANGLE hardware-accelerated rendering for Avalonia
         /// </summary>
         public bool EnableHardwareAcceleration { get; set; }
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.UI.Common.Configuration
         public bool ShowConfirmExit { get; set; }
 
         /// <summary>
-        /// Enables ANGLE hardware-accelerated rendering for Avalonia
+        /// Enables hardware-accelerated rendering for Avalonia
         /// </summary>
         public bool EnableHardwareAcceleration { get; set; }
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -627,7 +627,7 @@ namespace Ryujinx.UI.Common.Configuration
         public ReactiveObject<bool> ShowConfirmExit { get; private set; }
 
         /// <summary>
-        /// Enables ANGLE hardware-accelerated rendering for Avalonia
+        /// Enables hardware-accelerated rendering for Avalonia
         /// </summary>
         public ReactiveObject<bool> EnableHardwareAcceleration { get; private set; }
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -627,6 +627,11 @@ namespace Ryujinx.UI.Common.Configuration
         public ReactiveObject<bool> ShowConfirmExit { get; private set; }
 
         /// <summary>
+        /// Enables ANGLE hardware-accelerated rendering for Avalonia
+        /// </summary>
+        public ReactiveObject<bool> EnableHardwareAcceleration { get; private set; }
+
+        /// <summary>
         /// Hide Cursor on Idle
         /// </summary>
         public ReactiveObject<HideCursorMode> HideCursor { get; private set; }
@@ -642,6 +647,7 @@ namespace Ryujinx.UI.Common.Configuration
             EnableDiscordIntegration = new ReactiveObject<bool>();
             CheckUpdatesOnStart = new ReactiveObject<bool>();
             ShowConfirmExit = new ReactiveObject<bool>();
+            EnableHardwareAcceleration = new ReactiveObject<bool>();
             HideCursor = new ReactiveObject<HideCursorMode>();
         }
 
@@ -678,6 +684,7 @@ namespace Ryujinx.UI.Common.Configuration
                 EnableDiscordIntegration = EnableDiscordIntegration,
                 CheckUpdatesOnStart = CheckUpdatesOnStart,
                 ShowConfirmExit = ShowConfirmExit,
+                EnableHardwareAcceleration = EnableHardwareAcceleration,
                 HideCursor = HideCursor,
                 EnableVsync = Graphics.EnableVsync,
                 EnableShaderCache = Graphics.EnableShaderCache,
@@ -785,6 +792,7 @@ namespace Ryujinx.UI.Common.Configuration
             EnableDiscordIntegration.Value = true;
             CheckUpdatesOnStart.Value = true;
             ShowConfirmExit.Value = true;
+            EnableHardwareAcceleration.Value = true;
             HideCursor.Value = HideCursorMode.OnIdle;
             Graphics.EnableVsync.Value = true;
             Graphics.EnableShaderCache.Value = true;
@@ -1442,6 +1450,15 @@ namespace Ryujinx.UI.Common.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 50)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 50.");
+
+                configurationFileFormat.EnableHardwareAcceleration = true;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value = configurationFileFormat.ResScaleCustom;
@@ -1472,6 +1489,7 @@ namespace Ryujinx.UI.Common.Configuration
             EnableDiscordIntegration.Value = configurationFileFormat.EnableDiscordIntegration;
             CheckUpdatesOnStart.Value = configurationFileFormat.CheckUpdatesOnStart;
             ShowConfirmExit.Value = configurationFileFormat.ShowConfirmExit;
+            EnableHardwareAcceleration.Value = configurationFileFormat.EnableHardwareAcceleration;
             HideCursor.Value = configurationFileFormat.HideCursor;
             Graphics.EnableVsync.Value = configurationFileFormat.EnableVsync;
             Graphics.EnableShaderCache.Value = configurationFileFormat.EnableShaderCache;

--- a/src/Ryujinx.UI.Common/Helper/CommandLineState.cs
+++ b/src/Ryujinx.UI.Common/Helper/CommandLineState.cs
@@ -88,7 +88,10 @@ namespace Ryujinx.UI.Common.Helper
 
                         OverrideHideCursor = args[++i];
                         break;
-                    case "--disable-angle":
+                    case "--software-gui":
+                        OverrideHardwareAcceleration = false;
+                        break;
+                    case "--hardware-gui":
                         OverrideHardwareAcceleration = true;
                         break;
                     default:

--- a/src/Ryujinx.UI.Common/Helper/CommandLineState.cs
+++ b/src/Ryujinx.UI.Common/Helper/CommandLineState.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.UI.Common.Helper
         public static string[] Arguments { get; private set; }
 
         public static bool? OverrideDockedMode { get; private set; }
+        public static bool? OverrideHardwareAcceleration { get; private set; }
         public static string OverrideGraphicsBackend { get; private set; }
         public static string OverrideHideCursor { get; private set; }
         public static string BaseDirPathArg { get; private set; }
@@ -86,6 +87,9 @@ namespace Ryujinx.UI.Common.Helper
                         }
 
                         OverrideHideCursor = args[++i];
+                        break;
+                    case "--disable-angle":
+                        OverrideHardwareAcceleration = true;
                         break;
                     default:
                         LaunchPathArg = arg;

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -195,9 +195,9 @@ namespace Ryujinx.Ava
             }
 
             // Check if hardware-acceleration was overridden.
-            if (CommandLineState.OverrideHardwareAcceleration == true)
+            if (CommandLineState.OverrideHardwareAcceleration != null)
             {
-                ConfigurationState.Instance.EnableHardwareAcceleration.Value = false;
+                ConfigurationState.Instance.EnableHardwareAcceleration.Value = CommandLineState.OverrideHardwareAcceleration.Value;
             }
         }
 

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -65,8 +65,8 @@ namespace Ryujinx.Ava
                 .With(new Win32PlatformOptions
                 {
                     WinUICompositionBackdropCornerRadius = 8.0f,
-                    RenderingMode = ConfigurationState.Instance.EnableHardwareAcceleration ? 
-                        new[] { Win32RenderingMode.AngleEgl, Win32RenderingMode.Software } : 
+                    RenderingMode = ConfigurationState.Instance.EnableHardwareAcceleration ?
+                        new[] { Win32RenderingMode.AngleEgl, Win32RenderingMode.Software } :
                         new[] { Win32RenderingMode.Software },
                 })
                 .UseSkia();

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -193,6 +193,12 @@ namespace Ryujinx.Ava
                     _ => ConfigurationState.Instance.HideCursor.Value,
                 };
             }
+
+            // Check if hardware-acceleration was overridden.
+            if (CommandLineState.OverrideHardwareAcceleration == true)
+            {
+                ConfigurationState.Instance.EnableHardwareAcceleration.Value = false;
+            }
         }
 
         private static void PrintSystemInfo()

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -65,7 +65,9 @@ namespace Ryujinx.Ava
                 .With(new Win32PlatformOptions
                 {
                     WinUICompositionBackdropCornerRadius = 8.0f,
-                    RenderingMode = new[] { Win32RenderingMode.AngleEgl, Win32RenderingMode.Software },
+                    RenderingMode = ConfigurationState.Instance.EnableHardwareAcceleration ? 
+                        new[] { Win32RenderingMode.AngleEgl, Win32RenderingMode.Software } : 
+                        new[] { Win32RenderingMode.Software },
                 })
                 .UseSkia();
         }

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -60,7 +60,9 @@ namespace Ryujinx.Ava
                     EnableMultiTouch = true,
                     EnableIme = true,
                     EnableInputFocusProxy = Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP") == "gamescope",
-                    RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Software },
+                    RenderingMode = ConfigurationState.Instance.EnableHardwareAcceleration ?
+                        new[] { X11RenderingMode.Glx, X11RenderingMode.Software } :
+                        new[] { X11RenderingMode.Software },
                 })
                 .With(new Win32PlatformOptions
                 {


### PR DESCRIPTION
Adds a configuration option to disable hardware-accelerated rendering for Avalonia which can also be triggered via the CLI.
`--software-gui` = Avalonia will use software rendering.
`--hardware-gui` = Avalonia will use ANGLE/GLX rendering.

Not intended to be a user facing change (hence no GUI toggle), but should make it easier to access for those that need it and CLI arguments in renderdoc etc.
![image](https://github.com/Ryujinx/Ryujinx/assets/44103205/59360a52-b7cc-4b46-b651-acd16eb1ce69)

Will obviously break stuff like transparency and performance **will** be reduced with large window sizes.