### PR TITLE
Disable hypervisor by default on macOS

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -803,7 +803,7 @@ namespace Ryujinx.UI.Common.Configuration
             System.MemoryManagerMode.Value = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value = false;
             System.IgnoreMissingServices.Value = false;
-            System.UseHypervisor.Value = true;
+            System.UseHypervisor.Value = false;
             Multiplayer.LanInterfaceId.Value = "0";
             Multiplayer.Mode.Value = MultiplayerMode.Disabled;
             UI.GuiColumns.FavColumn.Value = true;
@@ -1365,7 +1365,7 @@ namespace Ryujinx.UI.Common.Configuration
             {
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 43.");
 
-                configurationFileFormat.UseHypervisor = true;
+                configurationFileFormat.UseHypervisor = false;
             }
 
             if (configurationFileFormat.Version < 44)


### PR DESCRIPTION
Thanks to #6057 and #6356, most performance and compatibility issues with JIT have been fixed. Since some games freezes randomly when using hypervisor, I believe using JIT is a better default on macOS now. This only changes the default setting, people that already has it enabled or disabled will keep their current setting.

It would be nice to get some confirmation that games generally running better on JIT than hypervisor, or in other words, that this is a good change, I'm doing mainly based on reports of people that had better results with JIT.