### PR TITLE
Add support for partial shader bindless elimination

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5936;
+        private const uint CodeGenVersion = 6865;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -3,7 +3,6 @@ using Ryujinx.Graphics.Shader.IntermediateRepresentation;
 using Ryujinx.Graphics.Shader.StructuredIr;
 using System;
 using System.Collections.Generic;
-using System.Management;
 
 namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 {


### PR DESCRIPTION
This is sort of an alternative way to fix the issue that #6853, though this one does not work correctly for all cases. Basically if everything else fails, this change will consider any constant buffer source as the unique source for texture handles. This will not work correctly if the handle is sourced from other places, but it's still better than it being completely non-existent. Compared to the other change, this one is less risky as we don't need to load all textures from the pool.

master:
![333043366-bee1856d-80f0-475e-89cf-3608c577037f](https://github.com/Ryujinx/Ryujinx/assets/5624669/08a7e1b5-c513-4fdc-a7ff-0844f63cbff0)
PR:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/98a1fa05-213f-4ba8-a31e-9d53b8a555f8)
It could be interesting to compare this and #6853 to find how much we miss by not accounting for the storage buffer source for this game.