### PR TITLE
Resolve some Vulkan validation errors

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -103,12 +103,19 @@ namespace Ryujinx.Graphics.Vulkan
                 usage |= BufferUsageFlags.IndirectBufferBit;
             }
 
+            var externalMemoryBuffer = new ExternalMemoryBufferCreateInfo
+            {
+                SType = StructureType.ExternalMemoryBufferCreateInfo,
+                HandleTypes = ExternalMemoryHandleTypeFlags.HostAllocationBitExt,
+            };
+
             var bufferCreateInfo = new BufferCreateInfo
             {
                 SType = StructureType.BufferCreateInfo,
                 Size = (ulong)size,
                 Usage = usage,
                 SharingMode = SharingMode.Exclusive,
+                PNext = &externalMemoryBuffer,
             };
 
             gd.Api.CreateBuffer(_device, in bufferCreateInfo, null, out var buffer).ThrowOnError();

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -20,8 +20,6 @@ namespace Ryujinx.Graphics.Vulkan
             ImageUsageFlags.TransferSrcBit |
             ImageUsageFlags.TransferDstBit;
 
-        public readonly ImageUsageFlags StorageImageUsageFlags;
-
         public const AccessFlags DefaultAccessMask =
             AccessFlags.ShaderReadBit |
             AccessFlags.ShaderWriteBit |
@@ -80,9 +78,9 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sampleCountFlags = ConvertToSampleCountFlags(gd.Capabilities.SupportedSampleCounts, (uint)info.Samples);
 
-            StorageImageUsageFlags = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
+            var usage = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
 
-            var flags = ImageCreateFlags.CreateMutableFormatBit;
+            var flags = ImageCreateFlags.CreateMutableFormatBit | ImageCreateFlags.CreateExtendedUsageBit;
 
             // This flag causes mipmapped texture arrays to break on AMD GCN, so for that copy dependencies are forced for aliasing as cube.
             bool isCube = info.Target == Target.Cubemap || info.Target == Target.CubemapArray;
@@ -108,7 +106,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ArrayLayers = layers,
                 Samples = sampleCountFlags,
                 Tiling = ImageTiling.Optimal,
-                Usage = StorageImageUsageFlags,
+                Usage = usage,
                 SharingMode = SharingMode.Exclusive,
                 InitialLayout = ImageLayout.Undefined,
                 Flags = flags,

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -20,6 +20,8 @@ namespace Ryujinx.Graphics.Vulkan
             ImageUsageFlags.TransferSrcBit |
             ImageUsageFlags.TransferDstBit;
 
+        public readonly ImageUsageFlags StorageImageUsageFlags;
+
         public const AccessFlags DefaultAccessMask =
             AccessFlags.ShaderReadBit |
             AccessFlags.ShaderWriteBit |
@@ -78,7 +80,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sampleCountFlags = ConvertToSampleCountFlags(gd.Capabilities.SupportedSampleCounts, (uint)info.Samples);
 
-            var usage = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
+            StorageImageUsageFlags = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
 
             var flags = ImageCreateFlags.CreateMutableFormatBit;
 
@@ -106,7 +108,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ArrayLayers = layers,
                 Samples = sampleCountFlags,
                 Tiling = ImageTiling.Optimal,
-                Usage = usage,
+                Usage = StorageImageUsageFlags,
                 SharingMode = SharingMode.Exclusive,
                 InitialLayout = ImageLayout.Undefined,
                 Flags = flags,

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -123,7 +123,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             ImageUsageFlags shaderUsage = ImageUsageFlags.SampledBit;
 
-            if (info.Format.IsImageCompatible())
+            if (info.Format.IsImageCompatible() && (_gd.Capabilities.SupportsShaderStorageImageMultisample || !info.Target.IsMultisample()))
             {
                 shaderUsage |= ImageUsageFlags.StorageBit;
             }

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 shaderUsage |= ImageUsageFlags.StorageBit;
             }
-            
+
             _imageView = CreateImageView(componentMapping, subresourceRange, type, shaderUsage);
 
             // Framebuffer attachments and storage images requires a identity component mapping.

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.Graphics.Vulkan
             gd.Textures.Add(this);
 
             var format = _gd.FormatCapabilities.ConvertToVkFormat(info.Format);
-            var usage = storage.StorageImageUsageFlags;
+            var usage = TextureStorage.GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
             var levels = (uint)info.Levels;
             var layers = (uint)info.GetLayers();
 
@@ -123,7 +123,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             ImageUsageFlags shaderUsage = ImageUsageFlags.SampledBit;
 
-            if (storage.Info.Format.IsImageCompatible())
+            if (info.Format.IsImageCompatible())
             {
                 shaderUsage |= ImageUsageFlags.StorageBit;
             }

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -462,11 +462,11 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 SType = StructureType.PhysicalDeviceVulkan12Features,
                 PNext = pExtendedFeatures,
-                DescriptorIndexing = physicalDevice.IsDeviceExtensionPresent("VK_EXT_descriptor_indexing") || supportedPhysicalDeviceVulkan12Features.DescriptorIndexing,
-                DrawIndirectCount = physicalDevice.IsDeviceExtensionPresent(KhrDrawIndirectCount.ExtensionName) || supportedPhysicalDeviceVulkan12Features.DrawIndirectCount,
-                UniformBufferStandardLayout = physicalDevice.IsDeviceExtensionPresent("VK_KHR_uniform_buffer_standard_layout"),
-                UniformAndStorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage"),
-                StorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage") || supportedPhysicalDeviceVulkan12Features.StorageBuffer8BitAccess,
+                DescriptorIndexing = supportedPhysicalDeviceVulkan12Features.DescriptorIndexing,
+                DrawIndirectCount = supportedPhysicalDeviceVulkan12Features.DrawIndirectCount,
+                UniformBufferStandardLayout = supportedPhysicalDeviceVulkan12Features.UniformBufferStandardLayout,
+                UniformAndStorageBuffer8BitAccess = supportedPhysicalDeviceVulkan12Features.UniformAndStorageBuffer8BitAccess,
+                StorageBuffer8BitAccess = supportedPhysicalDeviceVulkan12Features.StorageBuffer8BitAccess,
             };
 
             pExtendedFeatures = &featuresVk12;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -43,6 +43,7 @@ namespace Ryujinx.Graphics.Vulkan
             "VK_KHR_portability_subset", // As per spec, we should enable this if present.
             "VK_EXT_4444_formats",
             "VK_KHR_8bit_storage",
+            "VK_KHR_maintenance2",
         };
 
         private static readonly string[] _requiredExtensions = {
@@ -466,7 +467,6 @@ namespace Ryujinx.Graphics.Vulkan
                 UniformBufferStandardLayout = physicalDevice.IsDeviceExtensionPresent("VK_KHR_uniform_buffer_standard_layout"),
                 UniformAndStorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage"),
                 StorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage") || supportedPhysicalDeviceVulkan12Features.StorageBuffer8BitAccess,
-
             };
 
             pExtendedFeatures = &featuresVk12;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -42,6 +42,7 @@ namespace Ryujinx.Graphics.Vulkan
             "VK_EXT_depth_clip_control",
             "VK_KHR_portability_subset", // As per spec, we should enable this if present.
             "VK_EXT_4444_formats",
+            "VK_KHR_8bit_storage",
         };
 
         private static readonly string[] _requiredExtensions = {
@@ -354,6 +355,14 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 features2.PNext = &supportedFeaturesDepthClipControl;
             }
+            
+            PhysicalDeviceVulkan12Features supportedPhysicalDeviceVulkan12Features = new()
+            {
+                SType = StructureType.PhysicalDeviceVulkan12Features,
+                PNext = features2.PNext,
+            };
+            
+            features2.PNext = &supportedPhysicalDeviceVulkan12Features;
 
             api.GetPhysicalDeviceFeatures2(physicalDevice.PhysicalDevice, &features2);
 
@@ -382,6 +391,7 @@ namespace Ryujinx.Graphics.Vulkan
                 TessellationShader = supportedFeatures.TessellationShader,
                 VertexPipelineStoresAndAtomics = supportedFeatures.VertexPipelineStoresAndAtomics,
                 RobustBufferAccess = useRobustBufferAccess,
+                SampleRateShading = supportedFeatures.SampleRateShading,
             };
 
             void* pExtendedFeatures = null;
@@ -451,9 +461,12 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 SType = StructureType.PhysicalDeviceVulkan12Features,
                 PNext = pExtendedFeatures,
-                DescriptorIndexing = physicalDevice.IsDeviceExtensionPresent("VK_EXT_descriptor_indexing"),
-                DrawIndirectCount = physicalDevice.IsDeviceExtensionPresent(KhrDrawIndirectCount.ExtensionName),
+                DescriptorIndexing = physicalDevice.IsDeviceExtensionPresent("VK_EXT_descriptor_indexing") || supportedPhysicalDeviceVulkan12Features.DescriptorIndexing,
+                DrawIndirectCount = physicalDevice.IsDeviceExtensionPresent(KhrDrawIndirectCount.ExtensionName) || supportedPhysicalDeviceVulkan12Features.DrawIndirectCount,
                 UniformBufferStandardLayout = physicalDevice.IsDeviceExtensionPresent("VK_KHR_uniform_buffer_standard_layout"),
+                UniformAndStorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage"),
+                StorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage") || supportedPhysicalDeviceVulkan12Features.StorageBuffer8BitAccess,
+                
             };
 
             pExtendedFeatures = &featuresVk12;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -355,13 +355,13 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 features2.PNext = &supportedFeaturesDepthClipControl;
             }
-            
+
             PhysicalDeviceVulkan12Features supportedPhysicalDeviceVulkan12Features = new()
             {
                 SType = StructureType.PhysicalDeviceVulkan12Features,
                 PNext = features2.PNext,
             };
-            
+
             features2.PNext = &supportedPhysicalDeviceVulkan12Features;
 
             api.GetPhysicalDeviceFeatures2(physicalDevice.PhysicalDevice, &features2);
@@ -466,7 +466,7 @@ namespace Ryujinx.Graphics.Vulkan
                 UniformBufferStandardLayout = physicalDevice.IsDeviceExtensionPresent("VK_KHR_uniform_buffer_standard_layout"),
                 UniformAndStorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage"),
                 StorageBuffer8BitAccess = physicalDevice.IsDeviceExtensionPresent("VK_KHR_8bit_storage") || supportedPhysicalDeviceVulkan12Features.StorageBuffer8BitAccess,
-                
+
             };
 
             pExtendedFeatures = &featuresVk12;


### PR DESCRIPTION
- Pass ExternalMemoryBufferCreateInfo to BufferCreateInfo with HandleType (based on import) 
resolves: 
```
VUID-vkBindBufferMemory-memory-02985(ERROR / SPEC): msgNum: -1873212623 - Validation Error: [ VUID-vkBindBufferMemory-memory-02985 ] Object 0: handle = 0x19ea8aa6b68, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0x19ea8acc288, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x90590b31 | vkBindBufferMemory(): memory (VkDeviceMemory 0x19ea8acc288[]) was created with an import operation with handleType of VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT which is not set in the VkBuffer (VkBuffer 0x19ea8aa6b68[]) VkExternalMemoryBufferCreateInfo::handleType (VkExternalMemoryHandleTypeFlags(0)). The Vulkan spec states: If memory was allocated by a memory import operation, that is not VkImportAndroidHardwareBufferInfoANDROID with a non-NULL buffer value, the external handle type of the imported memory must also have been set in VkExternalMemoryBufferCreateInfo::handleTypes when buffer was created (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-vkBindBufferMemory-memory-02985)
    Objects: 2
        [0] 0x19ea8aa6b68, type: 9, name: NULL
        [1] 0x19ea8acc288, type: 8, name: NULL
```

- Set Image SubResourceRange level to 1 when Image type is 3d and view type is 2d. 
```
VUID-VkImageViewCreateInfo-image-04970(ERROR / SPEC): msgNum: 795313062 - Validation Error: [ VUID-VkImageViewCreateInfo-image-04970 ] Object 0: handle = 0x19ea9fb5f08, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x2f6783a6 | vkCreateImageView(): pCreateInfo->viewType (VK_IMAGE_VIEW_TYPE_2D_ARRAY) is with image type VK_IMAGE_TYPE_3D must have a levelCount of 1 but it is 6. The Vulkan spec states: If image was created with VK_IMAGE_TYPE_3D and viewType is VK_IMAGE_VIEW_TYPE_2D or VK_IMAGE_VIEW_TYPE_2D_ARRAY then subresourceRange.levelCount must be 1 (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-image-04970)
    Objects: 1
        [0] 0x19ea9fb5f08, type: 10, name: NULL
```

- This was a tough one, I believe this solution should work, but need confirmation that it should be okay. Using usage flags from texture storage. 
```
VUID-VkImageViewCreateInfo-pNext-02662(ERROR / SPEC): msgNum: -55646969 - Validation Error: [ VUID-VkImageViewCreateInfo-pNext-02662 ] Object 0: handle = 0x2a0397f0628, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0xfcaee507 | vkCreateImageView(): pCreateInfo->pNext<VkImageViewUsageCreateInfo>.usage (VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_STORAGE_BIT) must not include any bits that were not set in VkImageCreateInfo::usage (VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) of the image. The Vulkan spec states: If the pNext chain includes a VkImageViewUsageCreateInfo structure, and image was not created with a VkImageStencilUsageCreateInfo structure included in the pNext chain of VkImageCreateInfo, its usage member must not include any bits that were not set in the usage member of the VkImageCreateInfo structure used to create image (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-pNext-02662)
    Objects: 1
        [0] 0x2a0397f0628, type: 10, name: NULL
```

- The rest are all just runtime validation errors that should make no difference, but just addressed them as they came up during testing. Sample rate shading isn't used currently. If feature isn't supported below the other two errors will still occur. [Spec for the initialization changes. ](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage)

```
VUID-VkShaderModuleCreateInfo-pCode-08740(ERROR / SPEC): msgNum: 115483881 - Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08740 ] | MessageID = 0x6e224e9 | vkCreateShaderModule():  SPIR-V Capability SampleRateShading was declared, but one of the following requirements is required (VkPhysicalDeviceFeatures::sampleRateShading). The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-08740)
    Objects: 0

VUID-RuntimeSpirv-storageBuffer8BitAccess-06328(ERROR / SPEC): msgNum: -1143895426 - Validation Error: [ VUID-RuntimeSpirv-storageBuffer8BitAccess-06328 ] | MessageID = 0xbbd18a7e | vkCreateShaderModule():  SPIR-V contains an 8-bit OpVariable with StorageBuffer Storage Class, but storageBuffer8BitAccess was not enabled.
%113 = OpVariable %112 12
. The Vulkan spec states: If storageBuffer8BitAccess is VK_FALSE, then objects containing an 8-bit integer element must not have Storage Class of StorageBuffer, ShaderRecordBufferKHR, or PhysicalStorageBuffer (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-RuntimeSpirv-storageBuffer8BitAccess-06328)
    Objects: 0
VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329(ERROR / SPEC): msgNum: 1428187428 - Validation Error: [ VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329 ] | MessageID = 0x55206924 | vkCreateShaderModule():  SPIR-V contains an 8-bit OpVariable with Uniform Storage Class, but uniformAndStorageBuffer8BitAccess was not enabled.
%93 = OpVariable %92 2
. The Vulkan spec states: If uniformAndStorageBuffer8BitAccess is VK_FALSE, then objects in the Uniform Storage Class with the Block decoration must not have an 8-bit integer member (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329)
    Objects: 0
```

