### PR TITLE
Disable keyboard controller input while swkbd is open (foreground)

### DIFF
--- a/src/Ryujinx.Gtk3/Input/GTK3/GTK3KeyboardDriver.cs
+++ b/src/Ryujinx.Gtk3/Input/GTK3/GTK3KeyboardDriver.cs
@@ -81,6 +81,11 @@ namespace Ryujinx.Input.GTK3
             return _pressedKeys.Contains(nativeKey);
         }
 
+        public void Flush()
+        {
+            _pressedKeys.Clear();
+        }
+
         public IGamepad GetGamepad(string id)
         {
             if (!_keyboardIdentifers[0].Equals(id))

--- a/src/Ryujinx.Gtk3/Input/GTK3/GTK3KeyboardDriver.cs
+++ b/src/Ryujinx.Gtk3/Input/GTK3/GTK3KeyboardDriver.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Input.GTK3
             return _pressedKeys.Contains(nativeKey);
         }
 
-        public void Flush()
+        public void Clear()
         {
             _pressedKeys.Clear();
         }

--- a/src/Ryujinx.Gtk3/UI/Applet/GtkHostUIHandler.cs
+++ b/src/Ryujinx.Gtk3/UI/Applet/GtkHostUIHandler.cs
@@ -107,6 +107,8 @@ namespace Ryujinx.UI.Applet
                     swkbdDialog.SetInputLengthValidation(args.StringLengthMin, args.StringLengthMax);
                     swkbdDialog.SetInputValidation(args.KeyboardMode);
 
+                    ((MainWindow)_parent).RendererWidget.NpadManager.BlockInputUpdates();
+
                     if (swkbdDialog.Run() == (int)ResponseType.Ok)
                     {
                         inputText = swkbdDialog.InputEntry.Text;
@@ -128,6 +130,7 @@ namespace Ryujinx.UI.Applet
             });
 
             dialogCloseEvent.WaitOne();
+            ((MainWindow)_parent).RendererWidget.NpadManager.UnblockInputUpdates();
 
             userText = error ? null : inputText;
 

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -176,7 +176,7 @@ namespace Ryujinx.Input.HLE
             {
                 foreach (InputConfig inputConfig in _inputConfig)
                 {
-                    _controllers[(int)inputConfig.PlayerIndex].GamepadDriver.Flush();
+                    _controllers[(int)inputConfig.PlayerIndex].GamepadDriver.Clear();
                 }
 
                 _blockInputUpdates = false;

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -174,6 +174,11 @@ namespace Ryujinx.Input.HLE
         {
             lock (_lock)
             {
+                foreach (InputConfig inputConfig in _inputConfig)
+                {
+                    _controllers[(int)inputConfig.PlayerIndex].GamepadDriver.Flush();
+                }
+
                 _blockInputUpdates = false;
             }
         }

--- a/src/Ryujinx.Input/IGamepadDriver.cs
+++ b/src/Ryujinx.Input/IGamepadDriver.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Input
 {
@@ -39,7 +38,6 @@ namespace Ryujinx.Input
         /// Flush the internal state of the driver.
         /// </summary>
         /// <remarks>Does nothing by default.</remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void Flush() { }
+        void Clear() { }
     }
 }

--- a/src/Ryujinx.Input/IGamepadDriver.cs
+++ b/src/Ryujinx.Input/IGamepadDriver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Input
 {
@@ -33,5 +34,12 @@ namespace Ryujinx.Input
         /// <param name="id">The unique id of the gamepad</param>
         /// <returns>An instance of <see cref="IGamepad"/> associated to the gamepad id given or null if not found</returns>
         IGamepad GetGamepad(string id);
+
+        /// <summary>
+        /// Flush the internal state of the driver.
+        /// </summary>
+        /// <remarks>Does nothing by default.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void Flush() { }
     }
 }

--- a/src/Ryujinx/Input/AvaloniaKeyboard.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboard.cs
@@ -195,7 +195,7 @@ namespace Ryujinx.Ava.Input
 
         public void Clear()
         {
-            _driver?.ResetKeys();
+            _driver?.Flush();
         }
 
         public void Dispose() { }

--- a/src/Ryujinx/Input/AvaloniaKeyboard.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboard.cs
@@ -195,7 +195,7 @@ namespace Ryujinx.Ava.Input
 
         public void Clear()
         {
-            _driver?.Flush();
+            _driver?.Clear();
         }
 
         public void Dispose() { }

--- a/src/Ryujinx/Input/AvaloniaKeyboardDriver.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboardDriver.cs
@@ -94,7 +94,7 @@ namespace Ryujinx.Ava.Input
             return _pressedKeys.Contains(nativeKey);
         }
 
-        public void ResetKeys()
+        public void Flush()
         {
             _pressedKeys.Clear();
         }

--- a/src/Ryujinx/Input/AvaloniaKeyboardDriver.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboardDriver.cs
@@ -94,7 +94,7 @@ namespace Ryujinx.Ava.Input
             return _pressedKeys.Contains(nativeKey);
         }
 
-        public void Flush()
+        public void Clear()
         {
             _pressedKeys.Clear();
         }

--- a/src/Ryujinx/UI/Applet/AvaHostUIHandler.cs
+++ b/src/Ryujinx/UI/Applet/AvaHostUIHandler.cs
@@ -122,6 +122,7 @@ namespace Ryujinx.Ava.UI.Applet
             {
                 try
                 {
+                    _parent.ViewModel.AppHost.NpadManager.BlockInputUpdates();
                     var response = await SwkbdAppletDialog.ShowInputDialog(LocaleManager.Instance[LocaleKeys.SoftwareKeyboard], args);
 
                     if (response.Result == UserResult.Ok)
@@ -143,6 +144,7 @@ namespace Ryujinx.Ava.UI.Applet
             });
 
             dialogCloseEvent.WaitOne();
+            _parent.ViewModel.AppHost.NpadManager.UnblockInputUpdates();
 
             userText = error ? null : inputText;
 


### PR DESCRIPTION
This PR fixes #5625 by disabling the keyboard controller input while the swkbd applet is open.

> [!WARNING]
> This does not prevent keyboard controller inputs while the inline keyboard is active.

---

Thank you @music-discussion for figuring out the bug and describing it in the [comments](https://github.com/Ryujinx/Ryujinx/issues/5625#issuecomment-1736538968)! It saved me quite some time and allowed me to create this PR quickly.