### PR TITLE
Update StoreConstantToMemory to match StoreConstantToAddress on value read

### DIFF
--- a/src/Ryujinx.HLE/HOS/Tamper/CodeEmitters/StoreConstantToMemory.cs
+++ b/src/Ryujinx.HLE/HOS/Tamper/CodeEmitters/StoreConstantToMemory.cs
@@ -15,7 +15,8 @@ namespace Ryujinx.HLE.HOS.Tamper.CodeEmitters
         private const int OffsetRegisterIndex = 6;
         private const int ValueImmediateIndex = 8;
 
-        private const int ValueImmediateSize = 16;
+        private const int ValueImmediateSize8 = 8;
+        private const int ValueImmediateSize16 = 16;
 
         public static void Emit(byte[] instruction, CompilationContext context)
         {
@@ -31,7 +32,8 @@ namespace Ryujinx.HLE.HOS.Tamper.CodeEmitters
             Register sourceRegister = context.GetRegister(instruction[AddressRegisterIndex]);
             byte incrementAddressRegister = instruction[IncrementAddressRegisterIndex];
             byte useOffsetRegister = instruction[UseOffsetRegisterIndex];
-            ulong immediate = InstructionHelper.GetImmediate(instruction, ValueImmediateIndex, ValueImmediateSize);
+            int valueImmediateSize = operationWidth <= 4 ? ValueImmediateSize8 : ValueImmediateSize16;
+            ulong immediate = InstructionHelper.GetImmediate(instruction, ValueImmediateIndex, valueImmediateSize);
             Value<ulong> storeValue = new(immediate);
 
             Pointer destinationMemory;


### PR DESCRIPTION
As it turns out the reading of cheat instruction starting with 6XXXXXXX (`StoreConstantToMemory`) was wrong, so by collective mind of the dev team, the simple fix is to just follow what `StoreConstantToAddress` has done to read the value.

This was part of investigating the issue https://github.com/Ryujinx/ryuko-ng/issues/89