### PR TITLE
discordRPC: Truncate game title and details if they exceed discord byte limit.

### DIFF
--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -1,7 +1,6 @@
 using DiscordRPC;
 using Ryujinx.Common;
 using Ryujinx.UI.Common.Configuration;
-using System;
 using System.Text;
 
 namespace Ryujinx.UI.Common

--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -1,6 +1,7 @@
 using DiscordRPC;
 using Ryujinx.Common;
 using Ryujinx.UI.Common.Configuration;
+using System;
 using System.Text;
 
 namespace Ryujinx.UI.Common
@@ -11,6 +12,7 @@ namespace Ryujinx.UI.Common
         private const string ApplicationId = "1216775165866807456";
 
         private const int TitleByteLimit = 128;
+        private const string Ellipsis = "…";
 
         private static DiscordRpcClient _discordClient;
         private static RichPresence _discordPresenceMain;
@@ -100,18 +102,19 @@ namespace Ryujinx.UI.Common
                 return input;
             }
 
-            string trimmed = input;
+            // Find the length to trim the string to guarantee we have space for the trailing ellipsis.
+            int trimLimit = byteLimit - Encoding.UTF8.GetByteCount(Ellipsis);
 
-            while (Encoding.UTF8.GetByteCount(trimmed) > byteLimit)
+            // Basic trim to best case scenario of 1 byte characters.
+            input = input[..trimLimit];
+
+            while (Encoding.UTF8.GetByteCount(input) > trimLimit)
             {
                 // Remove one character from the end of the string at a time.
-                trimmed = trimmed[..^1];
+                input = input[..^1];
             }
 
-            // Remove another 3 characters to make sure we have room for "…".
-            trimmed = trimmed[..^3].TrimEnd() + "…";
-
-            return trimmed;
+            return input.TrimEnd() + Ellipsis;
         }
 
         public static void Exit()

--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -95,18 +95,21 @@ namespace Ryujinx.UI.Common
 
         private static string TruncateToByteLength(string input, int byteLimit)
         {
+            bool isModified = false;
             string trimmed = input;
 
             while (Encoding.UTF8.GetByteCount(trimmed) > byteLimit)
             {
                 // Remove one character from the end of the string at a time.
                 trimmed = trimmed[..^1];
+
+                isModified = true;
             }
 
             // Remove another 3 characters to make sure we have room for "…".
             trimmed = trimmed[..^3].TrimEnd() + "…";
 
-            return trimmed == input ? input : trimmed;
+            return isModified ? trimmed : input;
         }
 
         public static void Exit()

--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -95,21 +95,23 @@ namespace Ryujinx.UI.Common
 
         private static string TruncateToByteLength(string input, int byteLimit)
         {
-            bool isModified = false;
+            if (Encoding.UTF8.GetByteCount(input) <= byteLimit)
+            {
+                return input;
+            }
+
             string trimmed = input;
 
             while (Encoding.UTF8.GetByteCount(trimmed) > byteLimit)
             {
                 // Remove one character from the end of the string at a time.
                 trimmed = trimmed[..^1];
-
-                isModified = true;
             }
 
             // Remove another 3 characters to make sure we have room for "…".
             trimmed = trimmed[..^3].TrimEnd() + "…";
 
-            return isModified ? trimmed : input;
+            return trimmed;
         }
 
         public static void Exit()

--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -9,6 +9,8 @@ namespace Ryujinx.UI.Common
         private const string Description = "A simple, experimental Nintendo Switch emulator.";
         private const string ApplicationId = "1216775165866807456";
 
+        private const int TitleCharLimit = 128;
+
         private static DiscordRpcClient _discordClient;
         private static RichPresence _discordPresenceMain;
 
@@ -62,6 +64,10 @@ namespace Ryujinx.UI.Common
 
         public static void SwitchToPlayingState(string titleId, string titleName)
         {
+            // LargeImageText and Details must be 128 characters or less.
+            titleName = titleName.Length > TitleCharLimit ? titleName[..TitleCharLimit] : titleName;
+            string details = titleName.Length > TitleCharLimit - 8 ? titleName[..(TitleCharLimit - 8)] : titleName;
+
             _discordClient?.SetPresence(new RichPresence
             {
                 Assets = new Assets
@@ -71,7 +77,7 @@ namespace Ryujinx.UI.Common
                     SmallImageKey = "ryujinx",
                     SmallImageText = Description,
                 },
-                Details = $"Playing {titleName}",
+                Details = $"Playing {details}",
                 State = (titleId == "0000000000000000") ? "Homebrew" : titleId.ToUpper(),
                 Timestamps = Timestamps.Now,
                 Buttons =

--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.UI.Common
         private const string Description = "A simple, experimental Nintendo Switch emulator.";
         private const string ApplicationId = "1216775165866807456";
 
-        private const int TitleByteLimit = 128;
+        private const int ApplicationByteLimit = 128;
         private const string Ellipsis = "…";
 
         private static DiscordRpcClient _discordClient;
@@ -64,18 +64,18 @@ namespace Ryujinx.UI.Common
             }
         }
 
-        public static void SwitchToPlayingState(string titleId, string titleName)
+        public static void SwitchToPlayingState(string titleId, string applicationName)
         {
             _discordClient?.SetPresence(new RichPresence
             {
                 Assets = new Assets
                 {
                     LargeImageKey = "game",
-                    LargeImageText = TruncateToByteLength(titleName, TitleByteLimit),
+                    LargeImageText = TruncateToByteLength(applicationName, ApplicationByteLimit),
                     SmallImageKey = "ryujinx",
                     SmallImageText = Description,
                 },
-                Details = TruncateToByteLength($"Playing {titleName}", TitleByteLimit),
+                Details = TruncateToByteLength($"Playing {applicationName}", ApplicationByteLimit),
                 State = (titleId == "0000000000000000") ? "Homebrew" : titleId.ToUpper(),
                 Timestamps = Timestamps.Now,
                 Buttons =


### PR DESCRIPTION
Fixes https://github.com/Ryujinx/Ryujinx/issues/6576

Also hit in the wild with:
`INAZUMA ELEVEN: Victory Road Versione di prova per beta testing per tutto il mondo Incidi i cieli con il fulmine Inazuma!`

Unsure if it would be desirable to truncate a further 3 characters and add a `...`? 
Thoughts appreciated.