### PR TITLE
Disable push descriptors for Intel ARC GPUs on Windows

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -111,8 +111,8 @@ namespace Ryujinx.Graphics.Vulkan
             bool usePushDescriptors = !isMinimal &&
                 VulkanConfiguration.UsePushDescriptors &&
                 _gd.Capabilities.SupportsPushDescriptors &&
-                !_gd.IsNvidiaPreTuring &&
                 !IsCompute &&
+                !HasPushDescriptorsBug(gd) &&
                 CanUsePushDescriptors(gd, resourceLayout, IsCompute);
 
             ReadOnlyCollection<ResourceDescriptorCollection> sets = usePushDescriptors ?
@@ -145,6 +145,12 @@ namespace Ryujinx.Graphics.Vulkan
 
             _compileTask = BackgroundCompilation();
             _firstBackgroundUse = !fromCache;
+        }
+
+        private static bool HasPushDescriptorsBug(VulkanRenderer gd)
+        {
+            // Those GPUs/drivers do not work properly with push descriptors, so we must force disable them.
+            return gd.IsNvidiaPreTuring || (gd.IsIntelArc && gd.IsIntelWindows);
         }
 
         private static bool CanUsePushDescriptors(VulkanRenderer gd, ResourceLayout layout, bool isCompute)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -87,6 +87,7 @@ namespace Ryujinx.Graphics.Vulkan
         internal bool IsIntelWindows { get; private set; }
         internal bool IsAmdGcn { get; private set; }
         internal bool IsNvidiaPreTuring { get; private set; }
+        internal bool IsIntelArc { get; private set; }
         internal bool IsMoltenVk { get; private set; }
         internal bool IsTBDR { get; private set; }
         internal bool IsSharedMemory { get; private set; }
@@ -349,6 +350,10 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     IsNvidiaPreTuring = true;
                 }
+            }
+            else if (Vendor == Vendor.Intel)
+            {
+                IsIntelArc = GpuRenderer.StartsWith("Intel(R) Arc(TM)");
             }
 
             ulong minResourceAlignment = Math.Max(

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -801,11 +801,16 @@ namespace Ryujinx.Graphics.Vulkan
             };
         }
 
+        private void PrintGpuInformation()
+        {
+            Logger.Notice.Print(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
+        }
+
         public void Initialize(GraphicsDebugLevel logLevel)
         {
             SetupContext(logLevel);
 
-            Logger.Notice.Print(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
+            PrintGpuInformation();
         }
 
         internal bool NeedsVertexBufferAlignment(int attrScalarAlignment, out int alignment)


### PR DESCRIPTION
Apparently it is not working on those GPUs.

Additionally moves vendor information init logic out of the `PrintGpuInformation` method, since it does not make sense for that to be there, and it is actually a source of bugs (for example, `LoadFeatures` checks that `features2.Features.MultiViewport && !(IsMoltenVk && Vendor == Vendor.Amd)`, but `Vendor` has not been set at this point before this change, which means this condition will always be true, since Amd happens to have value 0 in the enum).

Fixes #6512.