### PR TITLE
Use pooled memory and avoid memory copies

### DIFF
--- a/src/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
@@ -1,8 +1,10 @@
 using Ryujinx.Audio.Backends.Common;
 using Ryujinx.Audio.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.Common.Memory;
 using Ryujinx.Memory;
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -87,7 +89,9 @@ namespace Ryujinx.Audio.Backends.SDL2
                 return;
             }
 
-            byte[] samples = new byte[frameCount * _bytesPerFrame];
+            using IMemoryOwner<byte> samplesOwner = ByteMemoryPool.Rent(frameCount * _bytesPerFrame);
+
+            Span<byte> samples = samplesOwner.Memory.Span;
 
             _ringBuffer.Read(samples, 0, samples.Length);
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Ipc/KServerSession.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Ipc/KServerSession.cs
@@ -570,7 +570,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Ipc
                 }
                 else
                 {
-                    serverProcess.CpuMemory.Write(copyDst, clientProcess.CpuMemory.GetSpan(copySrc, (int)copySize));
+                    serverProcess.CpuMemory.Write(copyDst, clientProcess.CpuMemory.GetReadOnlySequence(copySrc, (int)copySize));
                 }
 
                 if (clientResult != Result.Success)
@@ -858,7 +858,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Ipc
                 }
                 else
                 {
-                    clientProcess.CpuMemory.Write(copyDst, serverProcess.CpuMemory.GetSpan(copySrc, (int)copySize));
+                    clientProcess.CpuMemory.Write(copyDst, serverProcess.CpuMemory.GetReadOnlySequence(copySrc, (int)copySize));
                 }
             }
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTable.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTable.cs
@@ -2,6 +2,7 @@ using Ryujinx.Horizon.Common;
 using Ryujinx.Memory;
 using Ryujinx.Memory.Range;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -32,6 +33,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
             {
                 pageList.AddRange(range.Address + DramMemoryMap.DramBase, range.Size / PageSize);
             }
+        }
+
+        /// <inheritdoc/>
+        protected override ReadOnlySequence<byte> GetReadOnlySequence(ulong va, int size)
+        {
+            return _cpuMemory.GetReadOnlySequence(va, size);
         }
 
         /// <inheritdoc/>
@@ -245,6 +252,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         protected override void SignalMemoryTracking(ulong va, ulong size, bool write)
         {
             _cpuMemory.SignalMemoryTracking(va, size, write);
+        }
+
+        /// <inheritdoc/>
+        protected override void Write(ulong va, ReadOnlySequence<byte> data)
+        {
+            _cpuMemory.Write(va, data);
         }
 
         /// <inheritdoc/>

--- a/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
@@ -5,6 +5,7 @@ using Ryujinx.Horizon.Common;
 using Ryujinx.Memory;
 using Ryujinx.Memory.Range;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -2944,6 +2945,18 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         protected abstract void GetPhysicalRegions(ulong va, ulong size, KPageList pageList);
 
         /// <summary>
+        /// Gets a read-only sequence of data from CPU mapped memory.
+        /// </summary>
+        /// <remarks>
+        /// Allows reading non-contiguous memory without first copying it to a newly allocated single contiguous block.
+        /// </remarks>
+        /// <param name="va">Virtual address of the data</param>
+        /// <param name="size">Size of the data</param>
+        /// <returns>A read-only sequence of the data</returns>
+        /// <exception cref="Ryujinx.Memory.InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
+        protected abstract ReadOnlySequence<byte> GetReadOnlySequence(ulong va, int size);
+
+        /// <summary>
         /// Gets a read-only span of data from CPU mapped memory.
         /// </summary>
         /// <remarks>
@@ -2952,7 +2965,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         /// </remarks>
         /// <param name="va">Virtual address of the data</param>
         /// <param name="size">Size of the data</param>
-        /// <param name="tracked">True if read tracking is triggered on the span</param>
         /// <returns>A read-only span of the data</returns>
         /// <exception cref="Ryujinx.Memory.InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
         protected abstract ReadOnlySpan<byte> GetSpan(ulong va, int size);
@@ -3059,6 +3071,14 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         /// <param name="va">Virtual address of the region</param>
         /// <param name="size">Size of the region</param>
         protected abstract void SignalMemoryTracking(ulong va, ulong size, bool write);
+
+        /// <summary>
+        /// Writes data to CPU mapped memory, with write tracking.
+        /// </summary>
+        /// <param name="va">Virtual address to write the data into</param>
+        /// <param name="data">Data to be written</param>
+        /// <exception cref="Ryujinx.Memory.InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
+        protected abstract void Write(ulong va, ReadOnlySequence<byte> data);
 
         /// <summary>
         /// Writes data to CPU mapped memory, with write tracking.

--- a/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
@@ -1569,10 +1569,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
                     while (size > 0)
                     {
-                        // Copy chunk size. Previous impl created copies to write using GetSpan(), and moderate sizes
-                        // were recommended to avoid allocating very large temporary buffers. Since moving to use
-                        // ReadOnlySequence<byte> and reading directly, we set the copySize to the max size of a
-                        // segment: Int32.MaxValue.
                         ulong copySize = int.MaxValue;
 
                         if (copySize > size)

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IBinder.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IBinder.cs
@@ -13,10 +13,10 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         ResultCode OnTransact(uint code, uint flags, ReadOnlySpan<byte> inputParcel, Span<byte> outputParcel)
         {
-            Parcel inputParcelReader = new(inputParcel.ToArray());
+            using Parcel inputParcelReader = new(inputParcel);
 
             // TODO: support objects?
-            Parcel outputParcelWriter = new((uint)(outputParcel.Length - Unsafe.SizeOf<ParcelHeader>()), 0);
+            using Parcel outputParcelWriter = new((uint)(outputParcel.Length - Unsafe.SizeOf<ParcelHeader>()), 0);
 
             string inputInterfaceToken = inputParcelReader.ReadInterfaceToken();
 

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Parcel.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Parcel.cs
@@ -137,7 +137,6 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             // TODO: figure out what this value is
 
             Span<byte> fourBytes = stackalloc byte[4];
-            fourBytes.Clear();
 
             WriteInplaceObject(fourBytes);
         }

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Parcel.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Parcel.cs
@@ -1,7 +1,9 @@
 using Ryujinx.Common;
+using Ryujinx.Common.Memory;
 using Ryujinx.Common.Utilities;
 using Ryujinx.HLE.HOS.Services.SurfaceFlinger.Types;
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -9,13 +11,13 @@ using System.Text;
 
 namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 {
-    class Parcel
+    sealed class Parcel : IDisposable
     {
-        private readonly byte[] _rawData;
+        private readonly IMemoryOwner<byte> _rawDataOwner;
 
-        private Span<byte> Raw => new(_rawData);
+        private Span<byte> Raw => _rawDataOwner.Memory.Span;
 
-        private ref ParcelHeader Header => ref MemoryMarshal.Cast<byte, ParcelHeader>(_rawData)[0];
+        private ref ParcelHeader Header => ref MemoryMarshal.Cast<byte, ParcelHeader>(Raw)[0];
 
         private Span<byte> Payload => Raw.Slice((int)Header.PayloadOffset, (int)Header.PayloadSize);
 
@@ -24,9 +26,11 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         private int _payloadPosition;
         private int _objectPosition;
 
-        public Parcel(byte[] rawData)
+        private bool _isDisposed;
+
+        public Parcel(ReadOnlySpan<byte> data)
         {
-            _rawData = rawData;
+            _rawDataOwner = ByteMemoryPool.RentCopy(data);
 
             _payloadPosition = 0;
             _objectPosition = 0;
@@ -36,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             uint headerSize = (uint)Unsafe.SizeOf<ParcelHeader>();
 
-            _rawData = new byte[BitUtils.AlignUp<uint>(headerSize + payloadSize + objectsSize, 4)];
+            _rawDataOwner = ByteMemoryPool.RentCleared(BitUtils.AlignUp<uint>(headerSize + payloadSize + objectsSize, 4));
 
             Header.PayloadSize = payloadSize;
             Header.ObjectsSize = objectsSize;
@@ -132,7 +136,10 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             // TODO: figure out what this value is
 
-            WriteInplaceObject(new byte[4] { 0, 0, 0, 0 });
+            Span<byte> fourBytes = stackalloc byte[4];
+            fourBytes.Clear();
+
+            WriteInplaceObject(fourBytes);
         }
 
         public AndroidStrongPointer<T> ReadStrongPointer<T>() where T : unmanaged, IFlattenable
@@ -218,6 +225,16 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             UpdateHeader();
 
             return Raw[..(int)(Header.PayloadSize + Header.ObjectsSize + Unsafe.SizeOf<ParcelHeader>())];
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+
+                _rawDataOwner.Dispose();
+            }
         }
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -250,7 +250,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             context.Device.System.SurfaceFlinger.SetRenderLayer(layerId);
 
-            Parcel parcel = new(0x28, 0x4);
+            using Parcel parcel = new(0x28, 0x4);
 
             parcel.WriteObject(producer, "dispdrv\0");
 
@@ -288,7 +288,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             context.Device.System.SurfaceFlinger.SetRenderLayer(layerId);
 
-            Parcel parcel = new(0x28, 0x4);
+            using Parcel parcel = new(0x28, 0x4);
 
             parcel.WriteObject(producer, "dispdrv\0");
 

--- a/src/Ryujinx.Memory/IWritableBlock.cs
+++ b/src/Ryujinx.Memory/IWritableBlock.cs
@@ -1,9 +1,25 @@
 using System;
+using System.Buffers;
 
 namespace Ryujinx.Memory
 {
     public interface IWritableBlock
     {
+        /// <summary>
+        /// Writes data to CPU mapped memory, with write tracking.
+        /// </summary>
+        /// <param name="va">Virtual address to write the data into</param>
+        /// <param name="data">Data to be written</param>
+        /// <exception cref="InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
+        void Write(ulong va, ReadOnlySequence<byte> data)
+        {
+            foreach (ReadOnlyMemory<byte> segment in data)
+            {
+                Write(va, segment.Span);
+                va += (ulong)segment.Length;
+            }
+        }
+
         void Write(ulong va, ReadOnlySpan<byte> data);
 
         void WriteUntracked(ulong va, ReadOnlySpan<byte> data) => Write(va, data);


### PR DESCRIPTION
I am reworking PR #4777 into 4 new PRs. This PR is # 4 of 4 and it changes a few miscellaneous areas that stood out in a memory profiler. Generally, it:

- changes some `new byte[]` allocations to use pooled memory instead.
- changes some HLE kernel-level methods that were copying data via a temporary copy buffer, to instead copy directly from source to destination via `GetReadOnlySequence()` and `Write(ReadOnlySequence<byte>)`

These are relatively minor, but are the last of the improvements originally proposed by PR #4777.
