### PR TITLE
End render target lifetime on syncpoint increment

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -157,6 +157,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             }
             else if (operation == SyncpointbOperation.Incr)
             {
+                // "Unbind" render targets since a syncpoint increment might indicate future CPU access for the textures.
+                _parent.TextureManager.RefreshModifiedTextures();
+
                 _context.CreateHostSyncIfNeeded(HostSyncFlags.StrictSyncpoint);
                 _context.Synchronization.IncrementSyncpoint(syncpointId);
             }

--- a/src/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
@@ -4,6 +4,7 @@ using Ryujinx.Graphics.Gpu.Engine.Dma;
 using Ryujinx.Graphics.Gpu.Engine.InlineToMemory;
 using Ryujinx.Graphics.Gpu.Engine.Threed;
 using Ryujinx.Graphics.Gpu.Engine.Twod;
+using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.Memory;
 using System;
 using System.Runtime.CompilerServices;
@@ -27,6 +28,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// Channel memory manager.
         /// </summary>
         public MemoryManager MemoryManager => _channel.MemoryManager;
+
+        /// <summary>
+        /// Channel texture manager.
+        /// </summary>
+        public TextureManager TextureManager => _channel.TextureManager;
 
         /// <summary>
         /// 3D Engine.


### PR DESCRIPTION
On #5933 I added a way to end the lifetime of render targets with a new `RefreshModifiedTextures` method, when this method is called, it will set the `Modified` flag if needed, and then if any flush happens after that, the `Modified` flag will be cleared and will remain that way unless the render target is actually used again.

However, the linked PR currently only makes use of that in the DMA copy method. This solve some cases of the texture being flushed without being actually modified (due to `Modified` flag being resurected on unbind), but not all of them. This PR aims to fix the remaining cases by calling the method during syncpoint increment as well. Since a syncpoint increment usually means that GPU resources will be accessed from CPU, I think it makes sense to do it there.

This fixes a crash on boot on the game Balatro.
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/81ba1797-68e1-49a7-a4a4-89a7b813379c)
Fixes #6177, fixes #6582.
Testing is welcome.