### PR TITLE
replace ByteMemoryPool in Audio projects

### DIFF
--- a/src/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
@@ -89,9 +89,9 @@ namespace Ryujinx.Audio.Backends.SDL2
                 return;
             }
 
-            using IMemoryOwner<byte> samplesOwner = ByteMemoryPool.Rent(frameCount * _bytesPerFrame);
+            using SpanOwner<byte> samplesOwner = SpanOwner<byte>.Rent(frameCount * _bytesPerFrame);
 
-            Span<byte> samples = samplesOwner.Memory.Span;
+            Span<byte> samples = samplesOwner.Span;
 
             _ringBuffer.Read(samples, 0, samples.Length);
 

--- a/src/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceSession.cs
@@ -122,9 +122,9 @@ namespace Ryujinx.Audio.Backends.SoundIo
 
             int channelCount = areas.Length;
 
-            using IMemoryOwner<byte> samplesOwner = ByteMemoryPool.Rent(frameCount * bytesPerFrame);
+            using SpanOwner<byte> samplesOwner = SpanOwner<byte>.Rent(frameCount * bytesPerFrame);
 
-            Span<byte> samples = samplesOwner.Memory.Span;
+            Span<byte> samples = samplesOwner.Span;
 
             _ringBuffer.Read(samples, 0, samples.Length);
 

--- a/src/Ryujinx.Audio/Backends/Common/DynamicRingBuffer.cs
+++ b/src/Ryujinx.Audio/Backends/Common/DynamicRingBuffer.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Audio.Backends.Common
 
         private readonly object _lock = new();
 
-        private IMemoryOwner<byte> _bufferOwner;
+        private MemoryOwner<byte> _bufferOwner;
         private Memory<byte> _buffer;
         private int _size;
         private int _headOffset;
@@ -24,7 +24,7 @@ namespace Ryujinx.Audio.Backends.Common
 
         public DynamicRingBuffer(int initialCapacity = RingBufferAlignment)
         {
-            _bufferOwner = ByteMemoryPool.RentCleared(initialCapacity);
+            _bufferOwner = MemoryOwner<byte>.RentCleared(initialCapacity);
             _buffer = _bufferOwner.Memory;
         }
 
@@ -62,7 +62,7 @@ namespace Ryujinx.Audio.Backends.Common
 
         private void SetCapacityLocked(int capacity)
         {
-            IMemoryOwner<byte> newBufferOwner = ByteMemoryPool.RentCleared(capacity);
+            MemoryOwner<byte> newBufferOwner = MemoryOwner<byte>.RentCleared(capacity);
             Memory<byte> newBuffer = newBufferOwner.Memory;
 
             if (_size > 0)


### PR DESCRIPTION
Replaces use of ByteMemoryPool with the new `MemoryOwner` and `SpanOwner` types in the following projects:

- Ryujinx.Audio
- Ryujinx.Audio.Backends.SDL2
- Ryujinx.Audio.Backends.SoundIo
