### PR TITLE
implement `MemoryManagerHostTracked.GetReadOnlySequence()`

### DIFF
--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -123,6 +123,7 @@ namespace Ryujinx.Cpu.Jit
                         if (last.IsContiguousWith(physicalMemory, out nuint contiguousStart, out int contiguousSize))
                         {
                             Memory<byte> contiguousPhysicalMemory = new NativeMemoryManager<byte>(contiguousStart, contiguousSize).Memory;
+
                             last.Replace(contiguousPhysicalMemory);
                         }
                         else

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -85,6 +85,61 @@ namespace Ryujinx.Cpu.Jit
             _addressSpace = new(Tracking, backingMemory, _nativePageTable, useProtectionMirrors);
         }
 
+        public override ReadOnlySequence<byte> GetReadOnlySequence(ulong va, int size, bool tracked = false)
+        {
+            if (size == 0)
+            {
+                return ReadOnlySequence<byte>.Empty;
+            }
+
+            try
+            {
+                AssertValidAddressAndSize(va, (ulong)size);
+
+                ulong endVa = va + (ulong)size;
+                int offset = 0;
+                
+                BytesReadOnlySequenceSegment first = null, last = null;
+
+                while (va < endVa)
+                {
+                    (MemoryBlock memory, ulong rangeOffset, ulong copySize) = GetMemoryOffsetAndSize(va, (ulong)(size - offset));
+
+                    Memory<byte> physicalMemory = memory.GetMemory(rangeOffset, (int)copySize);
+                    
+                    if (first is null)
+                    {
+                        first = last = new BytesReadOnlySequenceSegment(physicalMemory);
+                    }
+                    else
+                    {
+                        if (last.IsContiguousWith(physicalMemory, out nuint contiguousStart, out int contiguousSize))
+                        {
+                            last.Replace(GetPhysicalAddressMemory(contiguousStart, contiguousSize));
+                        }
+                        else
+                        {
+                            last = last.Append(physicalMemory);
+                        }
+                    }
+                    
+                    va += copySize;
+                    offset += (int)copySize;
+                }
+                
+                return new ReadOnlySequence<byte>(first, 0, last, (int)(size - last.RunningIndex));
+            }
+            catch (InvalidMemoryRegionException)
+            {
+                if (_invalidAccessHandler == null || !_invalidAccessHandler(va))
+                {
+                    throw;
+                }
+                
+                return ReadOnlySequence<byte>.Empty;
+            }
+        }
+
         /// <inheritdoc/>
         public void Map(ulong va, ulong pa, ulong size, MemoryMapFlags flags)
         {

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -92,14 +92,16 @@ namespace Ryujinx.Cpu.Jit
                 return ReadOnlySequence<byte>.Empty;
             }
 
-            if (tracked)
-            {
-                SignalMemoryTracking(va, (ulong)size, false);
-            }
-
             try
             {
-                AssertValidAddressAndSize(va, (ulong)size);
+                if (tracked)
+                {
+                    SignalMemoryTracking(va, (ulong)size, false);
+                }
+                else
+                {
+                    AssertValidAddressAndSize(va, (ulong)size);
+                }
 
                 ulong endVa = va + (ulong)size;
                 int offset = 0;

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -92,6 +92,11 @@ namespace Ryujinx.Cpu.Jit
                 return ReadOnlySequence<byte>.Empty;
             }
 
+            if (tracked)
+            {
+                SignalMemoryTracking(va, (ulong)size, false);
+            }
+
             try
             {
                 AssertValidAddressAndSize(va, (ulong)size);

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -122,7 +122,8 @@ namespace Ryujinx.Cpu.Jit
                     {
                         if (last.IsContiguousWith(physicalMemory, out nuint contiguousStart, out int contiguousSize))
                         {
-                            last.Replace(GetPhysicalAddressMemory(contiguousStart, contiguousSize));
+                            Memory<byte> contiguousPhysicalMemory = new NativeMemoryManager<byte>(contiguousStart, contiguousSize).Memory;
+                            last.Replace(contiguousPhysicalMemory);
                         }
                         else
                         {

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -126,7 +126,7 @@ namespace Ryujinx.Cpu.Jit
                     va += copySize;
                     offset += (int)copySize;
                 }
-                
+
                 return new ReadOnlySequence<byte>(first, 0, last, (int)(size - last.RunningIndex));
             }
             catch (InvalidMemoryRegionException)

--- a/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
+++ b/src/Ryujinx.Cpu/Jit/MemoryManagerHostTracked.cs
@@ -98,7 +98,7 @@ namespace Ryujinx.Cpu.Jit
 
                 ulong endVa = va + (ulong)size;
                 int offset = 0;
-                
+
                 BytesReadOnlySequenceSegment first = null, last = null;
 
                 while (va < endVa)
@@ -106,7 +106,7 @@ namespace Ryujinx.Cpu.Jit
                     (MemoryBlock memory, ulong rangeOffset, ulong copySize) = GetMemoryOffsetAndSize(va, (ulong)(size - offset));
 
                     Memory<byte> physicalMemory = memory.GetMemory(rangeOffset, (int)copySize);
-                    
+
                     if (first is null)
                     {
                         first = last = new BytesReadOnlySequenceSegment(physicalMemory);
@@ -122,7 +122,7 @@ namespace Ryujinx.Cpu.Jit
                             last = last.Append(physicalMemory);
                         }
                     }
-                    
+
                     va += copySize;
                     offset += (int)copySize;
                 }
@@ -135,7 +135,7 @@ namespace Ryujinx.Cpu.Jit
                 {
                     throw;
                 }
-                
+
                 return ReadOnlySequence<byte>.Empty;
             }
         }

--- a/src/Ryujinx.Memory/NativeMemoryManager.cs
+++ b/src/Ryujinx.Memory/NativeMemoryManager.cs
@@ -8,6 +8,11 @@ namespace Ryujinx.Memory
         private readonly T* _pointer;
         private readonly int _length;
 
+        public NativeMemoryManager(nuint pointer, int length)
+            : this((T*)pointer, length)
+        {
+        }
+
         public NativeMemoryManager(T* pointer, int length)
         {
             _pointer = pointer;


### PR DESCRIPTION
implement `MemoryManagerHostTracked.GetReadOnlySequence()`, fixes crashes on game starts on MacOS

---

Fixes  #6696