### PR TITLE
Replace "List.ForEach" for "foreach"

### DIFF
--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -857,8 +857,8 @@ namespace ARMeilleure.Translation.PTC
 
             Stopwatch sw = Stopwatch.StartNew();
 
-            threads.ForEach((thread) => thread.Start());
-            threads.ForEach((thread) => thread.Join());
+            foreach (var thread in threads) thread.Start();
+            foreach (var thread in threads) thread.Join();
 
             threads.Clear();
 

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -858,9 +858,13 @@ namespace ARMeilleure.Translation.PTC
             Stopwatch sw = Stopwatch.StartNew();
 
             foreach (var thread in threads)
+            {
                 thread.Start();
+            }
             foreach (var thread in threads)
+            {
                 thread.Join();
+            }
 
             threads.Clear();
 

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -857,8 +857,10 @@ namespace ARMeilleure.Translation.PTC
 
             Stopwatch sw = Stopwatch.StartNew();
 
-            foreach (var thread in threads) thread.Start();
-            foreach (var thread in threads) thread.Join();
+            foreach (var thread in threads)
+                thread.Start();
+            foreach (var thread in threads)
+                thread.Join();
 
             threads.Clear();
 

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -395,8 +395,8 @@ namespace Ryujinx.Graphics.Gpu
             {
                 Renderer.CreateSync(SyncNumber, strict);
 
-                SyncActions.ForEach(action => action.SyncPreAction(syncpoint));
-                SyncpointActions.ForEach(action => action.SyncPreAction(syncpoint));
+                foreach (var action in SyncActions) action.SyncPreAction(syncpoint);
+                foreach (var action in SyncpointActions) action.SyncPreAction(syncpoint);
 
                 SyncNumber++;
 

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -395,8 +395,10 @@ namespace Ryujinx.Graphics.Gpu
             {
                 Renderer.CreateSync(SyncNumber, strict);
 
-                foreach (var action in SyncActions) action.SyncPreAction(syncpoint);
-                foreach (var action in SyncpointActions) action.SyncPreAction(syncpoint);
+                foreach (var action in SyncActions)
+                    action.SyncPreAction(syncpoint);
+                foreach (var action in SyncpointActions)
+                    action.SyncPreAction(syncpoint);
 
                 SyncNumber++;
 

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -396,9 +396,13 @@ namespace Ryujinx.Graphics.Gpu
                 Renderer.CreateSync(SyncNumber, strict);
 
                 foreach (var action in SyncActions)
+                {
                     action.SyncPreAction(syncpoint);
+                }
                 foreach (var action in SyncpointActions)
+                {
                     action.SyncPreAction(syncpoint);
+                }
 
                 SyncNumber++;
 


### PR DESCRIPTION
Benchmark:

```cs
[SimpleJob(RuntimeMoniker.Net80)]
[SimpleJob(RuntimeMoniker.Net90)]
[MemoryDiagnoser]
[RankColumn]
public class MyBenchmark
{
    private readonly List<string> _list = [];
    private readonly int _size = 100000;

    [GlobalSetup]
    public void Setup()
    {
        var random = new Random(420);
        for (var i = 0; i < _size; i++)
        {
            _list.Add(random.Next().ToString());
        }
    }

    [Benchmark]
    public string Foreach()
    {
        var result = string.Empty;
        foreach (var item in _list)
        {
            result = item;
        }
        return result;
    }

    [Benchmark]
    public string ListForeach()
    {
        var result = string.Empty;
        _list.ForEach(item => result = item);
        return result;
    }
}
```

Results:

```sh
| Method      | Job      | Runtime  | Mean      | Error    | StdDev   | Median    | Rank | Allocated |
|------------ |--------- |--------- |----------:|---------:|---------:|----------:|-----:|----------:|
| Foreach     | .NET 8.0 | .NET 8.0 |  57.10 us | 1.914 us | 5.491 us |  54.09 us |    1 |         - |
| ListForeach | .NET 8.0 | .NET 8.0 | 138.52 us | 2.690 us | 3.202 us | 138.13 us |    3 |      88 B |
| Foreach     | .NET 9.0 | .NET 9.0 |  53.82 us | 0.734 us | 0.613 us |  53.77 us |    1 |         - |
| ListForeach | .NET 9.0 | .NET 9.0 | 123.66 us | 1.493 us | 1.323 us | 123.64 us |    2 |      88 B |
```