### PR TITLE
Account for swapchain image count change after re-creation

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Window.cs
@@ -330,6 +330,7 @@ namespace Ryujinx.Graphics.Vulkan
                     _swapchainIsDirty)
                 {
                     RecreateSwapchain();
+                    semaphoreIndex = (_frameIndex - 1) % _imageAvailableSemaphores.Length;
                 }
                 else
                 {


### PR DESCRIPTION
We need to update the semaphore index in case the amount of swapchain images change.
This is an attemp to fix a crash when VSync is toggled on some drivers.