### PR TITLE
BcatService: Return InternetRequestDenied for CmifCommand 10101

### DIFF
--- a/src/Ryujinx.Horizon/Bcat/Ipc/ServiceCreator/BcatService.cs
+++ b/src/Ryujinx.Horizon/Bcat/Ipc/ServiceCreator/BcatService.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.Horizon.Bcat.Types;
 using Ryujinx.Horizon.Common;
 using Ryujinx.Horizon.Sdk.Bcat;
@@ -15,6 +16,16 @@ namespace Ryujinx.Horizon.Bcat.Ipc
             deliveryCacheProgressService = new DeliveryCacheProgressService();
 
             return Result.Success;
+        }
+
+        [CmifCommand(10101)]
+        public Result RequestSyncDeliveryCacheWithDirectoryName(out IDeliveryCacheProgressService deliveryCacheProgressService)
+        {
+            // Temporary fix for Endless Ocean Luminous (010067B017588000).
+            // Just pretend the network request failed and pretend that everything is fine.
+            deliveryCacheProgressService = new DeliveryCacheProgressService();
+
+            return BcatResult.InternetRequestDenied;
         }
     }
 }

--- a/src/Ryujinx.Horizon/Sdk/Bcat/IBcatService.cs
+++ b/src/Ryujinx.Horizon/Sdk/Bcat/IBcatService.cs
@@ -6,5 +6,6 @@ namespace Ryujinx.Horizon.Sdk.Bcat
     internal interface IBcatService : IServiceObject
     {
         Result RequestSyncDeliveryCache(out IDeliveryCacheProgressService deliveryCacheProgressService);
+        Result RequestSyncDeliveryCacheWithDirectoryName(out IDeliveryCacheProgressService deliveryCacheProgressService);
     }
 }


### PR DESCRIPTION
Implementation for BcatService.RequestSyncDeliveryCacheWithDirectoryName()

Instead of trying to connect to official servers, returns BcatResult.InternetRequestDenied.

This fixes https://github.com/Ryujinx/Ryujinx-Games-List/issues/4953 , causing the game to be playable without "Ignore Missing Services". Skips the crash after Chapter 1-1. Also prompts an error message on trying to play online, alerting the user that internet access is not available.