### PR TITLE
Fix crash when changing controller config

### DIFF
--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -246,8 +246,8 @@ namespace Ryujinx.Input.HLE
             if (config is StandardControllerInputConfig controllerConfig)
             {
                 bool needsMotionInputUpdate = _config is not StandardControllerInputConfig oldControllerConfig ||
-                                                    ((oldControllerConfig.Motion.EnableMotion != controllerConfig.Motion.EnableMotion) &&
-                                                    (oldControllerConfig.Motion.MotionBackend != controllerConfig.Motion.MotionBackend));
+                    ((oldControllerConfig.Motion.EnableMotion != controllerConfig.Motion.EnableMotion) &&
+                    (oldControllerConfig.Motion.MotionBackend != controllerConfig.Motion.MotionBackend));
 
                 if (needsMotionInputUpdate)
                 {

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -245,9 +245,9 @@ namespace Ryujinx.Input.HLE
         {
             if (config is StandardControllerInputConfig controllerConfig)
             {
-                bool needsMotionInputUpdate = _config == null || (_config is StandardControllerInputConfig oldControllerConfig &&
-                                                                (oldControllerConfig.Motion.EnableMotion != controllerConfig.Motion.EnableMotion) &&
-                                                                (oldControllerConfig.Motion.MotionBackend != controllerConfig.Motion.MotionBackend));
+                bool needsMotionInputUpdate = _config is not StandardControllerInputConfig oldControllerConfig ||
+                                                    ((oldControllerConfig.Motion.EnableMotion != controllerConfig.Motion.EnableMotion) &&
+                                                    (oldControllerConfig.Motion.MotionBackend != controllerConfig.Motion.MotionBackend));
 
                 if (needsMotionInputUpdate)
                 {


### PR DESCRIPTION
fixes the crash when changing from a keyboard to a controller with motion support while a game is running (https://github.com/Ryujinx/Ryujinx/issues/6647). 

The root cause of this crash is ```needsMotionInputUpdate``` is not calculated correctly when switching from a keyboard to a controller. specifically if _config is the type ```StandardKeyboardInputConfig``` and the new config is ```StandardControllerInputConfig```, then the old code always evaluated ```needsMotionInputUpdate``` to false.

when the motion input is not correctly updated, ```_leftMotionInput``` is left as null when it shouldn't be and causes a null reference exception.