### PR TITLE
CPU: Produce non-inf results for RSQRTE instruction with subnormal inputs

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
@@ -2426,7 +2426,11 @@ namespace ARMeilleure.Instructions
             }
             else if (Optimizations.FastFP && Optimizations.UseSse41 && sizeF == 0)
             {
-                Operand res = EmitSse41Round32Exp8OpF(context, context.AddIntrinsic(Intrinsic.X86Rsqrtss, GetVec(op.Rn)), scalar: true);
+                // RSQRTSS handles subnormals as zero, which differs from Arm, so we can't use it here.
+
+                Operand res = context.AddIntrinsic(Intrinsic.X86Sqrtss, GetVec(op.Rn));
+                res = context.AddIntrinsic(Intrinsic.X86Rcpss, res);
+                res = EmitSse41Round32Exp8OpF(context, res, scalar: true);
 
                 context.Copy(GetVec(op.Rd), context.VectorZeroUpper96(res));
             }
@@ -2451,7 +2455,11 @@ namespace ARMeilleure.Instructions
             }
             else if (Optimizations.FastFP && Optimizations.UseSse41 && sizeF == 0)
             {
-                Operand res = EmitSse41Round32Exp8OpF(context, context.AddIntrinsic(Intrinsic.X86Rsqrtps, GetVec(op.Rn)), scalar: false);
+                // RSQRTPS handles subnormals as zero, which differs from Arm, so we can't use it here.
+
+                Operand res = context.AddIntrinsic(Intrinsic.X86Sqrtps, GetVec(op.Rn));
+                res = context.AddIntrinsic(Intrinsic.X86Rcpps, res);
+                res = EmitSse41Round32Exp8OpF(context, res, scalar: false);
 
                 if (op.RegisterSize == RegisterSize.Simd64)
                 {

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 6613; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 6634; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This PR addresses a difference between x86 and Arm for the recriprocal square root estimate instruction. x86 handles subnormal values the same way as zero, which means that any subnormal value will have a infinity result, while Arm does produce what one would expect (an approximation of the result).

To account for this difference, this PR stops using the RSQRTPS/RSQRTSS instructions on x86, and instead uses the regular square root instruction followed by RCPPS/RCPSS.

This seems to fix the terrain randomly disappearing on Penny's Big Breakaway.

Before:

https://github.com/Ryujinx/Ryujinx/assets/5624669/5f34f366-eb41-4c8f-8315-b60e6c853504

After:

https://github.com/Ryujinx/Ryujinx/assets/5624669/393eb07b-3aed-4a8a-b8da-c11e05da42e8

This is the only place where I was able to reproduce the issue semi-consistently. It used to break before the lift would ever get on the top, but for some reason when I recorded it only happened on the 2nd try...
It would be nice to get confirmation from someone else.

I wrote a micro benchmark to try measuring the performance difference of using RSQRTSS and SQRTSS + RCPSS. On my CPU (Ryzen 9 7900X), the result seems different depending on the input being subnormal or not.
For 0xD6E93 (subnormal value):
```
fast rsqrte took 16 ms
rsqrte took 28 ms
rsqrt took 32 ms
```
For 0.42f:
```
fast rsqrte took 16 ms
rsqrte took 16 ms
rsqrt took 16 ms
```
Code:
```cs
private static void Bench(float v)
{
    float k = 0;

    Stopwatch stp = new Stopwatch();

    stp.Start();

    for (int i = 0; i < 4000000; i++)
    {
        k += Sse.ReciprocalSqrtScalar(Vector128.Create(v)).GetElement(0);
    }

    stp.Stop();

    Console.WriteLine($"fast rsqrte took {stp.ElapsedMilliseconds} ms");

    stp.Restart();

    for (int i = 0; i < 4000000; i++)
    {
        k += Sse.ReciprocalScalar(Vector128.Create(MathF.Sqrt(v))).GetElement(0);
    }

    stp.Stop();

    Console.WriteLine($"rsqrte took {stp.ElapsedMilliseconds} ms");

    stp.Restart();

    for (int i = 0; i < 4000000; i++)
    {
        k += Sse.DivideScalar(Vector128.Create(1f), Sse.SqrtScalar(Vector128.Create(v))).GetElement(0);
    }

    stp.Stop();

    Console.WriteLine($"rsqrt took {stp.ElapsedMilliseconds} ms");
}
```
So it seems that there is a significant difference only if the value is a subnormal value, at least on that CPU.

Note that even with this change, some results are slightly different from Arm results. It's worth noting that the reciprocal estimate instruction has a similar limitation, but I think its not as problematic since a lot of subnormal values would have its reciprocal result in infinity for not being representable as a 32-bit floating point number.