### PR TITLE
Improves some log messages and fixes a typo

### DIFF
--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -181,21 +181,24 @@ namespace Ryujinx
             {
                 // No configuration, we load the default values and save it to disk
                 ConfigurationPath = appDataConfigurationPath;
+                Logger.Notice.Print(LogClass.Application, $"No configuration file found. Saving default configuration to: {ConfigurationPath}");
 
                 ConfigurationState.Instance.LoadDefault();
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
             }
             else
             {
+                Logger.Notice.Print(LogClass.Application, $"Loading configuration from: {ConfigurationPath}");
+
                 if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
                 {
                     ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
                 }
                 else
                 {
-                    ConfigurationState.Instance.LoadDefault();
+                    Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.\nFailed config location: {ConfigurationPath}");
 
-                    Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.\nFailed config location {ConfigurationPath}");
+                    ConfigurationState.Instance.LoadDefault();
                 }
             }
 

--- a/src/Ryujinx.UI.Common/App/ApplicationData.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationData.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.UI.App.Common
 
             if (!System.IO.Path.Exists(titleFilePath))
             {
-                Logger.Error?.Print(LogClass.Application, $"File does not exists. {titleFilePath}");
+                Logger.Error?.Print(LogClass.Application, $"File \"{titleFilePath}\" does not exist.");
                 return string.Empty;
             }
 

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -106,7 +106,7 @@ namespace Ryujinx.UI.App.Common
 
                     if (!Directory.Exists(appDir))
                     {
-                        Logger.Warning?.Print(LogClass.Application, $"The \"game_dirs\" section in \"{ReleaseInformation.ConfigName}\" contains an invalid directory: \"{appDir}\"");
+                        Logger.Warning?.Print(LogClass.Application, $"The specified game directory \"{appDir}\" does not exist.");
 
                         continue;
                     }

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1595,7 +1595,7 @@ namespace Ryujinx.UI.Common.Configuration
 
         private static void LogValueChange<T>(ReactiveEventArgs<T> eventArgs, string valueName)
         {
-            string message =  string.Create(CultureInfo.InvariantCulture, $"{valueName} set to: {eventArgs.NewValue}");
+            string message = string.Create(CultureInfo.InvariantCulture, $"{valueName} set to: {eventArgs.NewValue}");
             Ryujinx.Common.Logging.Logger.Info?.Print(LogClass.Configuration, message);
         }
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1596,6 +1596,7 @@ namespace Ryujinx.UI.Common.Configuration
         private static void LogValueChange<T>(ReactiveEventArgs<T> eventArgs, string valueName)
         {
             string message = string.Create(CultureInfo.InvariantCulture, $"{valueName} set to: {eventArgs.NewValue}");
+
             Ryujinx.Common.Logging.Logger.Info?.Print(LogClass.Configuration, message);
         }
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -11,6 +11,7 @@ using Ryujinx.UI.Common.Configuration.UI;
 using Ryujinx.UI.Common.Helper;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json.Nodes;
 
 namespace Ryujinx.UI.Common.Configuration
@@ -1594,7 +1595,8 @@ namespace Ryujinx.UI.Common.Configuration
 
         private static void LogValueChange<T>(ReactiveEventArgs<T> eventArgs, string valueName)
         {
-            Ryujinx.Common.Logging.Logger.Info?.Print(LogClass.Configuration, $"{valueName} set to: {eventArgs.NewValue}");
+            string message =  string.Create(CultureInfo.InvariantCulture, $"{valueName} set to: {eventArgs.NewValue}");
+            Ryujinx.Common.Logging.Logger.Info?.Print(LogClass.Configuration, message);
         }
 
         public static void Initialize()

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -148,21 +148,24 @@ namespace Ryujinx.Ava
             {
                 // No configuration, we load the default values and save it to disk
                 ConfigurationPath = appDataConfigurationPath;
+                Logger.Notice.Print(LogClass.Application, $"No configuration file found. Saving default configuration to: {ConfigurationPath}");
 
                 ConfigurationState.Instance.LoadDefault();
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
             }
             else
             {
+                Logger.Notice.Print(LogClass.Application, $"Loading configuration from: {ConfigurationPath}");
+
                 if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
                 {
                     ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
                 }
                 else
                 {
-                    ConfigurationState.Instance.LoadDefault();
+                    Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.\nFailed config location: {ConfigurationPath}");
 
-                    Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.\nFailed config location {ConfigurationPath}");
+                    ConfigurationState.Instance.LoadDefault();
                 }
             }
 


### PR DESCRIPTION
The main goal of this commit is to improve the somewhat cryptic wording of the log message that shows up when previously specified game directories no longer exist. I removed the config file's name from the message since the **vast** majority of users do not and should never interact with that file directly.

As for the change in `ConfigurationState.cs`: I noticed floats (like the one for `AudioVolume`) got formatted with the local culture for some reason, so I made it use the invariant culture.