### PR TITLE
Stop clearing Modified flag on DiscardData

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -573,7 +573,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         /// <summary>
         /// Discards all data for this texture.
-        /// This clears all dirty flags, modified flags, and pending copies from other textures.
+        /// This clears all dirty flags and pending copies from other textures.
         /// It should be used if the texture data will be fully overwritten by the next use.
         /// </summary>
         public void DiscardData()

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -282,7 +282,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         /// <summary>
         /// Discards all data for a given texture.
-        /// This clears all dirty flags, modified flags, and pending copies from other textures.
+        /// This clears all dirty flags and pending copies from other textures.
         /// </summary>
         /// <param name="texture">The texture being discarded</param>
         public void DiscardData(Texture texture)

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -182,11 +182,10 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         /// <summary>
         /// Discards all data for this handle.
-        /// This clears all dirty flags, modified flags, and pending copies from other handles.
+        /// This clears all dirty flags and pending copies from other handles.
         /// </summary>
         public void DiscardData()
         {
-            Modified = false;
             DeferredCopy = null;
 
             foreach (RegionHandle handle in Handles)


### PR DESCRIPTION
`DiscardData` is called for textures that are cleared. Since the entire texture data will be overwritten on the GPU side, there is no need to load any CPU side data. However, `DiscardData` also clear the `Modified` flag which as far as I can tell is not correct, since the fact that the GPU will overwrite all texture data implies that is is being modified, so the `Modified` flag should remain set. Clearing it may be problematic since for render target, it is only set on first use, then when the render target is replaced with another. So a clear for a render target that is already bound could cause the flag to be lost.

Fixes #6587 (regression caused by #5719).

Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/199ab1f4-ba23-457a-a361-097186c0e309)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/ba0b7472-5918-41d2-8e33-418ad78b7063)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/8de6e7d3-a102-4df1-835e-832755d150fb)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/0d508fd4-fddb-4014-ac1a-651d3b2e8b3c)