### PR TITLE
Change default user creation behavior

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             _profiles.Remove(userId.ToString(), out _);
 
-            OpenUser(DefaultUserId);
+            OpenUser(new UserId(_profiles.First().Key));
 
             _accountSaveDataManager.Save(_profiles);
         }

--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
@@ -37,13 +37,16 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             _accountSaveDataManager = new AccountSaveDataManager(_profiles);
 
-            if (!_profiles.TryGetValue(DefaultUserId.ToString(), out _))
+            if (_profiles.IsEmpty)
             {
                 byte[] defaultUserImage = EmbeddedResources.Read("Ryujinx.HLE/HOS/Services/Account/Acc/DefaultUserImage.jpg");
 
-                AddUser("RyuPlayer", defaultUserImage, DefaultUserId);
+                // Use a random UserId as default to avoid issues in multiplayer per #3396.
+                UserId userId = new UserId(Guid.NewGuid().ToString().Replace("-", ""));
+                
+                AddUser("RyuPlayer", defaultUserImage, userId);
 
-                OpenUser(DefaultUserId);
+                OpenUser(userId);
             }
             else
             {

--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
                 // Use a random UserId as default to avoid issues in multiplayer per #3396.
                 UserId userId = new UserId(Guid.NewGuid().ToString().Replace("-", ""));
-                
+
                 AddUser("RyuPlayer", defaultUserImage, userId);
 
                 OpenUser(userId);

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -118,6 +118,13 @@ namespace Ryujinx.Ava
                 }
             }
 
+            // Check if we've made any profiles yet
+            if (!File.Exists(Path.Combine(AppDataManager.BaseDirPath, "system", "Profiles.json")))
+            {
+                MainWindow.ShowNewUserEditPrompt = true;
+            }
+
+
             if (CommandLineState.LaunchPathArg != null)
             {
                 MainWindow.DeferLoadApplication(CommandLineState.LaunchPathArg, CommandLineState.StartFullscreenArg);

--- a/src/Ryujinx/UI/Views/User/UserEditorView.axaml.cs
+++ b/src/Ryujinx/UI/Views/User/UserEditorView.axaml.cs
@@ -1,13 +1,13 @@
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Interactivity;
+using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls;
 using FluentAvalonia.UI.Navigation;
 using Ryujinx.Ava.Common.Locale;
 using Ryujinx.Ava.UI.Controls;
 using Ryujinx.Ava.UI.Helpers;
 using Ryujinx.Ava.UI.Models;
-using Ryujinx.HLE.HOS.Services.Account.Acc;
 using System;
 using UserProfile = Ryujinx.Ava.UI.Models.UserProfile;
 
@@ -21,7 +21,9 @@ namespace Ryujinx.Ava.UI.Views.User
 
         public TempProfile TempProfile { get; set; }
         public static uint MaxProfileNameLength => 0x20;
-        public bool IsDeletable => _profile.UserId != AccountManager.DefaultUserId;
+
+        // Don't allow deletion if there is only one user
+        public bool IsDeletable => _parent.AccountManager.GetAllUsers().Count() != 1;
 
         public UserEditorView()
         {

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -54,6 +54,8 @@ namespace Ryujinx.Ava.UI.Windows
         public SettingsWindow SettingsWindow { get; set; }
 
         public static bool ShowKeyErrorOnLoad { get; set; }
+
+        public static bool ShowNewUserEditPrompt { get; set; }
         public ApplicationLibrary ApplicationLibrary { get; set; }
 
         public MainWindow()
@@ -293,6 +295,20 @@ namespace Ryujinx.Ava.UI.Windows
                 ShowKeyErrorOnLoad = false;
 
                 await Dispatcher.UIThread.InvokeAsync(async () => await UserErrorDialog.ShowUserErrorDialog(UserError.NoKeys));
+            }
+
+            if (ShowNewUserEditPrompt)
+            {
+                ShowNewUserEditPrompt = false;
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    UserResult result = await ContentDialogHelper.CreateInfoDialog("The default profile has been created.", "Would you like to manage profiles now?", "Yes", "No", "First Launch");
+                    if (result == UserResult.Ok)
+                    {
+                        await ViewModel.ManageProfiles();
+                    }
+                });
             }
 
             if (ConfigurationState.Instance.CheckUpdatesOnStart.Value && Updater.CanUpdate(false))


### PR DESCRIPTION
This resolves #3396. Changed the way that AccountManager creates the first user. Instead of creating a user if one with the DefaultUserId does not exists, it now creates a user if the profiles dictionary is empty. And when creating that user it uses a randomly generated user id instead of the fixed default. Also added a prompt on the first launch (technically if system/Profiles.json does not exist) which will ask the user if they wish to manage user profiles immediately.

Sidenote:
This is my first time contributing to an open source project, so I apologize if I have failed to follow any etiquette. In addition, I also apologize if the solution to the issue is not appropriate. I would appreciate any feedback anyone may have.