### PR TITLE
Fast D32S8 2D depth texture copy

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -247,6 +247,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     return TextureMatchQuality.FormatAlias;
                 }
+                else if (lhs.FormatInfo.Format == Format.D32FloatS8Uint && rhs.FormatInfo.Format == Format.R32G32Float)
+                {
+                    return TextureMatchQuality.FormatAlias;
+                }
             }
 
             return lhs.FormatInfo.Format == rhs.FormatInfo.Format ? TextureMatchQuality.Perfect : TextureMatchQuality.NoMatch;


### PR DESCRIPTION
We allow color formats to match depth formats for the purpose of texture lookup for 2D copy, since 2D engine does not really have any depth formats as APIs alias depth formats as color formats for copy. However we currently don't support such matches for the D32S8 depth format, which forces it to flush the source texture and do the copy on CPU which is very slow.

This PR enables D32S8 textures to be copied on GPU, which greatly improves Penny's Big Breakaway performance, showing up to ~1500% (16x) improvement on my machine.

Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/76c8c467-0157-4544-9669-b8e74217d232)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/2ec2c949-129e-4cf0-978d-b82eec0ff8a6)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/94deec97-fa4a-4dc4-bf06-4d0b06fc1346)
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/28464ef8-360b-481d-a768-a67014742ee9)
