### PR TITLE
misc: Change disk shader cache compression algorithm to `Brotli` (RFC 7932)

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
@@ -135,6 +135,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                 case CompressionAlgorithm.Brotli:
                     _activeStream = new BrotliStream(_stream, CompressionMode.Decompress, true);
                     break;
+                default:
+                    throw new ArgumentException($"Invalid compression algorithm \"{algorithm}\"");
             }
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
@@ -237,7 +237,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     stream.Dispose();
                     break;
                 case CompressionAlgorithm.Brotli:
-                    stream = new BrotliStream(stream, CompressionLevel.Optimal, true);
+                    stream = new BrotliStream(stream, CompressionLevel.Fastest, true);
                     stream.Write(data);
                     stream.Dispose();
                     break;

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
@@ -125,9 +125,16 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             CompressionAlgorithm algorithm = CompressionAlgorithm.None;
             Read(ref algorithm);
 
-            if (algorithm == CompressionAlgorithm.Deflate)
+            switch (algorithm)
             {
-                _activeStream = new DeflateStream(_stream, CompressionMode.Decompress, true);
+                case CompressionAlgorithm.None:
+                    break;
+                case CompressionAlgorithm.Deflate:
+                    _activeStream = new DeflateStream(_stream, CompressionMode.Decompress, true);
+                    break;
+                case CompressionAlgorithm.Brotli:
+                    _activeStream = new BrotliStream(_stream, CompressionMode.Decompress, true);
+                    break;
             }
         }
 
@@ -139,9 +146,18 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         {
             Write(ref algorithm);
 
-            if (algorithm == CompressionAlgorithm.Deflate)
+            switch (algorithm)
             {
-                _activeStream = new DeflateStream(_stream, CompressionLevel.Fastest, true);
+                case CompressionAlgorithm.None:
+                    break;
+                case CompressionAlgorithm.Deflate:
+                    _activeStream = new DeflateStream(_stream, CompressionLevel.Fastest, true);
+                    break;
+                case CompressionAlgorithm.Brotli:
+                    _activeStream = new BrotliStream(_stream, CompressionLevel.Fastest, true);
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid compression algorithm \"{algorithm}\"");
             }
         }
 
@@ -187,6 +203,14 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     }
                     stream.Dispose();
                     break;
+                case CompressionAlgorithm.Brotli:
+                    stream = new BrotliStream(stream, CompressionMode.Decompress, true);
+                    for (int offset = 0; offset < data.Length;)
+                    {
+                        offset += stream.Read(data[offset..]);
+                    }
+                    stream.Dispose();
+                    break;
             }
         }
 
@@ -207,6 +231,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     break;
                 case CompressionAlgorithm.Deflate:
                     stream = new DeflateStream(stream, CompressionLevel.Fastest, true);
+                    stream.Write(data);
+                    stream.Dispose();
+                    break;
+                case CompressionAlgorithm.Brotli:
+                    stream = new BrotliStream(stream, CompressionLevel.Optimal, true);
                     stream.Write(data);
                     stream.Dispose();
                     break;

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/CompressionAlgorithm.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/CompressionAlgorithm.cs
@@ -14,5 +14,10 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         /// Deflate compression (RFC 1951).
         /// </summary>
         Deflate,
+
+        /// <summary>
+        /// Brotli compression (RFC 7932).
+        /// </summary>
+        Brotli,
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheCommon.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheCommon.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         /// <returns>Compression algorithm</returns>
         public static CompressionAlgorithm GetCompressionAlgorithm()
         {
-            return CompressionAlgorithm.Deflate;
+            return CompressionAlgorithm.Brotli;
         }
     }
 }


### PR DESCRIPTION
.NET offers a number of compression algorithms built into `System.IO.Compression`.
- Deflate (current default)
- Brotli
- GZip
- Zlib

While initially I simply updated the shader cache logic to use the fastest version of `Deflate`, `Brotli` is actually 40% faster under equal load and matches the compression ratio at each level.
![image](https://github.com/Ryujinx/Ryujinx/assets/44103205/037fa043-712d-4380-8de1-f70985dcf605)
![image](https://github.com/Ryujinx/Ryujinx/assets/44103205/e4fd62bc-5bc4-4d33-b29d-7347f86af064)

Testing would be nice to make sure this doesn't change disproportionately on lower end systems or something. 