### PR TITLE
Fix input consumed by audio renderer SplitterState.Update

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Server/Splitter/SplitterState.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/Splitter/SplitterState.cs
@@ -159,6 +159,11 @@ namespace Ryujinx.Audio.Renderer.Server.Splitter
                 }
             }
 
+            if (destinationCount < parameter.DestinationCount)
+            {
+                input.Advance((parameter.DestinationCount - destinationCount) * 4);
+            }
+
             Debug.Assert(parameter.Id == Id);
 
             if (parameter.Id == Id)

--- a/src/Ryujinx.Audio/Renderer/Server/Splitter/SplitterState.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/Splitter/SplitterState.cs
@@ -161,7 +161,7 @@ namespace Ryujinx.Audio.Renderer.Server.Splitter
 
             if (destinationCount < parameter.DestinationCount)
             {
-                input.Advance((parameter.DestinationCount - destinationCount) * 4);
+                input.Advance((parameter.DestinationCount - destinationCount) * sizeof(int));
             }
 
             Debug.Assert(parameter.Id == Id);


### PR DESCRIPTION
Fixes a regression caused by #6604. `SplitterState.Update` should advance the input by `parameter.DestinationCount` elements, even if it actually consumes less than that. This should match the behaviour before the change.

Fixes #6639.