### PR TITLE
HID: Correct direct mouse deltas

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/MouseDevice.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/MouseDevice.cs
@@ -23,8 +23,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 newState.Buttons = (MouseButton)buttons;
                 newState.X = mouseX;
                 newState.Y = mouseY;
-                newState.DeltaX = mouseX - previousEntry.DeltaX;
-                newState.DeltaY = mouseY - previousEntry.DeltaY;
+                newState.DeltaX = mouseX - previousEntry.X;
+                newState.DeltaY = mouseY - previousEntry.Y;
                 newState.WheelDeltaX = scrollX;
                 newState.WheelDeltaY = scrollY;
                 newState.Attributes = connected ? MouseAttribute.IsConnected : MouseAttribute.None;


### PR DESCRIPTION
The delta position of the mouse should be the difference between the current and last position. Subtracting the last deltas doesn't really make sense.

Won't implement pointer lock for first person games, but might stop some super weird behaviour with the mouse values appearing totally random.