### PR TITLE
Extend bindless elimination to catch a few more specific cases

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 6852;
+        private const uint CodeGenVersion = 6921;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitPredicate.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitPredicate.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             if (op.BVal)
             {
-                context.Copy(dest, context.ConditionalSelect(res, ConstF(1), Const(0)));
+                context.Copy(dest, context.ConditionalSelect(res, ConstF(1), ConstF(0)));
             }
             else
             {

--- a/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
+++ b/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
@@ -156,6 +156,26 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             return false;
         }
 
+        public static bool IsComparison(this Instruction inst)
+        {
+            switch (inst & Instruction.Mask)
+            {
+                case Instruction.CompareEqual:
+                case Instruction.CompareGreater:
+                case Instruction.CompareGreaterOrEqual:
+                case Instruction.CompareGreaterOrEqualU32:
+                case Instruction.CompareGreaterU32:
+                case Instruction.CompareLess:
+                case Instruction.CompareLessOrEqual:
+                case Instruction.CompareLessOrEqualU32:
+                case Instruction.CompareLessU32:
+                case Instruction.CompareNotEqual:
+                    return true;
+            }
+
+            return false;
+        }
+
         public static bool IsTextureQuery(this Instruction inst)
         {
             inst &= Instruction.Mask;

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -141,16 +141,16 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             return true;
         }
 
-        private static bool IsBindlessAccessAllowed(Operand nvHandle)
+        private static bool IsBindlessAccessAllowed(Operand bindlessHandle)
         {
-            if (nvHandle.Type == OperandType.ConstantBuffer)
+            if (bindlessHandle.Type == OperandType.ConstantBuffer)
             {
                 // Bindless access with handles from constant buffer is allowed.
 
                 return true;
             }
 
-            if (nvHandle.AsgOp is not Operation handleOp ||
+            if (bindlessHandle.AsgOp is not Operation handleOp ||
                 handleOp.Inst != Instruction.Load ||
                 (handleOp.StorageKind != StorageKind.Input && handleOp.StorageKind != StorageKind.StorageBuffer))
             {
@@ -300,7 +300,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                         resourceManager,
                         gpuAccessor,
                         texOp,
-                        TextureHandle.PackOffsets(src0.GetCbufOffset(), ((src1.Value >> 20) & 0xfff), handleType),
+                        TextureHandle.PackOffsets(src0.GetCbufOffset(), (src1.Value >> 20) & 0xfff, handleType),
                         TextureHandle.PackSlots(src0.GetCbufSlot(), 0),
                         rewriteSamplerType,
                         isImage: false);

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessToArray.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessToArray.cs
@@ -126,7 +126,9 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     continue;
                 }
 
-                if (texOp.GetSource(0).AsgOp is not Operation handleAsgOp)
+                Operand bindlessHandle = Utils.FindLastOperation(texOp.GetSource(0), block);
+
+                if (bindlessHandle.AsgOp is not Operation handleAsgOp)
                 {
                     continue;
                 }
@@ -137,8 +139,8 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                 if (handleAsgOp.Inst == Instruction.BitwiseOr)
                 {
-                    Operand src0 = handleAsgOp.GetSource(0);
-                    Operand src1 = handleAsgOp.GetSource(1);
+                    Operand src0 = Utils.FindLastOperation(handleAsgOp.GetSource(0), block);
+                    Operand src1 = Utils.FindLastOperation(handleAsgOp.GetSource(1), block);
 
                     if (src0.Type == OperandType.ConstantBuffer && src1.AsgOp is Operation)
                     {

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -152,18 +152,14 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
         {
             // If all phi sources are the same, we can propagate it and remove the phi.
 
-            Operand firstSrc = phi.GetSource(0);
-
-            for (int index = 1; index < phi.SourcesCount; index++)
+            if (!Utils.AreAllSourcesTheSameOperand(phi))
             {
-                if (!IsSameOperand(firstSrc, phi.GetSource(index)))
-                {
-                    return false;
-                }
+                return false;
             }
 
             // All sources are equal, we can propagate the value.
 
+            Operand firstSrc = phi.GetSource(0);
             Operand dest = phi.Dest;
 
             INode[] uses = dest.UseOps.ToArray();
@@ -180,17 +176,6 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             }
 
             return true;
-        }
-
-        private static bool IsSameOperand(Operand x, Operand y)
-        {
-            if (x.Type != y.Type || x.Value != y.Value)
-            {
-                return false;
-            }
-
-            // TODO: Handle Load operations with the same storage and the same constant parameters.
-            return x.Type == OperandType.Constant || x.Type == OperandType.ConstantBuffer;
         }
 
         private static bool PropagatePack(Operation packOp)

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
@@ -45,6 +45,24 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             return x == y || x.Type == OperandType.Constant || x.Type == OperandType.ConstantBuffer;
         }
 
+        private static bool AreAllSourcesEqual(INode node, INode otherNode)
+        {
+            if (node.SourcesCount != otherNode.SourcesCount)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < node.SourcesCount; index++)
+            {
+                if (!IsSameOperand(node.GetSource(index), otherNode.GetSource(index)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public static bool AreAllSourcesTheSameOperand(INode node)
         {
             Operand firstSrc = node.GetSource(0);
@@ -81,6 +99,19 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             return inst == Instruction.BranchIfFalse || inst == Instruction.BranchIfTrue;
         }
 
+        private static bool IsSameCondition(Operand currentCondition, Operand queryCondition)
+        {
+            if (currentCondition == queryCondition)
+            {
+                return true;
+            }
+
+            return currentCondition.AsgOp is Operation currentOperation &&
+                queryCondition.AsgOp is Operation queryOperation &&
+                currentOperation.Inst == queryOperation.Inst &&
+                AreAllSourcesEqual(currentOperation, queryOperation);
+        }
+
         private static bool BlockConditionsMatch(BasicBlock currentBlock, BasicBlock queryBlock)
         {
             // Check if all the conditions for the query block are satisfied by the current block.
@@ -96,7 +127,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
             return currentBranch != null && queryBranch != null &&
                    currentBranch.Inst == queryBranch.Inst &&
-                   currentCondition == queryCondition;
+                   IsSameCondition(currentCondition, queryCondition);
         }
 
         public static Operand FindLastOperation(Operand source, BasicBlock block, bool recurse = true)


### PR DESCRIPTION
This is yet another PR to extend bindless elimination even further. It catches some cases that I found on some games (mainly UE4 games).

I will try to explain each case with the disassembly of the relevant code.

**Negated and non-negated predicate.**

```
@!P0 MOV R2, c[0x2][0x168] ;
@P0 MOV R2, RZ ;
@!P0 LOP.OR R14, R2, c[0x2][0x568] ;
@!P0 TEX.B.NODEP.P R0, R8, R14, 0x0, 2D, 0xf ;
```
Here there are two values assigned to `R2`, but there is only one that can actually reach the texture use. It is not easy to detect this in the code due to the use of predicates.  We already have code find the value from the source that has the same condition as the current block. So I just extended it to go a bit further. If the source is a phi node, it now tries to check the next sources as well. I do think we should also prove that the the block with the texture sample is not actually reachable from the other phi source blocks, but if this is a problem, then I believe it is an existing issue.

I found this on the game Shin Megami Tensei V. I'm not sure what it affects, I didn't notice anything wrong with it before. But at least we won't need to worry about this game anymore when enabling "full bindless" for everything in the future.

**Spill predicate to register and re-materialize predicate.**

```
ISETP.LT.U32.AND P0, PT, R4, c[0x3][0xc], PT ;
@P0 MOV R7, c[0x2][0x178] ;
PSET.AND.AND R22, P0, PT, PT ;
ISETP.NE.AND P0, PT, R22, RZ, PT ;
@P0 LOP.OR R7, R7, c[0x2][0x568] ;
@P0 TLD.B.LZ.T R17, R17, R7, 0x0, 1D, 0x1 ;
```

Here the compiler ran out of predicates when generating the shader code, so it moved one of the predicates to a  general register (R22), later it moves the value back to the predicate. The problem is that it sets the predicate to `P0 = R22 != 0`, so the conditions for the instructions are technically "different". This one was simple to solve, I just added an optimization where it propagate the source of any `x = y != 0` as long `y` is the result of another comparison.

The second case is somewhat similar:

```
@P5 MOV R4, c[0x2][0x178] ;
ISETP.LT.U32.AND P0, PT, R3, c[0x3][0xc], PT ;
@P0 LOP.OR R4, R4, c[0x2][0x568] ;
ISETP.LT.U32.AND P6, PT, R3, c[0x3][0xc], PT ;
@P6 TLD.B.LZ.T R19, R19, R4, 0x0, 1D, 0x1 ;
```

Here it just "re-materializes" the predicate, by doing the same comparison again. For this one it just extends the block condition comparison to also check the operation that assigns the condition value, and then checks if all inputs are the same. Maybe it would be better to do some kind of CSE early on to clear this up, but it would be more complicated to implement.

I found those cases on Mortal Kombat 1.

**Predicated indexed access.**

I don't have the disassembly for this one off-hand, but it's basically an indexed access (constant buffer access has non-constant offset), and all the instructions are predicated. To fix it I just used the existing `FindLastOperation` method to find sources in blocks with the same condition as the current block. It allows catching a few more cases on Hogwarts Legacy, but it's hard to test right now due to the performance regression that happened a while ago.

This might fix particles issues on some UE4 games.
Testing is welcome.

