### PR TITLE
Update to new standard for volatility operations

### DIFF
--- a/src/Ryujinx.HLE/HOS/TamperMachine.cs
+++ b/src/Ryujinx.HLE/HOS/TamperMachine.cs
@@ -143,7 +143,7 @@ namespace Ryujinx.HLE.HOS
 
             try
             {
-                ControllerKeys pressedKeys = (ControllerKeys)Thread.VolatileRead(ref _pressedKeys);
+                ControllerKeys pressedKeys = (ControllerKeys)Volatile.Read(ref _pressedKeys);
                 program.Process.TamperedCodeMemory = false;
                 program.Execute(pressedKeys);
 
@@ -175,14 +175,14 @@ namespace Ryujinx.HLE.HOS
             {
                 if (input.PlayerId == PlayerIndex.Player1 || input.PlayerId == PlayerIndex.Handheld)
                 {
-                    Thread.VolatileWrite(ref _pressedKeys, (long)input.Buttons);
+                    Volatile.Write(ref _pressedKeys, (long)input.Buttons);
 
                     return;
                 }
             }
 
             // Clear the input because player one is not conected.
-            Thread.VolatileWrite(ref _pressedKeys, 0);
+            Volatile.Write(ref _pressedKeys, 0);
         }
     }
 }

--- a/src/Ryujinx.Tests/Memory/PartialUnmaps.cs
+++ b/src/Ryujinx.Tests/Memory/PartialUnmaps.cs
@@ -388,14 +388,14 @@ namespace Ryujinx.Tests.Memory
                     {
                         rwLock.AcquireReaderLock();
 
-                        int originalValue = Thread.VolatileRead(ref value);
+                        int originalValue = Volatile.Read(ref value);
 
                         count++;
 
                         // Spin a bit.
                         for (int i = 0; i < 100; i++)
                         {
-                            if (Thread.VolatileRead(ref readersAllowed) == 0)
+                            if (Volatile.Read(ref readersAllowed) == 0)
                             {
                                 error = true;
                                 running = false;
@@ -403,7 +403,7 @@ namespace Ryujinx.Tests.Memory
                         }
 
                         // Should not change while the lock is held.
-                        if (Thread.VolatileRead(ref value) != originalValue)
+                        if (Volatile.Read(ref value) != originalValue)
                         {
                             error = true;
                             running = false;


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.volatileread
https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.volatilewrite
> [Thread.VolatileRead](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.volatileread?view=net-8.0) and [Thread.VolatileWrite](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.volatilewrite?view=net-8.0) are legacy APIs and have been replaced by [Volatile.Read](https://learn.microsoft.com/en-us/dotnet/api/system.threading.volatile.read?view=net-8.0) and [Volatile.Write](https://learn.microsoft.com/en-us/dotnet/api/system.threading.volatile.write?view=net-8.0).