### PR TITLE
misc: Change Deflate compression level to `Fastest`

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
@@ -141,7 +141,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
 
             if (algorithm == CompressionAlgorithm.Deflate)
             {
-                _activeStream = new DeflateStream(_stream, CompressionLevel.SmallestSize, true);
+                _activeStream = new DeflateStream(_stream, CompressionLevel.Fastest, true);
             }
         }
 
@@ -206,7 +206,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     stream.Write(data);
                     break;
                 case CompressionAlgorithm.Deflate:
-                    stream = new DeflateStream(stream, CompressionLevel.SmallestSize, true);
+                    stream = new DeflateStream(stream, CompressionLevel.Fastest, true);
                     stream.Write(data);
                     stream.Dispose();
                     break;


### PR DESCRIPTION
From my own empirical testing, `SmallestSize` is, naturally the slowest algorithm:
![image](https://github.com/Ryujinx/Ryujinx/assets/44103205/7170087e-ad69-4aff-ab82-99e66cb8a959)

It also has seemingly no benefit over faster algorithms for the current disk cache data structure:
![image](https://github.com/Ryujinx/Ryujinx/assets/44103205/622077d1-e53c-4c8c-ae1d-81c6e37a2bbd)

Based on these results the changes here simply update the compression level to `Fastest`. There was a near 14x speedup in the "packaging" stage of rebuild with a minimal 7% increase in disk usage.

Testing would be appreciated with some other games.

