### PR TITLE
Vulkan: Recreate swapchain correctly when toggling VSync

### DIFF
--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -420,6 +420,12 @@ namespace Ryujinx.Ava
             Device.Configuration.MultiplayerMode = e.NewValue;
         }
 
+        public void ToggleVSync()
+        {
+            Device.EnableDeviceVsync = !Device.EnableDeviceVsync;
+            _renderer.Window.ChangeVSyncMode(Device.EnableDeviceVsync);
+        }
+
         public void Stop()
         {
             _isActive = false;
@@ -1068,8 +1074,7 @@ namespace Ryujinx.Ava
                     switch (currentHotkeyState)
                     {
                         case KeyboardHotkeyState.ToggleVSync:
-                            Device.EnableDeviceVsync = !Device.EnableDeviceVsync;
-
+                            ToggleVSync();
                             break;
                         case KeyboardHotkeyState.Screenshot:
                             ScreenshotRequested = true;

--- a/src/Ryujinx/UI/Views/Main/MainStatusBarView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Main/MainStatusBarView.axaml.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.Ava.UI.Views.Main
 
         private void VsyncStatus_PointerReleased(object sender, PointerReleasedEventArgs e)
         {
-            Window.ViewModel.AppHost.Device.EnableDeviceVsync = !Window.ViewModel.AppHost.Device.EnableDeviceVsync;
+            Window.ViewModel.AppHost.ToggleVSync();
 
             Logger.Info?.Print(LogClass.Application, $"VSync toggled to: {Window.ViewModel.AppHost.Device.EnableDeviceVsync}");
         }


### PR DESCRIPTION
VSync toggling via hotkeys or the status bar has not been wired up to invalidate the swapchain in the Vulkan renderer window. This meant that, if the game was started with VSync on, and the player then toggled VSync off, the present mode would not be set to immediate, and FPS would (typically) be capped at host display refresh rate. Conversely if the game was started with VSync off, the present mode would be set to immediate, but could never be toggled to mailbox.

This PR creates a method in `AppHost.cs` that sets device VSync as well as calling the previously uncalled Vulkan Window `ChangeVSyncMode` toggle. Further, the hotkey toggle and the status bar toggle now call this new method instead of only directly changing the device VSync.