### PR TITLE
Workaround bug on logic op with float framebuffer

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -560,7 +560,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
-                // vendors other than nvidia have a bug where it enables logical operations even for float formats,
+                // Vendors other than NVIDIA have a bug where it enables logical operations even for float formats,
                 // so we need to force disable them here.
                 bool logicOpEnable = LogicOpEnable && (gd.Vendor == Vendor.Nvidia || Internal.LogicOpsAllowed);
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -560,7 +560,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
-                // AMD has a bug where it enables logical operations even for float formats,
+                // AMD and Intel has a bug where it enables logical operations even for float formats,
                 // so we need to force disable them here.
                 bool logicOpEnable = LogicOpEnable && (gd.Vendor != Vendor.Amd && gd.Vendor != Vendor.Intel || Internal.LogicOpsAllowed);
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -560,9 +560,9 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
-                // AMD and Intel has a bug where it enables logical operations even for float formats,
+                // vendors other than nvidia have a bug where it enables logical operations even for float formats,
                 // so we need to force disable them here.
-                bool logicOpEnable = LogicOpEnable && (gd.Vendor != Vendor.Amd && gd.Vendor != Vendor.Intel || Internal.LogicOpsAllowed);
+                bool logicOpEnable = LogicOpEnable && (gd.Vendor == Vendor.Nvidia || Internal.LogicOpsAllowed);
 
                 var colorBlendState = new PipelineColorBlendStateCreateInfo
                 {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -562,7 +562,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 // AMD has a bug where it enables logical operations even for float formats,
                 // so we need to force disable them here.
-                bool logicOpEnable = LogicOpEnable && (gd.Vendor != Vendor.Amd || Internal.LogicOpsAllowed);
+                bool logicOpEnable = LogicOpEnable && (gd.Vendor != Vendor.Amd && gd.Vendor != Vendor.Intel || Internal.LogicOpsAllowed);
 
                 var colorBlendState = new PipelineColorBlendStateCreateInfo
                 {


### PR DESCRIPTION
built on top of #6852 to add support for intel gpu's
NOTE: this won't fix the crashing on windows

fixes #6859

before:
![image](https://github.com/Ryujinx/Ryujinx/assets/100526773/265a2736-344f-4f4d-9838-64492f5c2853)

after:
![image](https://github.com/Ryujinx/Ryujinx/assets/100526773/f66bd447-38ae-4b45-9186-76fd63a7b5aa)
