### PR TITLE
Don't prevent windows Display Sleep while paused

### DIFF
--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -343,7 +343,10 @@ namespace Ryujinx.Ava
                 _windowsMultimediaTimerResolution = new WindowsMultimediaTimerResolution(1);
             }
 
-            DisplaySleep.Prevent();
+            Dispatcher.UIThread.Post(() =>
+            {
+                DisplaySleep.Prevent();
+            });
 
             NpadManager.Initialize(Device, ConfigurationState.Instance.Hid.InputConfig, ConfigurationState.Instance.Hid.EnableKeyboard, ConfigurationState.Instance.Hid.EnableMouse);
             TouchScreenManager.Initialize(Device);
@@ -456,7 +459,10 @@ namespace Ryujinx.Ava
             _gpuDoneEvent.WaitOne();
             _gpuDoneEvent.Dispose();
 
-            DisplaySleep.Restore();
+            Dispatcher.UIThread.Post(() =>
+            {
+                DisplaySleep.Restore();
+            });
 
             NpadManager.Dispose();
             TouchScreenManager.Dispose();
@@ -727,6 +733,11 @@ namespace Ryujinx.Ava
 
         internal void Resume()
         {
+            Dispatcher.UIThread.Post(() =>
+            {
+                DisplaySleep.Prevent();
+            });
+
             Device?.System.TogglePauseEmulation(false);
 
             _viewModel.IsPaused = false;
@@ -736,6 +747,11 @@ namespace Ryujinx.Ava
 
         internal void Pause()
         {
+            Dispatcher.UIThread.Post(() =>
+            {
+                DisplaySleep.Restore();
+            });
+
             Device?.System.TogglePauseEmulation(true);
 
             _viewModel.IsPaused = true;


### PR DESCRIPTION
Fixes https://github.com/Ryujinx/Ryujinx/issues/6703

I have not tested that this actually sleeps correctly, or that ryujinx can be restored correctly.
I just debugged and queried the thread execution state via `SetThreadExecutionState(0)`.
Please leave a comment if you test it and it works as intended (Can sleep and wake up fine while paused).

Ran into an issue since AppHost.cs Pause/Resume are called from the "Main Thread" (The one running Program.Main and the WndProc) and the thread that currently calls DisplayState Restore/Prevent is another one (The one running AppHost.MainLoop).
I just put all DisplayState calls within a `Dispatcher.UIThread.Post` delegate (It was not needed for the ones called from Resume/Pause in my tests but I added them just in case).
I considered adding a private method on AppHost that handles that but since it's only used twice per method I wasn't sure if it was worth it.