### PR TITLE
Make "Enable Discord Integration" disabled by default

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -789,7 +789,7 @@ namespace Ryujinx.UI.Common.Configuration
             System.TimeZone.Value = "UTC";
             System.SystemTimeOffset.Value = 0;
             System.EnableDockedMode.Value = true;
-            EnableDiscordIntegration.Value = true;
+            EnableDiscordIntegration.Value = false;
             CheckUpdatesOnStart.Value = true;
             ShowConfirmExit.Value = true;
             EnableHardwareAcceleration.Value = true;


### PR DESCRIPTION
The reason for this is that, at least in my environment, its throwning `TimeoutException` non-stop. May be linked to [Lachee/discord-rpc-csharp](https://github.com/Lachee/discord-rpc-csharp). Maybe these frequent exceptions could be impacting Ryujinx performance?

![image](https://github.com/Ryujinx/Ryujinx/assets/15821724/82118389-4ad2-49c1-a053-425755425e7c)
