### PR TITLE
Workaround AMD bug on logic op with float framebuffer

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Format.cs
+++ b/src/Ryujinx.Graphics.GAL/Format.cs
@@ -716,11 +716,11 @@ namespace Ryujinx.Graphics.GAL
         /// Checks if the texture format is a float or sRGB color format.
         /// </summary>
         /// <remarks>
-        /// Does not include normalized formats. Also does not include depth formats.
+        /// Does not include normalized, compressed or depth formats.
         /// Float and sRGB formats do not participate in logical operations.
         /// </remarks>
-        /// <param name="format"></param>
-        /// <returns></returns>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the format is a float or sRGB color format, false otherwise</returns>
         public static bool IsFloatOrSrgb(this Format format)
         {
             switch (format)

--- a/src/Ryujinx.Graphics.GAL/Format.cs
+++ b/src/Ryujinx.Graphics.GAL/Format.cs
@@ -711,5 +711,36 @@ namespace Ryujinx.Graphics.GAL
         {
             return format.IsUint() || format.IsSint();
         }
+
+        /// <summary>
+        /// Checks if the texture format is a float or sRGB color format.
+        /// </summary>
+        /// <remarks>
+        /// Does not include normalized formats. Also does not include depth formats.
+        /// Float and sRGB formats do not participate in logical operations.
+        /// </remarks>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        public static bool IsFloatOrSrgb(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8G8B8A8Srgb:
+                case Format.B8G8R8A8Srgb:
+                case Format.R16Float:
+                case Format.R16G16Float:
+                case Format.R16G16B16Float:
+                case Format.R16G16B16A16Float:
+                case Format.R32Float:
+                case Format.R32G32Float:
+                case Format.R32G32B32Float:
+                case Format.R32G32B32A32Float:
+                case Format.R11G11B10Float:
+                case Format.R9G9B9E5Float:
+                    return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1498,6 +1498,7 @@ namespace Ryujinx.Graphics.Vulkan
             var dstAttachmentFormats = _newState.Internal.AttachmentFormats.AsSpan();
             FramebufferParams.AttachmentFormats.CopyTo(dstAttachmentFormats);
             _newState.Internal.AttachmentIntegerFormatMask = FramebufferParams.AttachmentIntegerFormatMask;
+            _newState.Internal.LogicOpsAllowed = FramebufferParams.LogicOpsAllowed;
 
             for (int i = FramebufferParams.AttachmentFormats.Length; i < dstAttachmentFormats.Length; i++)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Common;
+using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Silk.NET.Vulkan;
 using System;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -1,4 +1,4 @@
-using Ryujinx.Common;
+﻿using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Silk.NET.Vulkan;
 using System;
@@ -302,6 +302,7 @@ namespace Ryujinx.Graphics.Vulkan
             int attachmentCount = 0;
             int maxColorAttachmentIndex = -1;
             uint attachmentIntegerFormatMask = 0;
+            bool allFormatsFloatOrSrgb = true;
 
             for (int i = 0; i < Constants.MaxRenderTargets; i++)
             {
@@ -314,6 +315,8 @@ namespace Ryujinx.Graphics.Vulkan
                     {
                         attachmentIntegerFormatMask |= 1u << i;
                     }
+
+                    allFormatsFloatOrSrgb &= state.AttachmentFormats[i].IsFloatOrSrgb();
                 }
             }
 
@@ -325,6 +328,7 @@ namespace Ryujinx.Graphics.Vulkan
             pipeline.ColorBlendAttachmentStateCount = (uint)(maxColorAttachmentIndex + 1);
             pipeline.VertexAttributeDescriptionsCount = (uint)Math.Min(Constants.MaxVertexAttributes, state.VertexAttribCount);
             pipeline.Internal.AttachmentIntegerFormatMask = attachmentIntegerFormatMask;
+            pipeline.Internal.LogicOpsAllowed = attachmentCount == 0 || !allFormatsFloatOrSrgb;
 
             return pipeline;
         }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Common.Memory;
+using Ryujinx.Common.Memory;
 using Silk.NET.Vulkan;
 using System;
 using System.Numerics;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -1,4 +1,4 @@
-using Ryujinx.Common.Memory;
+﻿using Ryujinx.Common.Memory;
 using Silk.NET.Vulkan;
 using System;
 using System.Numerics;
@@ -560,10 +560,14 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
+                // AMD has a bug where it enables logical operations even for float formats,
+                // so we need to force disable them here.
+                bool logicOpEnable = LogicOpEnable && (gd.Vendor != Vendor.Amd || Internal.LogicOpsAllowed);
+
                 var colorBlendState = new PipelineColorBlendStateCreateInfo
                 {
                     SType = StructureType.PipelineColorBlendStateCreateInfo,
-                    LogicOpEnable = LogicOpEnable,
+                    LogicOpEnable = logicOpEnable,
                     LogicOp = LogicOp,
                     AttachmentCount = ColorBlendAttachmentStateCount,
                     PAttachments = pColorBlendAttachmentState,

--- a/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
@@ -34,6 +34,7 @@ namespace Ryujinx.Graphics.Vulkan
         public Array8<PipelineColorBlendAttachmentState> ColorBlendAttachmentState;
         public Array9<Format> AttachmentFormats;
         public uint AttachmentIntegerFormatMask;
+        public bool LogicOpsAllowed;
 
         public readonly override bool Equals(object obj)
         {


### PR DESCRIPTION
According to the Vulkan spec:
> The application can enable a logical operation between the fragment’s color values and the existing value in the framebuffer attachment. This logical operation is applied prior to updating the framebuffer attachment. Logical operations are applied only for signed and unsigned integer and normalized integer framebuffers. Logical operations are not applied to floating-point or sRGB format color attachments.

But AMD does not seems to follow that, and if logical operations are enabled, it will be applied even for attachment with float formats (at least for R11G11B10_FLOAT format). To work around this issue, this change forces logic ops to be disabled if all attachment formats are float or sRGB formats (following what the spec says), but only on AMD.

This fixes black screen in specific areas on Paper Mario: The Thousand-Year Door.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/6d2e02a7-2601-4b3e-89d8-db9e3544422f)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/8b63955a-4a15-4f3a-a954-9910e2faf23d)
Testing is welcome (especially in other games that uses logical operations).
Fixes #6851.