### PR TITLE
Fix direct keyboard not working when using a Controller.

### DIFF
--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -487,7 +487,7 @@ namespace Ryujinx.Input.HLE
             return value;
         }
 
-        public static KeyboardInput? GetHLEKeyboardInput(IGamepadDriver KeyboardDriver)
+        public static KeyboardInput GetHLEKeyboardInput(IGamepadDriver KeyboardDriver)
         {
             var keyboard = KeyboardDriver.GetGamepad("0") as IKeyboard;
 

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -487,36 +487,34 @@ namespace Ryujinx.Input.HLE
             return value;
         }
 
-        public KeyboardInput? GetHLEKeyboardInput()
+        public KeyboardInput? GetHLEKeyboardInput(IGamepadDriver KeyboardDriver)
         {
-            if (_gamepad is IKeyboard keyboard)
+            var keyboard = KeyboardDriver.GetGamepad("0") as IKeyboard;
+
+            KeyboardStateSnapshot keyboardState = keyboard.GetKeyboardStateSnapshot();
+
+            KeyboardInput hidKeyboard = new()
             {
-                KeyboardStateSnapshot keyboardState = keyboard.GetKeyboardStateSnapshot();
+                Modifier = 0,
+                Keys = new ulong[0x4],
+            };
 
-                KeyboardInput hidKeyboard = new()
-                {
-                    Modifier = 0,
-                    Keys = new ulong[0x4],
-                };
+            foreach (HLEKeyboardMappingEntry entry in _keyMapping)
+            {
+                ulong value = keyboardState.IsPressed(entry.TargetKey) ? 1UL : 0UL;
 
-                foreach (HLEKeyboardMappingEntry entry in _keyMapping)
-                {
-                    ulong value = keyboardState.IsPressed(entry.TargetKey) ? 1UL : 0UL;
-
-                    hidKeyboard.Keys[entry.Target / 0x40] |= (value << (entry.Target % 0x40));
-                }
-
-                foreach (HLEKeyboardMappingEntry entry in _keyModifierMapping)
-                {
-                    int value = keyboardState.IsPressed(entry.TargetKey) ? 1 : 0;
-
-                    hidKeyboard.Modifier |= value << entry.Target;
-                }
-
-                return hidKeyboard;
+                hidKeyboard.Keys[entry.Target / 0x40] |= (value << (entry.Target % 0x40));
             }
 
-            return null;
+            foreach (HLEKeyboardMappingEntry entry in _keyModifierMapping)
+            {
+                int value = keyboardState.IsPressed(entry.TargetKey) ? 1 : 0;
+
+                hidKeyboard.Modifier |= value << entry.Target;
+            }
+
+            return hidKeyboard;
+
         }
 
 

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -517,7 +517,6 @@ namespace Ryujinx.Input.HLE
 
         }
 
-
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/Ryujinx.Input/HLE/NpadController.cs
+++ b/src/Ryujinx.Input/HLE/NpadController.cs
@@ -487,7 +487,7 @@ namespace Ryujinx.Input.HLE
             return value;
         }
 
-        public KeyboardInput? GetHLEKeyboardInput(IGamepadDriver KeyboardDriver)
+        public static KeyboardInput? GetHLEKeyboardInput(IGamepadDriver KeyboardDriver)
         {
             var keyboard = KeyboardDriver.GetGamepad("0") as IKeyboard;
 

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -234,7 +234,7 @@ namespace Ryujinx.Input.HLE
 
                         if (_enableKeyboard)
                         {
-                            hleKeyboardInput = controller.GetHLEKeyboardInput();
+                            hleKeyboardInput = controller.GetHLEKeyboardInput(_keyboardDriver);
                         }
                     }
                     else

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -231,7 +231,6 @@ namespace Ryujinx.Input.HLE
                         var altMotionState = isJoyconPair ? controller.GetHLEMotionState(true) : default;
 
                         motionState = (controller.GetHLEMotionState(), altMotionState);
-
                     }
                     else
                     {

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -232,10 +232,6 @@ namespace Ryujinx.Input.HLE
 
                         motionState = (controller.GetHLEMotionState(), altMotionState);
 
-                        if (_enableKeyboard)
-                        {
-                            hleKeyboardInput = controller.GetHLEKeyboardInput(_keyboardDriver);
-                        }
                     }
                     else
                     {
@@ -255,6 +251,11 @@ namespace Ryujinx.Input.HLE
 
                         hleMotionStates.Add(motionState.Item2);
                     }
+                }
+
+                if (!_blockInputUpdates && _enableKeyboard)
+                {
+                    hleKeyboardInput = NpadController.GetHLEKeyboardInput(_keyboardDriver);
                 }
 
                 _device.Hid.Npads.Update(hleInputStates);


### PR DESCRIPTION
- Pass KeyboardDriver to NpadController.GetHLEKeyboardInput().
- Always fetch a Keyboard with KeyboardDriver.GetGamepad("0") if Direct Keyboard is on.
- Remove unnecessary return null.