### PR TITLE
Avoid inexact read with 'Stream.Read'

### DIFF
--- a/src/ARMeilleure/CodeGen/Arm64/CodeGenContext.cs
+++ b/src/ARMeilleure/CodeGen/Arm64/CodeGenContext.cs
@@ -237,7 +237,7 @@ namespace ARMeilleure.CodeGen.Arm64
             long originalPosition = _stream.Position;
 
             _stream.Seek(0, SeekOrigin.Begin);
-            _stream.Read(code, 0, code.Length);
+            _stream.ReadExactly(code, 0, code.Length);
             _stream.Seek(originalPosition, SeekOrigin.Begin);
 
             RelocInfo relocInfo;

--- a/src/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/src/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -1444,7 +1444,7 @@ namespace ARMeilleure.CodeGen.X86
 
                 Span<byte> buffer = new byte[jump.JumpPosition - _stream.Position];
 
-                _stream.Read(buffer);
+                _stream.ReadExactly(buffer);
                 _stream.Seek(ReservedBytesForJump, SeekOrigin.Current);
 
                 codeStream.Write(buffer);

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BinarySerializer.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             switch (algorithm)
             {
                 case CompressionAlgorithm.None:
-                    stream.Read(data);
+                    stream.ReadExactly(data);
                     break;
                 case CompressionAlgorithm.Deflate:
                     stream = new DeflateStream(stream, CompressionMode.Decompress, true);

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheGuestStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheGuestStorage.cs
@@ -220,7 +220,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                 }
 
                 dataFileStream.Seek((long)entry.Offset, SeekOrigin.Begin);
-                dataFileStream.Read(cb1Data);
+                dataFileStream.ReadExactly(cb1Data);
                 BinarySerializer.ReadCompressed(dataFileStream, guestCode);
 
                 _cache[index] = (guestCode, cb1Data);
@@ -279,7 +279,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     dataFileStream.Seek((long)entry.Offset, SeekOrigin.Begin);
                     byte[] cachedCode = new byte[entry.CodeSize];
                     byte[] cachedCb1Data = new byte[entry.Cb1DataSize];
-                    dataFileStream.Read(cachedCb1Data);
+                    dataFileStream.ReadExactly(cachedCb1Data);
                     BinarySerializer.ReadCompressed(dataFileStream, cachedCode);
 
                     if (data.SequenceEqual(cachedCode) && cb1Data.SequenceEqual(cachedCb1Data))

--- a/src/Ryujinx.Gtk3/UI/Windows/AvatarWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/AvatarWindow.cs
@@ -233,7 +233,7 @@ namespace Ryujinx.UI.Windows
             reader.ReadInt64(); // Padding
 
             byte[] input = new byte[stream.Length - stream.Position];
-            stream.Read(input, 0, input.Length);
+            stream.ReadExactly(input, 0, input.Length);
 
             long inputOffset = 0;
 

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -65,7 +65,7 @@ namespace Ryujinx.UI.App.Common
             Stream resourceStream = Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName);
             byte[] resourceByteArray = new byte[resourceStream.Length];
 
-            resourceStream.Read(resourceByteArray);
+            resourceStream.ReadExactly(resourceByteArray);
 
             return resourceByteArray;
         }

--- a/src/Ryujinx/UI/ViewModels/UserFirmwareAvatarSelectorViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/UserFirmwareAvatarSelectorViewModel.cs
@@ -151,7 +151,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             reader.ReadInt64(); // Padding
 
             byte[] input = new byte[stream.Length - stream.Position];
-            stream.Read(input, 0, input.Length);
+            stream.ReadExactly(input, 0, input.Length);
 
             uint inputOffset = 0;
 


### PR DESCRIPTION
https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md#ca2022-avoid-inexact-read-with-streamread
> A call to 'Stream.Read' may return fewer bytes than requested, resulting in unreliable code if the return value is not checked.