### PR TITLE
Make TextureGroup.ClearModified thread safe

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -390,7 +390,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             _views.Remove(texture);
 
-            Group.RemoveView(texture);
+            Group.RemoveView(_views, texture);
 
             texture._viewStorage = texture;
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -88,9 +88,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         private MultiRange TextureRange => Storage.Range;
 
         /// <summary>
-        /// The views list from the storage texture.
+        /// The views array from the storage texture.
         /// </summary>
-        private List<Texture> _views;
+        private Texture[] _views;
         private TextureGroupHandle[] _handles;
         private bool[] _loadNeeded;
 
@@ -1074,7 +1074,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public void UpdateViews(List<Texture> views, Texture texture)
         {
             // This is saved to calculate overlapping views for each handle.
-            _views = views;
+            _views = views.ToArray();
 
             bool layerViews = _hasLayerViews;
             bool mipViews = _hasMipViews;
@@ -1136,9 +1136,13 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Removes a view from the group, removing it from all overlap lists.
         /// </summary>
+        /// <param name="views">The views list of the storage texture</param>
         /// <param name="view">View to remove from the group</param>
-        public void RemoveView(Texture view)
+        public void RemoveView(List<Texture> views, Texture view)
         {
+            // This is saved to calculate overlapping views for each handle.
+            _views = views.ToArray();
+
             int offset = FindOffset(view);
 
             foreach (TextureGroupHandle handle in _handles)
@@ -1605,9 +1609,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             Storage.SignalModifiedDirty();
 
-            if (_views != null)
+            Texture[] views = _views;
+
+            if (views != null)
             {
-                foreach (Texture texture in _views)
+                foreach (Texture texture in views)
                 {
                     texture.SignalModifiedDirty();
                 }

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -121,7 +121,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public TextureGroupHandle(TextureGroup group,
                                   int offset,
                                   ulong size,
-                                  List<Texture> views,
+                                  IEnumerable<Texture> views,
                                   int firstLayer,
                                   int firstLevel,
                                   int baseSlice,
@@ -201,8 +201,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Calculate a list of which views overlap this handle.
         /// </summary>
         /// <param name="group">The parent texture group, used to find a view's base CPU VA offset</param>
-        /// <param name="views">The list of views to search for overlaps</param>
-        public void RecalculateOverlaps(TextureGroup group, List<Texture> views)
+        /// <param name="views">The views to search for overlaps</param>
+        public void RecalculateOverlaps(TextureGroup group, IEnumerable<Texture> views)
         {
             // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
             lock (Overlaps)


### PR DESCRIPTION
The list of views from the texture is passed directly on `TextureGroup.UpdateViews`. That list is accessed on the `ClearModified` method. However the `ClearModified` method can be called from other threads (due to the `MemoryUnmappedHandler`). For the most part, this method seems already thread safe, except for the views list that can be modified from other threads and cause crashes. To fix this, I changed the code to store an array copy of the list, instead of a reference to the list itself.

One such crashes was reported on https://github.com/Ryujinx/Ryujinx-Games-List/issues/4935
Testing is welcome.