### PR TITLE
GPU: Remove unused dynamic state and pipeline settings

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -180,9 +180,6 @@ namespace Ryujinx.Graphics.Vulkan
             pipeline.LogicOpEnable = state.LogicOpEnable;
             pipeline.LogicOp = state.LogicOp.Convert();
 
-            pipeline.MinDepthBounds = 0f; // Not implemented.
-            pipeline.MaxDepthBounds = 0f; // Not implemented.
-
             pipeline.PatchControlPoints = state.PatchControlPoints;
             pipeline.PolygonMode = PolygonMode.Fill; // Not implemented.
             pipeline.PrimitiveRestartEnable = state.PrimitiveRestartEnable;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -208,17 +208,11 @@ namespace Ryujinx.Graphics.Vulkan
             pipeline.StencilFrontPassOp = state.StencilTest.FrontDpPass.Convert();
             pipeline.StencilFrontDepthFailOp = state.StencilTest.FrontDpFail.Convert();
             pipeline.StencilFrontCompareOp = state.StencilTest.FrontFunc.Convert();
-            pipeline.StencilFrontCompareMask = 0;
-            pipeline.StencilFrontWriteMask = 0;
-            pipeline.StencilFrontReference = 0;
 
             pipeline.StencilBackFailOp = state.StencilTest.BackSFail.Convert();
             pipeline.StencilBackPassOp = state.StencilTest.BackDpPass.Convert();
             pipeline.StencilBackDepthFailOp = state.StencilTest.BackDpFail.Convert();
             pipeline.StencilBackCompareOp = state.StencilTest.BackFunc.Convert();
-            pipeline.StencilBackCompareMask = 0;
-            pipeline.StencilBackWriteMask = 0;
-            pipeline.StencilBackReference = 0;
 
             pipeline.StencilTestEnable = state.StencilTest.TestEnable;
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -618,7 +618,6 @@ namespace Ryujinx.Graphics.Vulkan
                     PDynamicState = &pipelineDynamicStateCreateInfo,
                     Layout = PipelineLayout,
                     RenderPass = renderPass,
-                    BasePipelineIndex = -1,
                 };
 
                 Result result = gd.Api.CreateGraphicsPipelines(device, cache, 1, &pipelineCreateInfo, null, &pipelineHandle);

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -504,19 +504,13 @@ namespace Ryujinx.Graphics.Vulkan
                     StencilFrontFailOp,
                     StencilFrontPassOp,
                     StencilFrontDepthFailOp,
-                    StencilFrontCompareOp,
-                    null,
-                    null,
-                    null);
+                    StencilFrontCompareOp);
 
                 var stencilBack = new StencilOpState(
                     StencilBackFailOp,
                     StencilBackPassOp,
                     StencilBackDepthFailOp,
-                    StencilBackCompareOp,
-                    null,
-                    null,
-                    null);
+                    StencilBackCompareOp);
 
                 var depthStencilState = new PipelineDepthStencilStateCreateInfo
                 {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -408,8 +408,6 @@ namespace Ryujinx.Graphics.Vulkan
             fixed (VertexInputAttributeDescription* pVertexAttributeDescriptions = &Internal.VertexAttributeDescriptions[0])
             fixed (VertexInputAttributeDescription* pVertexAttributeDescriptions2 = &_vertexAttributeDescriptions2[0])
             fixed (VertexInputBindingDescription* pVertexBindingDescriptions = &Internal.VertexBindingDescriptions[0])
-            fixed (Viewport* pViewports = &Internal.Viewports[0])
-            fixed (Rect2D* pScissors = &Internal.Scissors[0])
             fixed (PipelineColorBlendAttachmentState* pColorBlendAttachmentState = &Internal.ColorBlendAttachmentState[0])
             {
                 var vertexInputState = new PipelineVertexInputStateCreateInfo
@@ -472,18 +470,13 @@ namespace Ryujinx.Graphics.Vulkan
                     CullMode = CullMode,
                     FrontFace = FrontFace,
                     DepthBiasEnable = DepthBiasEnable,
-                    DepthBiasClamp = DepthBiasClamp,
-                    DepthBiasConstantFactor = DepthBiasConstantFactor,
-                    DepthBiasSlopeFactor = DepthBiasSlopeFactor,
                 };
 
                 var viewportState = new PipelineViewportStateCreateInfo
                 {
                     SType = StructureType.PipelineViewportStateCreateInfo,
                     ViewportCount = ViewportsCount,
-                    PViewports = pViewports,
                     ScissorCount = ScissorsCount,
-                    PScissors = pScissors,
                 };
 
                 if (gd.Capabilities.SupportsDepthClipControl)
@@ -512,18 +505,18 @@ namespace Ryujinx.Graphics.Vulkan
                     StencilFrontPassOp,
                     StencilFrontDepthFailOp,
                     StencilFrontCompareOp,
-                    StencilFrontCompareMask,
-                    StencilFrontWriteMask,
-                    StencilFrontReference);
+                    null,
+                    null,
+                    null);
 
                 var stencilBack = new StencilOpState(
                     StencilBackFailOp,
                     StencilBackPassOp,
                     StencilBackDepthFailOp,
                     StencilBackCompareOp,
-                    StencilBackCompareMask,
-                    StencilBackWriteMask,
-                    StencilBackReference);
+                    null,
+                    null,
+                    null);
 
                 var depthStencilState = new PipelineDepthStencilStateCreateInfo
                 {
@@ -591,22 +584,21 @@ namespace Ryujinx.Graphics.Vulkan
                 }
 
                 bool supportsExtDynamicState = gd.Capabilities.SupportsExtendedDynamicState;
-                int dynamicStatesCount = supportsExtDynamicState ? 9 : 8;
+                int dynamicStatesCount = supportsExtDynamicState ? 8 : 7;
 
                 DynamicState* dynamicStates = stackalloc DynamicState[dynamicStatesCount];
 
                 dynamicStates[0] = DynamicState.Viewport;
                 dynamicStates[1] = DynamicState.Scissor;
                 dynamicStates[2] = DynamicState.DepthBias;
-                dynamicStates[3] = DynamicState.DepthBounds;
-                dynamicStates[4] = DynamicState.StencilCompareMask;
-                dynamicStates[5] = DynamicState.StencilWriteMask;
-                dynamicStates[6] = DynamicState.StencilReference;
-                dynamicStates[7] = DynamicState.BlendConstants;
+                dynamicStates[3] = DynamicState.StencilCompareMask;
+                dynamicStates[4] = DynamicState.StencilWriteMask;
+                dynamicStates[5] = DynamicState.StencilReference;
+                dynamicStates[6] = DynamicState.BlendConstants;
 
                 if (supportsExtDynamicState)
                 {
-                    dynamicStates[8] = DynamicState.VertexInputBindingStrideExt;
+                    dynamicStates[7] = DynamicState.VertexInputBindingStrideExt;
                 }
 
                 var pipelineDynamicStateCreateInfo = new PipelineDynamicStateCreateInfo

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -71,244 +71,232 @@ namespace Ryujinx.Graphics.Vulkan
             set => Internal.Id4 = (Internal.Id4 & 0xFFFFFFFF) | ((ulong)value << 32);
         }
 
-        public float MinDepthBounds
-        {
-            readonly get => BitConverter.Int32BitsToSingle((int)((Internal.Id5 >> 0) & 0xFFFFFFFF));
-            set => Internal.Id5 = (Internal.Id5 & 0xFFFFFFFF00000000) | ((ulong)(uint)BitConverter.SingleToInt32Bits(value) << 0);
-        }
-
-        public float MaxDepthBounds
-        {
-            readonly get => BitConverter.Int32BitsToSingle((int)((Internal.Id5 >> 32) & 0xFFFFFFFF));
-            set => Internal.Id5 = (Internal.Id5 & 0xFFFFFFFF) | ((ulong)(uint)BitConverter.SingleToInt32Bits(value) << 32);
-        }
-
         public PolygonMode PolygonMode
         {
-            readonly get => (PolygonMode)((Internal.Id6 >> 0) & 0x3FFFFFFF);
-            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFC0000000) | ((ulong)value << 0);
+            readonly get => (PolygonMode)((Internal.Id5 >> 0) & 0x3FFFFFFF);
+            set => Internal.Id5 = (Internal.Id5 & 0xFFFFFFFFC0000000) | ((ulong)value << 0);
         }
 
         public uint StagesCount
         {
-            readonly get => (byte)((Internal.Id6 >> 30) & 0xFF);
-            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFC03FFFFFFF) | ((ulong)value << 30);
+            readonly get => (byte)((Internal.Id5 >> 30) & 0xFF);
+            set => Internal.Id5 = (Internal.Id5 & 0xFFFFFFC03FFFFFFF) | ((ulong)value << 30);
         }
 
         public uint VertexAttributeDescriptionsCount
         {
-            readonly get => (byte)((Internal.Id6 >> 38) & 0xFF);
-            set => Internal.Id6 = (Internal.Id6 & 0xFFFFC03FFFFFFFFF) | ((ulong)value << 38);
+            readonly get => (byte)((Internal.Id5 >> 38) & 0xFF);
+            set => Internal.Id5 = (Internal.Id5 & 0xFFFFC03FFFFFFFFF) | ((ulong)value << 38);
         }
 
         public uint VertexBindingDescriptionsCount
         {
-            readonly get => (byte)((Internal.Id6 >> 46) & 0xFF);
-            set => Internal.Id6 = (Internal.Id6 & 0xFFC03FFFFFFFFFFF) | ((ulong)value << 46);
+            readonly get => (byte)((Internal.Id5 >> 46) & 0xFF);
+            set => Internal.Id5 = (Internal.Id5 & 0xFFC03FFFFFFFFFFF) | ((ulong)value << 46);
         }
 
         public uint ViewportsCount
         {
-            readonly get => (byte)((Internal.Id6 >> 54) & 0xFF);
-            set => Internal.Id6 = (Internal.Id6 & 0xC03FFFFFFFFFFFFF) | ((ulong)value << 54);
+            readonly get => (byte)((Internal.Id5 >> 54) & 0xFF);
+            set => Internal.Id5 = (Internal.Id5 & 0xC03FFFFFFFFFFFFF) | ((ulong)value << 54);
         }
 
         public uint ScissorsCount
         {
-            readonly get => (byte)((Internal.Id7 >> 0) & 0xFF);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFFFFFFFF00) | ((ulong)value << 0);
+            readonly get => (byte)((Internal.Id6 >> 0) & 0xFF);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFFFFFFF00) | ((ulong)value << 0);
         }
 
         public uint ColorBlendAttachmentStateCount
         {
-            readonly get => (byte)((Internal.Id7 >> 8) & 0xFF);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFFFFFF00FF) | ((ulong)value << 8);
+            readonly get => (byte)((Internal.Id6 >> 8) & 0xFF);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFFFFF00FF) | ((ulong)value << 8);
         }
 
         public PrimitiveTopology Topology
         {
-            readonly get => (PrimitiveTopology)((Internal.Id7 >> 16) & 0xF);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFFFFF0FFFF) | ((ulong)value << 16);
+            readonly get => (PrimitiveTopology)((Internal.Id6 >> 16) & 0xF);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFFFF0FFFF) | ((ulong)value << 16);
         }
 
         public LogicOp LogicOp
         {
-            readonly get => (LogicOp)((Internal.Id7 >> 20) & 0xF);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFFFF0FFFFF) | ((ulong)value << 20);
+            readonly get => (LogicOp)((Internal.Id6 >> 20) & 0xF);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFFF0FFFFF) | ((ulong)value << 20);
         }
 
         public CompareOp DepthCompareOp
         {
-            readonly get => (CompareOp)((Internal.Id7 >> 24) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFFF8FFFFFF) | ((ulong)value << 24);
+            readonly get => (CompareOp)((Internal.Id6 >> 24) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFF8FFFFFF) | ((ulong)value << 24);
         }
 
         public StencilOp StencilFrontFailOp
         {
-            readonly get => (StencilOp)((Internal.Id7 >> 27) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFFC7FFFFFF) | ((ulong)value << 27);
+            readonly get => (StencilOp)((Internal.Id6 >> 27) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFFC7FFFFFF) | ((ulong)value << 27);
         }
 
         public StencilOp StencilFrontPassOp
         {
-            readonly get => (StencilOp)((Internal.Id7 >> 30) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFE3FFFFFFF) | ((ulong)value << 30);
+            readonly get => (StencilOp)((Internal.Id6 >> 30) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFFE3FFFFFFF) | ((ulong)value << 30);
         }
 
         public StencilOp StencilFrontDepthFailOp
         {
-            readonly get => (StencilOp)((Internal.Id7 >> 33) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFF1FFFFFFFF) | ((ulong)value << 33);
+            readonly get => (StencilOp)((Internal.Id6 >> 33) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFFF1FFFFFFFF) | ((ulong)value << 33);
         }
 
         public CompareOp StencilFrontCompareOp
         {
-            readonly get => (CompareOp)((Internal.Id7 >> 36) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFF8FFFFFFFFF) | ((ulong)value << 36);
+            readonly get => (CompareOp)((Internal.Id6 >> 36) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFF8FFFFFFFFF) | ((ulong)value << 36);
         }
 
         public StencilOp StencilBackFailOp
         {
-            readonly get => (StencilOp)((Internal.Id7 >> 39) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFC7FFFFFFFFF) | ((ulong)value << 39);
+            readonly get => (StencilOp)((Internal.Id6 >> 39) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFFC7FFFFFFFFF) | ((ulong)value << 39);
         }
 
         public StencilOp StencilBackPassOp
         {
-            readonly get => (StencilOp)((Internal.Id7 >> 42) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFFE3FFFFFFFFFF) | ((ulong)value << 42);
+            readonly get => (StencilOp)((Internal.Id6 >> 42) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFFE3FFFFFFFFFF) | ((ulong)value << 42);
         }
 
         public StencilOp StencilBackDepthFailOp
         {
-            readonly get => (StencilOp)((Internal.Id7 >> 45) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFFF1FFFFFFFFFFF) | ((ulong)value << 45);
+            readonly get => (StencilOp)((Internal.Id6 >> 45) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFFF1FFFFFFFFFFF) | ((ulong)value << 45);
         }
 
         public CompareOp StencilBackCompareOp
         {
-            readonly get => (CompareOp)((Internal.Id7 >> 48) & 0x7);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFF8FFFFFFFFFFFF) | ((ulong)value << 48);
+            readonly get => (CompareOp)((Internal.Id6 >> 48) & 0x7);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFF8FFFFFFFFFFFF) | ((ulong)value << 48);
         }
 
         public CullModeFlags CullMode
         {
-            readonly get => (CullModeFlags)((Internal.Id7 >> 51) & 0x3);
-            set => Internal.Id7 = (Internal.Id7 & 0xFFE7FFFFFFFFFFFF) | ((ulong)value << 51);
+            readonly get => (CullModeFlags)((Internal.Id6 >> 51) & 0x3);
+            set => Internal.Id6 = (Internal.Id6 & 0xFFE7FFFFFFFFFFFF) | ((ulong)value << 51);
         }
 
         public bool PrimitiveRestartEnable
         {
-            readonly get => ((Internal.Id7 >> 53) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xFFDFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 53);
+            readonly get => ((Internal.Id6 >> 53) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xFFDFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 53);
         }
 
         public bool DepthClampEnable
         {
-            readonly get => ((Internal.Id7 >> 54) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xFFBFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 54);
+            readonly get => ((Internal.Id6 >> 54) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xFFBFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 54);
         }
 
         public bool RasterizerDiscardEnable
         {
-            readonly get => ((Internal.Id7 >> 55) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xFF7FFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 55);
+            readonly get => ((Internal.Id6 >> 55) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xFF7FFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 55);
         }
 
         public FrontFace FrontFace
         {
-            readonly get => (FrontFace)((Internal.Id7 >> 56) & 0x1);
-            set => Internal.Id7 = (Internal.Id7 & 0xFEFFFFFFFFFFFFFF) | ((ulong)value << 56);
+            readonly get => (FrontFace)((Internal.Id6 >> 56) & 0x1);
+            set => Internal.Id6 = (Internal.Id6 & 0xFEFFFFFFFFFFFFFF) | ((ulong)value << 56);
         }
 
         public bool DepthBiasEnable
         {
-            readonly get => ((Internal.Id7 >> 57) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xFDFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 57);
+            readonly get => ((Internal.Id6 >> 57) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xFDFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 57);
         }
 
         public bool DepthTestEnable
         {
-            readonly get => ((Internal.Id7 >> 58) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xFBFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 58);
+            readonly get => ((Internal.Id6 >> 58) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xFBFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 58);
         }
 
         public bool DepthWriteEnable
         {
-            readonly get => ((Internal.Id7 >> 59) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xF7FFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 59);
+            readonly get => ((Internal.Id6 >> 59) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xF7FFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 59);
         }
 
         public bool DepthBoundsTestEnable
         {
-            readonly get => ((Internal.Id7 >> 60) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xEFFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 60);
+            readonly get => ((Internal.Id6 >> 60) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xEFFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 60);
         }
 
         public bool StencilTestEnable
         {
-            readonly get => ((Internal.Id7 >> 61) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xDFFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 61);
+            readonly get => ((Internal.Id6 >> 61) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xDFFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 61);
         }
 
         public bool LogicOpEnable
         {
-            readonly get => ((Internal.Id7 >> 62) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0xBFFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 62);
+            readonly get => ((Internal.Id6 >> 62) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0xBFFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 62);
         }
 
         public bool HasDepthStencil
         {
-            readonly get => ((Internal.Id7 >> 63) & 0x1) != 0UL;
-            set => Internal.Id7 = (Internal.Id7 & 0x7FFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 63);
+            readonly get => ((Internal.Id6 >> 63) & 0x1) != 0UL;
+            set => Internal.Id6 = (Internal.Id6 & 0x7FFFFFFFFFFFFFFF) | ((value ? 1UL : 0UL) << 63);
         }
 
         public uint PatchControlPoints
         {
-            readonly get => (uint)((Internal.Id8 >> 0) & 0xFFFFFFFF);
-            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFF00000000) | ((ulong)value << 0);
+            readonly get => (uint)((Internal.Id7 >> 0) & 0xFFFFFFFF);
+            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFF00000000) | ((ulong)value << 0);
         }
 
         public uint SamplesCount
         {
-            readonly get => (uint)((Internal.Id8 >> 32) & 0xFFFFFFFF);
-            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFF) | ((ulong)value << 32);
+            readonly get => (uint)((Internal.Id7 >> 32) & 0xFFFFFFFF);
+            set => Internal.Id7 = (Internal.Id7 & 0xFFFFFFFF) | ((ulong)value << 32);
         }
 
         public bool AlphaToCoverageEnable
         {
-            readonly get => ((Internal.Id9 >> 0) & 0x1) != 0UL;
-            set => Internal.Id9 = (Internal.Id9 & 0xFFFFFFFFFFFFFFFE) | ((value ? 1UL : 0UL) << 0);
+            readonly get => ((Internal.Id8 >> 0) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFFE) | ((value ? 1UL : 0UL) << 0);
         }
 
         public bool AlphaToOneEnable
         {
-            readonly get => ((Internal.Id9 >> 1) & 0x1) != 0UL;
-            set => Internal.Id9 = (Internal.Id9 & 0xFFFFFFFFFFFFFFFD) | ((value ? 1UL : 0UL) << 1);
+            readonly get => ((Internal.Id8 >> 1) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFFD) | ((value ? 1UL : 0UL) << 1);
         }
 
         public bool AdvancedBlendSrcPreMultiplied
         {
-            readonly get => ((Internal.Id9 >> 2) & 0x1) != 0UL;
-            set => Internal.Id9 = (Internal.Id9 & 0xFFFFFFFFFFFFFFFB) | ((value ? 1UL : 0UL) << 2);
+            readonly get => ((Internal.Id8 >> 2) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFFB) | ((value ? 1UL : 0UL) << 2);
         }
 
         public bool AdvancedBlendDstPreMultiplied
         {
-            readonly get => ((Internal.Id9 >> 3) & 0x1) != 0UL;
-            set => Internal.Id9 = (Internal.Id9 & 0xFFFFFFFFFFFFFFF7) | ((value ? 1UL : 0UL) << 3);
+            readonly get => ((Internal.Id8 >> 3) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFF7) | ((value ? 1UL : 0UL) << 3);
         }
 
         public BlendOverlapEXT AdvancedBlendOverlap
         {
-            readonly get => (BlendOverlapEXT)((Internal.Id9 >> 4) & 0x3);
-            set => Internal.Id9 = (Internal.Id9 & 0xFFFFFFFFFFFFFFCF) | ((ulong)value << 4);
+            readonly get => (BlendOverlapEXT)((Internal.Id8 >> 4) & 0x3);
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFCF) | ((ulong)value << 4);
         }
 
         public bool DepthMode
         {
-            readonly get => ((Internal.Id9 >> 6) & 0x1) != 0UL;
-            set => Internal.Id9 = (Internal.Id9 & 0xFFFFFFFFFFFFFFBF) | ((value ? 1UL : 0UL) << 6);
+            readonly get => ((Internal.Id8 >> 6) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFBF) | ((value ? 1UL : 0UL) << 6);
         }
 
         public bool HasTessellationControlShader;
@@ -518,12 +506,10 @@ namespace Ryujinx.Graphics.Vulkan
                     DepthTestEnable = DepthTestEnable,
                     DepthWriteEnable = DepthWriteEnable,
                     DepthCompareOp = DepthCompareOp,
-                    DepthBoundsTestEnable = DepthBoundsTestEnable,
+                    DepthBoundsTestEnable = false,
                     StencilTestEnable = StencilTestEnable,
                     Front = stencilFront,
                     Back = stencilBack,
-                    MinDepthBounds = MinDepthBounds,
-                    MaxDepthBounds = MaxDepthBounds,
                 };
 
                 uint blendEnables = 0;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
@@ -17,15 +17,14 @@ namespace Ryujinx.Graphics.Vulkan
         public ulong Id4;
         public ulong Id5;
         public ulong Id6;
+
         public ulong Id7;
-
         public ulong Id8;
-        public ulong Id9;
 
-        private readonly uint VertexAttributeDescriptionsCount => (byte)((Id6 >> 38) & 0xFF);
-        private readonly uint VertexBindingDescriptionsCount => (byte)((Id6 >> 46) & 0xFF);
-        private readonly uint ColorBlendAttachmentStateCount => (byte)((Id7 >> 8) & 0xFF);
-        private readonly bool HasDepthStencil => ((Id7 >> 63) & 0x1) != 0UL;
+        private readonly uint VertexAttributeDescriptionsCount => (byte)((Id5 >> 38) & 0xFF);
+        private readonly uint VertexBindingDescriptionsCount => (byte)((Id5 >> 46) & 0xFF);
+        private readonly uint ColorBlendAttachmentStateCount => (byte)((Id6 >> 8) & 0xFF);
+        private readonly bool HasDepthStencil => ((Id6 >> 63) & 0x1) != 0UL;
 
         public Array32<VertexInputAttributeDescription> VertexAttributeDescriptions;
         public Array33<VertexInputBindingDescription> VertexBindingDescriptions;
@@ -43,7 +42,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (!Unsafe.As<ulong, Vector256<byte>>(ref Id0).Equals(Unsafe.As<ulong, Vector256<byte>>(ref other.Id0)) ||
                 !Unsafe.As<ulong, Vector256<byte>>(ref Id4).Equals(Unsafe.As<ulong, Vector256<byte>>(ref other.Id4)) ||
-                !Unsafe.As<ulong, Vector128<byte>>(ref Id8).Equals(Unsafe.As<ulong, Vector128<byte>>(ref other.Id8)))
+                !Unsafe.As<ulong, Vector128<byte>>(ref Id7).Equals(Unsafe.As<ulong, Vector128<byte>>(ref other.Id7)))
             {
                 return false;
             }
@@ -86,8 +85,7 @@ namespace Ryujinx.Graphics.Vulkan
                            Id5 * 23 ^
                            Id6 * 23 ^
                            Id7 * 23 ^
-                           Id8 * 23 ^
-                           Id9 * 23;
+                           Id8 * 23;
 
             for (int i = 0; i < (int)VertexAttributeDescriptionsCount; i++)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
@@ -29,8 +29,6 @@ namespace Ryujinx.Graphics.Vulkan
 
         public Array32<VertexInputAttributeDescription> VertexAttributeDescriptions;
         public Array33<VertexInputBindingDescription> VertexBindingDescriptions;
-        public Array16<Viewport> Viewports;
-        public Array16<Rect2D> Scissors;
         public Array8<PipelineColorBlendAttachmentState> ColorBlendAttachmentState;
         public Array9<Format> AttachmentFormats;
         public uint AttachmentIntegerFormatMask;


### PR DESCRIPTION
- Removed dynamic state setting for Depth Bounds from PipelineDynamicStateCreateInfo as the command to set them is never used. At best this means no change. At worst this may have caused some validation errors?  
- Avoid passing pointers for viewport and scissor since these dynamic states are supported across devices that support Vulkan. 
- Removed references to unused DepthBias values and StencilOpState for both Front and Back.

This change likely has no user facing changes, but just need to check if there is anything broken. Just clean-up for future changes. 