### PR TITLE
Fix Cursor States On Windows

### DIFF
--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.Ava
         };
 
         private CursorStates _cursorState = !ConfigurationState.Instance.Hid.EnableMouse.Value ?
-                                             CursorStates.CursorIsVisible : CursorStates.CursorIsHidden;
+            CursorStates.CursorIsVisible : CursorStates.CursorIsHidden;
 
         private bool _isStopped;
         private bool _isActive;
@@ -236,7 +236,6 @@ namespace Ryujinx.Ava
                     windowYOffset -= window.MenuBarHeight;
                     windowYLimit += window.StatusBarHeight + 1;
                 }
-
 
                 _isCursorInRenderer = point.X >= bounds.X &&
                     Math.Ceiling(point.X) <= (int)window.Bounds.Width &&

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -103,10 +103,10 @@ namespace Ryujinx.Ava
             ForceChangeCursor
         };
 
-        private CursorStates cursorState = CursorStates.CursorIsVisible;
-
         private CursorStates _cursorState = !ConfigurationState.Instance.Hid.EnableMouse.Value ?
                                              CursorStates.CursorIsVisible : CursorStates.CursorIsHidden;
+
+        private bool _isCursorVisible = !ConfigurationState.Instance.Hid.EnableMouse.Value;
 
         private bool _isStopped;
         private bool _isActive;
@@ -239,10 +239,10 @@ namespace Ryujinx.Ava
 
 
                 _isCursorInRenderer = point.X >= bounds.X &&
-                                      Math.Ceiling(point.X) <= (int)window.Bounds.Width &&
-                                      point.Y >= windowYOffset &&
-                                      point.Y <= windowYLimit &&
-                                      !_viewModel.IsSubMenuOpen;
+                    Math.Ceiling(point.X) <= (int)window.Bounds.Width &&
+                    point.Y >= windowYOffset &&
+                    point.Y <= windowYLimit &&
+                    !_viewModel.IsSubMenuOpen;
 
                 _ignoreCursorState = false;
             }
@@ -266,9 +266,9 @@ namespace Ryujinx.Ava
                 }
 
                 _ignoreCursorState = (point.X == bounds.X ||
-                                     Math.Ceiling(point.X) == (int)window.Bounds.Width) &&
-                                     point.Y >= windowYOffset &&
-                                     point.Y <= windowYLimit;
+                    Math.Ceiling(point.X) == (int)window.Bounds.Width) &&
+                    point.Y >= windowYOffset &&
+                    point.Y <= windowYLimit;
 
             }
             _cursorState = CursorStates.ForceChangeCursor;
@@ -1105,21 +1105,18 @@ namespace Ryujinx.Ava
                 {
                     if (ConfigurationState.Instance.Hid.EnableMouse.Value)
                     {
-                        cursorState = ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Never
-                                      ? CursorStates.CursorIsVisible
-                                      : CursorStates.CursorIsHidden;
+                        _isCursorVisible = ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Never;
                     }
                     else
                     {
-                        cursorState = ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Never ||
-                                      Stopwatch.GetTimestamp() - _lastCursorMoveTime < CursorHideIdleTime * Stopwatch.Frequency
-                                      ? CursorStates.CursorIsVisible
-                                      : CursorStates.CursorIsHidden;
+                        _isCursorVisible = ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Never ||
+                            (ConfigurationState.Instance.HideCursor.Value == HideCursorMode.OnIdle &&
+                            Stopwatch.GetTimestamp() - _lastCursorMoveTime < CursorHideIdleTime * Stopwatch.Frequency);
                     }
 
-                    if (_cursorState != cursorState)
+                    if (_cursorState != (_isCursorVisible ? CursorStates.CursorIsVisible : CursorStates.CursorIsHidden))
                     {
-                        if (cursorState == CursorStates.CursorIsVisible)
+                        if (_isCursorVisible)
                         {
                             ShowCursor();
                         }

--- a/src/Ryujinx/Input/AvaloniaMouse.cs
+++ b/src/Ryujinx/Input/AvaloniaMouse.cs
@@ -17,6 +17,13 @@ namespace Ryujinx.Ava.Input
         public GamepadFeaturesFlag Features => throw new NotImplementedException();
         public bool[] Buttons => _driver.PressedButtons;
 
+        public enum CursorStates
+        {
+            CursorIsHidden,
+            CursorIsVisible,
+            ForceChangeCursor
+        };
+
         public AvaloniaMouse(AvaloniaMouseDriver driver)
         {
             _driver = driver;

--- a/src/Ryujinx/Input/AvaloniaMouse.cs
+++ b/src/Ryujinx/Input/AvaloniaMouse.cs
@@ -17,13 +17,6 @@ namespace Ryujinx.Ava.Input
         public GamepadFeaturesFlag Features => throw new NotImplementedException();
         public bool[] Buttons => _driver.PressedButtons;
 
-        public enum CursorStates
-        {
-            CursorIsHidden,
-            CursorIsVisible,
-            ForceChangeCursor
-        };
-
         public AvaloniaMouse(AvaloniaMouseDriver driver)
         {
             _driver = driver;

--- a/src/Ryujinx/UI/Helpers/Win32NativeInterop.cs
+++ b/src/Ryujinx/UI/Helpers/Win32NativeInterop.cs
@@ -111,8 +111,5 @@ namespace Ryujinx.Ava.UI.Helpers
 
         [LibraryImport("user32.dll", SetLastError = true)]
         public static partial IntPtr SetWindowLongPtrW(IntPtr hWnd, int nIndex, IntPtr value);
-
-        [LibraryImport("user32.dll", SetLastError = true)]
-        public static partial IntPtr SetWindowLongW(IntPtr hWnd, int nIndex, int value);
     }
 }

--- a/src/Ryujinx/UI/Renderer/EmbeddedWindow.cs
+++ b/src/Ryujinx/UI/Renderer/EmbeddedWindow.cs
@@ -36,6 +36,9 @@ namespace Ryujinx.Ava.UI.Renderer
         public event EventHandler<IntPtr> WindowCreated;
         public event EventHandler<Size> BoundsChanged;
 
+        [SupportedOSPlatform("windows")]
+        private readonly IntPtr DefaultCursorWin = CreateArrowCursor();
+
         public EmbeddedWindow()
         {
             this.GetObservable(BoundsProperty).Subscribe(StateChanged);
@@ -157,7 +160,7 @@ namespace Ryujinx.Ava.UI.Renderer
                 lpfnWndProc = Marshal.GetFunctionPointerForDelegate(_wndProcDelegate),
                 style = ClassStyles.CsOwndc,
                 lpszClassName = Marshal.StringToHGlobalUni(_className),
-                hCursor = CreateArrowCursor(),
+                hCursor = DefaultCursorWin
             };
 
             RegisterClassEx(ref wndClassEx);

--- a/src/Ryujinx/UI/Renderer/EmbeddedWindow.cs
+++ b/src/Ryujinx/UI/Renderer/EmbeddedWindow.cs
@@ -36,9 +36,6 @@ namespace Ryujinx.Ava.UI.Renderer
         public event EventHandler<IntPtr> WindowCreated;
         public event EventHandler<Size> BoundsChanged;
 
-        [SupportedOSPlatform("windows")]
-        private readonly IntPtr DefaultCursorWin = CreateArrowCursor();
-
         public EmbeddedWindow()
         {
             this.GetObservable(BoundsProperty).Subscribe(StateChanged);
@@ -160,7 +157,7 @@ namespace Ryujinx.Ava.UI.Renderer
                 lpfnWndProc = Marshal.GetFunctionPointerForDelegate(_wndProcDelegate),
                 style = ClassStyles.CsOwndc,
                 lpszClassName = Marshal.StringToHGlobalUni(_className),
-                hCursor = DefaultCursorWin
+                hCursor = CreateArrowCursor()
             };
 
             RegisterClassEx(ref wndClassEx);

--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -104,6 +104,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         private double _windowHeight;
 
         private bool _isActive;
+        private bool _isSubMenuOpen;
 
         public ApplicationData ListSelectedApplication;
         public ApplicationData GridSelectedApplication;
@@ -312,6 +313,17 @@ namespace Ryujinx.Ava.UI.ViewModels
             set
             {
                 _isFullScreen = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsSubMenuOpen
+        {
+            get => _isSubMenuOpen;
+            set
+            {
+                _isSubMenuOpen = value;
 
                 OnPropertyChanged();
             }

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -16,7 +16,8 @@
             Name="Menu"
             Height="35"
             Margin="0"
-            HorizontalAlignment="Left">
+            HorizontalAlignment="Left"
+            IsOpen="{Binding IsSubMenuOpen, Mode=OneWayToSource}">
             <Menu.ItemsPanel>
                 <ItemsPanelTemplate>
                     <DockPanel Margin="0" HorizontalAlignment="Stretch" />
@@ -185,7 +186,7 @@
                     <MenuItem Header="{locale:Locale MenuBarToolsUninstallFileTypes}" Click="UninstallFileTypes_Click"/>
                 </MenuItem>
             </MenuItem>
-            <MenuItem VerticalAlignment="Center" Header="{locale:Locale MenuBarHelp}">
+            <MenuItem VerticalAlignment="Center" Header="{locale:Locale MenuBarHelp}" >
                 <MenuItem
                     Name="UpdateMenuItem"
                     IsEnabled="{Binding CanUpdate}"

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
@@ -186,7 +186,7 @@
                     <MenuItem Header="{locale:Locale MenuBarToolsUninstallFileTypes}" Click="UninstallFileTypes_Click"/>
                 </MenuItem>
             </MenuItem>
-            <MenuItem VerticalAlignment="Center" Header="{locale:Locale MenuBarHelp}" >
+            <MenuItem VerticalAlignment="Center" Header="{locale:Locale MenuBarHelp}">
                 <MenuItem
                     Name="UpdateMenuItem"
                     IsEnabled="{Binding CanUpdate}"

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -56,6 +56,9 @@ namespace Ryujinx.Ava.UI.Windows
         public static bool ShowKeyErrorOnLoad { get; set; }
         public ApplicationLibrary ApplicationLibrary { get; set; }
 
+        public readonly double StatusBarHeight;
+        public readonly double MenuBarHeight;
+
         public MainWindow()
         {
             ViewModel = new MainWindowViewModel();
@@ -74,7 +77,9 @@ namespace Ryujinx.Ava.UI.Windows
             ViewModel.Title = $"Ryujinx {Program.Version}";
 
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.
-            double barHeight = MenuBar.MinHeight + StatusBarView.StatusBar.MinHeight;
+            StatusBarHeight = StatusBarView.StatusBar.MinHeight;
+            MenuBarHeight = MenuBar.MinHeight;
+            double barHeight = MenuBarHeight + StatusBarHeight;
             Height = ((Height - barHeight) / Program.WindowScaleFactor) + barHeight;
             Width /= Program.WindowScaleFactor;
 


### PR DESCRIPTION
It's been sometime since the last PR #5415 was made and last time i was waiting for Ava 11 to be merged before re-writing the code and along the way forgot about the PR.

Anyway this PR supersedes both #5288 and #5415, and fixes issue: #5136

* Now, the bounds for which the cursor should be detected in renderer should be accurate to any scaling / resolution, taking into account the status and the menu bar. ( This issue was partially resolved by #6450 )

* Reduced the number of times the cursor updates from per frame update to updating only when the cursor state needs to be changed.

* Fixed the issue wherein you weren't able to resize the window, because of the cursor passthrough which caused the cursor to reset from the reset icon or flicker.

* Fixed the issue caused by #6450 which caused the cursor to disappear over the submenus while cursor was set to always hide.

* Changed the cursor state to not disappear while the game is being loaded. ( Needs Feedback ).

* Removed an unused library import.