### PR TITLE
Revert "Disable keyboard controller input while swkbd is open (foreground)"

### DIFF
--- a/src/Ryujinx.Gtk3/Input/GTK3/GTK3KeyboardDriver.cs
+++ b/src/Ryujinx.Gtk3/Input/GTK3/GTK3KeyboardDriver.cs
@@ -81,11 +81,6 @@ namespace Ryujinx.Input.GTK3
             return _pressedKeys.Contains(nativeKey);
         }
 
-        public void Clear()
-        {
-            _pressedKeys.Clear();
-        }
-
         public IGamepad GetGamepad(string id)
         {
             if (!_keyboardIdentifers[0].Equals(id))

--- a/src/Ryujinx.Gtk3/UI/Applet/GtkHostUIHandler.cs
+++ b/src/Ryujinx.Gtk3/UI/Applet/GtkHostUIHandler.cs
@@ -107,8 +107,6 @@ namespace Ryujinx.UI.Applet
                     swkbdDialog.SetInputLengthValidation(args.StringLengthMin, args.StringLengthMax);
                     swkbdDialog.SetInputValidation(args.KeyboardMode);
 
-                    ((MainWindow)_parent).RendererWidget.NpadManager.BlockInputUpdates();
-
                     if (swkbdDialog.Run() == (int)ResponseType.Ok)
                     {
                         inputText = swkbdDialog.InputEntry.Text;
@@ -130,7 +128,6 @@ namespace Ryujinx.UI.Applet
             });
 
             dialogCloseEvent.WaitOne();
-            ((MainWindow)_parent).RendererWidget.NpadManager.UnblockInputUpdates();
 
             userText = error ? null : inputText;
 

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -174,11 +174,6 @@ namespace Ryujinx.Input.HLE
         {
             lock (_lock)
             {
-                foreach (InputConfig inputConfig in _inputConfig)
-                {
-                    _controllers[(int)inputConfig.PlayerIndex].GamepadDriver.Clear();
-                }
-
                 _blockInputUpdates = false;
             }
         }

--- a/src/Ryujinx.Input/IGamepadDriver.cs
+++ b/src/Ryujinx.Input/IGamepadDriver.cs
@@ -33,11 +33,5 @@ namespace Ryujinx.Input
         /// <param name="id">The unique id of the gamepad</param>
         /// <returns>An instance of <see cref="IGamepad"/> associated to the gamepad id given or null if not found</returns>
         IGamepad GetGamepad(string id);
-
-        /// <summary>
-        /// Flush the internal state of the driver.
-        /// </summary>
-        /// <remarks>Does nothing by default.</remarks>
-        void Clear() { }
     }
 }

--- a/src/Ryujinx/Input/AvaloniaKeyboard.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboard.cs
@@ -195,7 +195,7 @@ namespace Ryujinx.Ava.Input
 
         public void Clear()
         {
-            _driver?.Clear();
+            _driver?.ResetKeys();
         }
 
         public void Dispose() { }

--- a/src/Ryujinx/Input/AvaloniaKeyboardDriver.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboardDriver.cs
@@ -94,7 +94,7 @@ namespace Ryujinx.Ava.Input
             return _pressedKeys.Contains(nativeKey);
         }
 
-        public void Clear()
+        public void ResetKeys()
         {
             _pressedKeys.Clear();
         }

--- a/src/Ryujinx/UI/Applet/AvaHostUIHandler.cs
+++ b/src/Ryujinx/UI/Applet/AvaHostUIHandler.cs
@@ -122,7 +122,6 @@ namespace Ryujinx.Ava.UI.Applet
             {
                 try
                 {
-                    _parent.ViewModel.AppHost.NpadManager.BlockInputUpdates();
                     var response = await SwkbdAppletDialog.ShowInputDialog(LocaleManager.Instance[LocaleKeys.SoftwareKeyboard], args);
 
                     if (response.Result == UserResult.Ok)
@@ -144,7 +143,6 @@ namespace Ryujinx.Ava.UI.Applet
             });
 
             dialogCloseEvent.WaitOne();
-            _parent.ViewModel.AppHost.NpadManager.UnblockInputUpdates();
 
             userText = error ? null : inputText;
 


### PR DESCRIPTION
Reverts Ryujinx/Ryujinx#6646

Reverting because "it causes pokemon to crash upon starting a new save and naming the char".