### PR TITLE
Add a few missing locale strings on Avalonia

### DIFF
--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -648,6 +648,9 @@
   "GraphicsAALabel": "Anti-Aliasing:",
   "GraphicsScalingFilterLabel": "Scaling Filter:",
   "GraphicsScalingFilterTooltip": "Choose the scaling filter that will be applied when using resolution scale.\n\nBilinear works well for 3D games and is a safe default option.\n\nNearest is recommended for pixel art games.\n\nFSR 1.0 is merely a sharpening filter, not recommended for use with FXAA or SMAA.\n\nThis option can be changed while a game is running by clicking \"Apply\" below; you can simply move the settings window aside and experiment until you find your preferred look for a game.\n\nLeave on BILINEAR if unsure.",
+  "GraphicsScalingFilterBilinear": "Bilinear",
+  "GraphicsScalingFilterNearest": "Nearest",
+  "GraphicsScalingFilterFsr": "FSR",
   "GraphicsScalingFilterLevelLabel": "Level",
   "GraphicsScalingFilterLevelTooltip": "Set FSR 1.0 sharpening level. Higher is sharper.",
   "SmaaLow": "SMAA Low",
@@ -664,5 +667,7 @@
   "AboutChangelogButtonTooltipMessage": "Click to open the changelog for this version in your default browser.",
   "SettingsTabNetworkMultiplayer": "Multiplayer",
   "MultiplayerMode": "Mode:",
-  "MultiplayerModeTooltip": "Change LDN multiplayer mode.\n\nLdnMitm will modify local wireless/local play functionality in games to function as if it were LAN, allowing for local, same-network connections with other Ryujinx instances and hacked Nintendo Switch consoles that have the ldn_mitm module installed.\n\nMultiplayer requires all players to be on the same game version (i.e. Super Smash Bros. Ultimate v13.0.1 can't connect to v13.0.0).\n\nLeave DISABLED if unsure."
+  "MultiplayerModeTooltip": "Change LDN multiplayer mode.\n\nLdnMitm will modify local wireless/local play functionality in games to function as if it were LAN, allowing for local, same-network connections with other Ryujinx instances and hacked Nintendo Switch consoles that have the ldn_mitm module installed.\n\nMultiplayer requires all players to be on the same game version (i.e. Super Smash Bros. Ultimate v13.0.1 can't connect to v13.0.0).\n\nLeave DISABLED if unsure.",
+  "MultiplayerModeDisabled": "Disabled",
+  "MultiplayerModeLdnMitm": "LDN MitM"
 }

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -669,5 +669,5 @@
   "MultiplayerMode": "Mode:",
   "MultiplayerModeTooltip": "Change LDN multiplayer mode.\n\nLdnMitm will modify local wireless/local play functionality in games to function as if it were LAN, allowing for local, same-network connections with other Ryujinx instances and hacked Nintendo Switch consoles that have the ldn_mitm module installed.\n\nMultiplayer requires all players to be on the same game version (i.e. Super Smash Bros. Ultimate v13.0.1 can't connect to v13.0.0).\n\nLeave DISABLED if unsure.",
   "MultiplayerModeDisabled": "Disabled",
-  "MultiplayerModeLdnMitm": "LDN MitM"
+  "MultiplayerModeLdnMitm": "ldn_mitm"
 }

--- a/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
@@ -237,11 +237,6 @@ namespace Ryujinx.Ava.UI.ViewModels
             get => new(_networkInterfaces.Keys);
         }
 
-        public AvaloniaList<string> MultiplayerModes
-        {
-            get => new(Enum.GetNames<MultiplayerMode>());
-        }
-
         public KeyboardHotkeys KeyboardHotkeys
         {
             get => _keyboardHotkeys;

--- a/src/Ryujinx/UI/Views/Settings/SettingsGraphicsView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsGraphicsView.axaml
@@ -165,13 +165,13 @@
                                       ToolTip.Tip="{locale:Locale GraphicsScalingFilterTooltip}"
                                       SelectedIndex="{Binding ScalingFilter}">
                                 <ComboBoxItem>
-                                    <TextBlock Text="Bilinear" />
+                                    <TextBlock Text="{locale:Locale GraphicsScalingFilterBilinear}" />
                                 </ComboBoxItem>
                                 <ComboBoxItem>
-                                    <TextBlock Text="Nearest" />
+                                    <TextBlock Text="{locale:Locale GraphicsScalingFilterNearest}" />
                                 </ComboBoxItem>
                                 <ComboBoxItem>
-                                    <TextBlock Text="FSR" />
+                                    <TextBlock Text="{locale:Locale GraphicsScalingFilterFsr}" />
                                 </ComboBoxItem>
                             </ComboBox>
                             <controls:SliderScroll Value="{Binding ScalingFilterLevel}"

--- a/src/Ryujinx/UI/Views/Settings/SettingsNetworkView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsNetworkView.axaml
@@ -32,8 +32,14 @@
                     <ComboBox SelectedIndex="{Binding MultiplayerModeIndex}"
                         ToolTip.Tip="{locale:Locale MultiplayerModeTooltip}"
                         HorizontalContentAlignment="Left"
-                        ItemsSource="{Binding MultiplayerModes}"
-                        Width="250" />
+                        Width="250">
+                        <ComboBoxItem>
+                            <TextBlock Text="{locale:Locale MultiplayerModeDisabled}" />
+                        </ComboBoxItem>
+                        <ComboBoxItem>
+                            <TextBlock Text="{locale:Locale MultiplayerModeLdnMitm}" />
+                        </ComboBoxItem>
+                    </ComboBox>
                 </StackPanel>
                 <Separator Height="1" />
                 <TextBlock Classes="h1" Text="{locale:Locale SettingsTabNetworkConnection}" />


### PR DESCRIPTION
Adds two groups of missing strings on the english locale file:
- Graphics scaling filter options (Bilinear, Nearest, FSR).
- Multiplayer network modes (Disabled, LdnMitm).

For the network modes, they were sourced directly from the enum before. To allow them to be translated, I changed the combo box to have its own items that can be translated. I also changed "LdnMitm" to "LDN MitM". Might be worth testing that it is still working properly.