### PR TITLE
Fix unmapped address check when reading texture handles

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -770,7 +770,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 ? _channel.BufferManager.GetComputeUniformBufferAddress(textureBufferIndex)
                 : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, textureBufferIndex);
 
-            int handle = textureBufferAddress != 0
+            int handle = textureBufferAddress != MemoryManager.PteUnmapped
                 ? _channel.MemoryManager.Physical.Read<int>(textureBufferAddress + (uint)textureWordOffset * 4)
                 : 0;
 
@@ -790,7 +790,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
                         : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
 
-                    samplerHandle = samplerBufferAddress != 0
+                    samplerHandle = samplerBufferAddress != MemoryManager.PteUnmapped
                         ? _channel.MemoryManager.Physical.Read<int>(samplerBufferAddress + (uint)samplerWordOffset * 4)
                         : 0;
                 }


### PR DESCRIPTION
On #3706, I added a check to prevent the emulator from trying to read texture handles from unbound constant buffer that would cause crashes. This was done by checking if the address is 0 which would be the case for unbound constant buffers. However, #5427 generally changed how unbound resources are handled, and instead of checking for an address of 0, it checks for the special "unmapped" value that the memory manager returns. But I forgot to update the texture handle read code to account for that.

This fixes a regression that was causing Sniper Elite 3 to crash again at launch, it was likely caused by #5427 but I did not test the version prior to this change to confirm.