### PR TITLE
Ignore diacritics on game search

### DIFF
--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -36,6 +36,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -980,7 +981,14 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             if (arg is ApplicationData app)
             {
-                return string.IsNullOrWhiteSpace(_searchText) || app.TitleName.ToLower().Contains(_searchText.ToLower());
+                if (string.IsNullOrWhiteSpace(_searchText))
+                {
+                    return true;
+                }
+
+                CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+
+                return compareInfo.IndexOf(app.TitleName, _searchText, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0;
             }
 
             return false;


### PR DESCRIPTION
Allows "pokemon" to match "Pokémon" for example.
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/77180d99-ff04-462b-a605-324c107d5d59)
Someone requested this.