### PR TITLE
Add mod enablement status in the log message

### DIFF
--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -218,7 +218,7 @@ namespace Ryujinx.HLE.HOS
 
                 if (types.Length > 0)
                 {
-                    Logger.Info?.Print(LogClass.ModLoader, $"Found mod '{mod.Name}' [{types}]");
+                    Logger.Info?.Print(LogClass.ModLoader, $"Found {(mod.Enabled ? "enabled" : "disabled")} mod '{mod.Name}' [{types}]");
                 }
             }
         }


### PR DESCRIPTION
As annoyed by not knowing the status of mod if it is enabled when investigating the log, I have decided to just add small update in the log message so that we all can see the status from the log itself.

That means it is also required to update the log parser. (https://github.com/Ryujinx/ryuko-ng/pull/93)
**! Merge the log parser first before this PR !**