### PR TITLE
Replacing the try-catch block with null-conditional and null-coalescing operators

### DIFF
--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -181,18 +181,8 @@ namespace Ryujinx.HLE.HOS
                 }
                 else if (StrEquals(ExefsDir, modDir.Name))
                 {
-                    bool enabled;
-
-                    try
-                    {
-                        var modData = modMetadata.Mods.Find(x => modDir.FullName.Contains(x.Path));
-                        enabled = modData.Enabled;
-                    }
-                    catch
-                    {
-                        // Mod is not in the list yet. New mods should be enabled by default.
-                        enabled = true;
-                    }
+                    var modData = modMetadata.Mods.Find(x => modDir.FullName.Contains(x.Path));
+                    var enabled = modData?.Enabled ?? true;
 
                     mods.ExefsDirs.Add(mod = new Mod<DirectoryInfo>(dir.Name, modDir, enabled));
                     types.Append('E');

--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -173,18 +173,8 @@ namespace Ryujinx.HLE.HOS
 
                 if (StrEquals(RomfsDir, modDir.Name))
                 {
-                    bool enabled;
-
-                    try
-                    {
-                        var modData = modMetadata.Mods.Find(x => modDir.FullName.Contains(x.Path));
-                        enabled = modData.Enabled;
-                    }
-                    catch
-                    {
-                        // Mod is not in the list yet. New mods should be enabled by default.
-                        enabled = true;
-                    }
+                    var modData = modMetadata.Mods.Find(x => modDir.FullName.Contains(x.Path));
+                    var enabled = modData?.Enabled ?? true;
 
                     mods.RomfsDirs.Add(mod = new Mod<DirectoryInfo>(dir.Name, modDir, enabled));
                     types.Append('R');


### PR DESCRIPTION
The reason for this is that, when `modData` is null, then a `NullReferenceException` would be thrown if we attempt to access its properties directly. So, this code effectively prevents such exceptions by using the null-conditional operator (`?.`) to safely access `Enabled` only when `modData` is not null. If `modData` is indeed null, the null-coalescing operator (`??`) ensures that `enabled` is set to `true`, maintaining the functionality of enabling new mods by default without the overhead of exception handling.