### PR TITLE
Pin audio renderer update output buffers

### DIFF
--- a/src/Ryujinx.Horizon/Sdk/Audio/Detail/AudioRenderer.cs
+++ b/src/Ryujinx.Horizon/Sdk/Audio/Detail/AudioRenderer.cs
@@ -61,6 +61,9 @@ namespace Ryujinx.Horizon.Sdk.Audio.Detail
             [Buffer(HipcBufferFlags.Out | HipcBufferFlags.MapAlias)] Memory<byte> performanceOutput,
             [Buffer(HipcBufferFlags.In | HipcBufferFlags.MapAlias)] ReadOnlySequence<byte> input)
         {
+            using MemoryHandle outputHandle = output.Pin();
+            using MemoryHandle performanceOutputHandle = performanceOutput.Pin();
+
             Result result = new Result((int)_renderSystem.Update(output, performanceOutput, input));
 
             return result;


### PR DESCRIPTION
`SpanMemoryManager` on `Ryujinx.Audio.Renderer.Utils` takes the pointer of a span and stores it on a field, for this reason, the audio output `Memory` needs to be pinned, otherwise GC might move it if its a managed array, which would cause the pointer to be invalid.

It is probably a good idea to change this code to not depend on memory being pinned in the future, but for now I'm pinning it again to fix the regression.

Fixes a regression caused by #6604.
Fixes #6628.