### PR TITLE
Allow BSD sockets Poll to exit when emulation ends

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -440,8 +440,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     // If we are here, that mean nothing was available, sleep for 50ms
                     context.Device.System.KernelContext.Syscall.SleepThread(50 * 1000000);
+                    context.Thread.HandlePostSyscall();
                 }
-                while (PerformanceCounter.ElapsedMilliseconds < budgetLeftMilliseconds);
+                while (context.Thread.Context.Running && PerformanceCounter.ElapsedMilliseconds < budgetLeftMilliseconds);
             }
             else if (timeout == -1)
             {


### PR DESCRIPTION
They would not exit before until the timeout expires (which might be infinite, in which case it might get stuck forever).
This fixes a freeze when trying to stop emulation and/or close the emulator on Penny's Big Breakaway and maybe other games that uses sockets with Poll.

---

Fixes #6355