### PR TITLE
HID: Fix another NullReferenceException when unblocking input updates

### DIFF
--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -176,7 +176,7 @@ namespace Ryujinx.Input.HLE
             {
                 foreach (InputConfig inputConfig in _inputConfig)
                 {
-                    _controllers[(int)inputConfig.PlayerIndex].GamepadDriver?.Clear();
+                    _controllers[(int)inputConfig.PlayerIndex]?.GamepadDriver?.Clear();
                 }
 
                 _blockInputUpdates = false;


### PR DESCRIPTION
I can't reproduce this locally, but the person crashing on discord reported that it worked fine with this fix.

Feels really bad to have a 2nd PR to address the same issue, but I guess it can't be helped.
I'll try to look into creating more/better unit tests when LDN upstreaming is done.