### PR TITLE
Fix crash when changing controller config

### DIFF
--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -245,14 +245,7 @@ namespace Ryujinx.Input.HLE
         {
             if (config is StandardControllerInputConfig controllerConfig)
             {
-                bool needsMotionInputUpdate = _config == null || (_config is StandardControllerInputConfig oldControllerConfig &&
-                                                                (oldControllerConfig.Motion.EnableMotion != controllerConfig.Motion.EnableMotion) &&
-                                                                (oldControllerConfig.Motion.MotionBackend != controllerConfig.Motion.MotionBackend));
-
-                if (needsMotionInputUpdate)
-                {
-                    UpdateMotionInput(controllerConfig.Motion);
-                }
+                UpdateMotionInput(controllerConfig.Motion);
             }
             else
             {


### PR DESCRIPTION
The issue:
When switching from an input device without motion (ie a keyboard) to one with motion while a game is running causes a hard crash. This happens on both Ava and Gtk (tested on linux).

this was really tricky to debug because the segfault handler seems to fail with a stack cookie corruption...
```
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x000079f58699a393 in __pthread_kill_internal (signo=6, threadid=<optimized out>) at pthread_kill.c:78
#2  0x000079f5869496c8 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x000079f586931542 in __GI_abort () at abort.c:100
#4  0x000079f586932395 in __libc_message_impl (fmt=fmt@entry=0x79f586aaa161 "*** %s ***: terminated\n") at ../sysdeps/posix/libc_fatal.c:132
#5  0x000079f586a2173b in __GI___fortify_fail (msg=msg@entry=0x79f586aaa179 "stack smashing detected") at fortify_fail.c:24
#6  0x000079f586a22a56 in __stack_chk_fail () at stack_chk_fail.c:24
#7  0x000079f5864a02a1 in sigsegv_handler (code=11, siginfo=0x79b270bfe470, context=0x79b270bfe340)
    at /build/dotnet-core/src/dotnet/src/runtime/artifacts/source-build/self/src/src/coreclr/pal/src/exception/signal.cpp:595
#8  0x0000000000000000 in ?? ()
```

Solution:
Instead of checking whether or not the motion input needs to be updated, just always call the update function. UpdateMotionInput is a very small/quick function and this code is only called when first initializing or when the user changes a setting so performance should not be an issue.

Potentially fixes (https://github.com/Ryujinx/Ryujinx/issues/4453) 