### PR TITLE
CPU: Fix PC alignment for ADR thumb instruction

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitAlu32.cs
+++ b/src/ARMeilleure/Instructions/InstEmitAlu32.cs
@@ -19,6 +19,12 @@ namespace ARMeilleure.Instructions
             Operand n = GetAluN(context);
             Operand m = GetAluM(context, setCarry: false);
 
+            if (op.Rn == RegisterAlias.Aarch32Pc && op is OpCodeT32AluImm12)
+            {
+                // For ADR, PC is always 4 bytes aligned, even in Thumb mode.
+                n = context.BitwiseAnd(n, Const(~3u));
+            }
+
             Operand res = context.Add(n, m);
 
             if (ShouldSetFlags(context))
@@ -466,6 +472,12 @@ namespace ARMeilleure.Instructions
 
             Operand n = GetAluN(context);
             Operand m = GetAluM(context, setCarry: false);
+
+            if (op.Rn == RegisterAlias.Aarch32Pc && op is OpCodeT32AluImm12)
+            {
+                // For ADR, PC is always 4 bytes aligned, even in Thumb mode.
+                n = context.BitwiseAnd(n, Const(~3u));
+            }
 
             Operand res = context.Subtract(n, m);
 

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 5518; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 6613; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
For ADR instructions, PC must be 4 bytes aligned, even in thumb mode where the instruction size might be 2 bytes.
Fixes black screen on Ni no Kuni when using the 1.0.2 update (and maybe 1.0.1 too).
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/f5adf143-a659-4fe1-a1de-5797e46b10c9)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/01fffd12-2f22-4797-be76-289dfea5d4cc)
The issue generally only affects x86 CPUs since the new Arm JIT does not have this issue.
As a reminder, the game still needs a save to get past the EULA loop.