### PR TITLE
clear pooled memory on return when used to hold object references

### DIFF
--- a/src/Ryujinx.Common/Memory/MemoryOwner.cs
+++ b/src/Ryujinx.Common/Memory/MemoryOwner.cs
@@ -124,7 +124,7 @@ namespace Ryujinx.Common.Memory
 
             if (array is not null)
             {
-                ArrayPool<T>.Shared.Return(array);
+                ArrayPool<T>.Shared.Return(array, RuntimeHelpers.IsReferenceOrContainsReferences<T>());
             }
         }
 

--- a/src/Ryujinx.Common/Memory/SpanOwner.cs
+++ b/src/Ryujinx.Common/Memory/SpanOwner.cs
@@ -108,7 +108,7 @@ namespace Ryujinx.Common.Memory
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
-            ArrayPool<T>.Shared.Return(_array);
+            ArrayPool<T>.Shared.Return(_array, RuntimeHelpers.IsReferenceOrContainsReferences<T>());
         }
     }
 }

--- a/src/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -616,7 +616,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 }
             }
 
-            ArrayPool<KSynchronizationObject>.Shared.Return(syncObjsArray);
+            ArrayPool<KSynchronizationObject>.Shared.Return(syncObjsArray, true);
 
             return result;
         }

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KSynchronization.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KSynchronization.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
                     }
                 }
 
-                ArrayPool<LinkedListNode<KThread>>.Shared.Return(syncNodesArray);
+                ArrayPool<LinkedListNode<KThread>>.Shared.Return(syncNodesArray, true);
             }
 
             _context.CriticalSection.Leave();


### PR DESCRIPTION
This PR adjusts calls to `ArrayPool<T>.Shared.Return(T[])` so that the memory is cleared when `T` is a reference type. This is important to prevent pooled memory from keeping alive object instances that would otherwise be collected by the GC.

I intend to profile this change eventually, but I didn't want that to delay submission of this (IMO important) fix to pooled memory usage.