### PR TITLE
Kernel: Wake cores from idle directly rather than through a host thread

### DIFF
--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KScheduler.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KScheduler.cs
@@ -236,7 +236,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
         private void ActivateIdleThread()
         {
             while (Interlocked.CompareExchange(ref _coreIdleLock, 1, 0) != 0)
-            { }
+            {
+                Thread.SpinWait(1);
+            }
 
             Thread.MemoryBarrier();
 
@@ -251,7 +253,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
         private void NotifyIdleThread()
         {
             while (Interlocked.CompareExchange(ref _coreIdleLock, 1, 0) != 0)
-            { }
+            {
+                Thread.SpinWait(1);
+            }
 
             Thread.MemoryBarrier();
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KScheduler.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KScheduler.cs
@@ -221,10 +221,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
                 KThread threadToSignal = context.Schedulers[coreToSignal]._currentThread;
 
                 // Request the thread running on that core to stop and reschedule, if we have one.
-                if (threadToSignal != null)
-                {
-                    threadToSignal.Context.RequestInterrupt();
-                }
+                threadToSignal?.Context.RequestInterrupt();
 
                 // If the core is idle, ensure that the idle thread is awaken.
                 context.Schedulers[coreToSignal].NotifyIdleThread();

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KScheduler.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KScheduler.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using System;
-using System.Diagnostics;
 using System.Numerics;
 using System.Threading;
 
@@ -294,8 +293,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
             {
                 return;
             }
-
-            Debug.Assert(currentThread != null);
 
             currentThread.SchedulerWaitEvent.Reset();
             currentThread.ThreadContext.Unlock();

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -6,7 +6,6 @@ using Ryujinx.HLE.HOS.Kernel.SupervisorCall;
 using Ryujinx.Horizon.Common;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
 using System.Threading;
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/ThreadType.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/ThreadType.cs
@@ -2,7 +2,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 {
     enum ThreadType
     {
-        Dummy,
         Kernel,
         Kernel2,
         User,

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -515,14 +515,11 @@ namespace Ryujinx.HLE.HOS.Services
         {
             if (disposing && _selfThread != null)
             {
-                if (_selfThread.HostThread != null)
+                if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId && _selfThread.HostThread.Join(_threadJoinTimeout) == false)
                 {
-                    if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId && _selfThread.HostThread.Join(_threadJoinTimeout) == false)
-                    {
-                        Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {_threadJoinTimeout:g}, waiting longer.");
+                    Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {_threadJoinTimeout:g}, waiting longer.");
 
-                        _selfThread.HostThread.Join(Timeout.Infinite);
-                    }
+                    _selfThread.HostThread.Join(Timeout.Infinite);
                 }
 
                 if (Interlocked.Exchange(ref _isDisposed, 1) == 0)

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -515,11 +515,14 @@ namespace Ryujinx.HLE.HOS.Services
         {
             if (disposing && _selfThread != null)
             {
-                if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId && _selfThread.HostThread.Join(_threadJoinTimeout) == false)
+                if (_selfThread.HostThread != null)
                 {
-                    Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {_threadJoinTimeout:g}, waiting longer.");
+                    if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId && _selfThread.HostThread.Join(_threadJoinTimeout) == false)
+                    {
+                        Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {_threadJoinTimeout:g}, waiting longer.");
 
-                    _selfThread.HostThread.Join(Timeout.Infinite);
+                        _selfThread.HostThread.Join(Timeout.Infinite);
+                    }
                 }
 
                 if (Interlocked.Exchange(ref _isDisposed, 1) == 0)


### PR DESCRIPTION
Right now when a core enters an idle state, leaving that idle state requires us to first signal the core's idle thread, which then signals the correct thread that we want to run on the core. This means that in a lot of cases, we're paying double for a thread to be awoken from an idle state.

This PR moves this process to happen on the thread that is waking others out of idle, instead of an idle thread that needs to be awoken first.

For compatibility the process has been kept as similar as possible - the process for IdleThreadLoop has been migrated to TryLeaveIdle, and is gated by a condition variable that lets it run only once at a time for each core. A core is only considered for wake from idle if idle is both active and has been signalled - the signal is consumed and the active state is cleared when the core leaves idle. Maybe we could go further with this to avoid waiting on other thread signals to complete, but a port of the current behaviour is the safest improvement for now.

~~Dummy threads (just the idle thread at the moment) have been changed to have no host thread, as the work is now done by threads entering idle and signalling out of it.~~ The idle thread has been removed entirely, and idle core state is now directly on the scheduler.

This could put a bit of extra work on threads that would have triggered `_idleInterruptEvent` before, but I'd expect less time wasted than signalling all those reset events and the OS overhead that follows. Worst case is that other threads performing these signals at the same time will have to wait for each other, but it's still going to be a very short amount of time.

Improvements are very slight, but are best seen in games with heavy (or very misguided) multithreading, such as Pokemon: Legends Arceus. Improvements are expected in Scarlet/Violet and TOTK, but are harder to measure due to GPU trouble.

Testing on Linux/MacOS still to be done, definitely need to test more games as this affects all of them (obviously) and any issues might be rare to encounter.