### PR TITLE
Added log message for third-party AVs

### DIFF
--- a/src/Ryujinx.Common/Utilities/AVUtils.cs
+++ b/src/Ryujinx.Common/Utilities/AVUtils.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Management;
+
+namespace Ryujinx.Common.Utilities
+{
+    public static class AVUtils
+    {
+        public static string GetAVName()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return null;
+            }
+
+            ManagementObjectSearcher wmiData = new ManagementObjectSearcher(@"root\SecurityCenter2", "SELECT * FROM AntiVirusProduct");
+            ManagementObjectCollection data = wmiData.Get();
+
+            foreach (ManagementObject dataObj in data.Cast<ManagementObject>())
+            {
+                try
+                {
+                    string displayName = (string)dataObj["displayName"];
+                    if (displayName != "Windows Defender")
+                    {
+                        return displayName;
+                    }
+                }
+                catch (ManagementException)
+                {
+                    continue;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Ryujinx.Common/Utilities/AVUtils.cs
+++ b/src/Ryujinx.Common/Utilities/AVUtils.cs
@@ -6,11 +6,11 @@ namespace Ryujinx.Common.Utilities
 {
     public static class AVUtils
     {
-        public static string GetAVName()
+        public static bool IsRunningThirdPartyAV()
         {
             if (!OperatingSystem.IsWindows())
             {
-                return null;
+                return false;
             }
 
             ManagementObjectSearcher wmiData = new ManagementObjectSearcher(@"root\SecurityCenter2", "SELECT * FROM AntiVirusProduct");
@@ -23,7 +23,7 @@ namespace Ryujinx.Common.Utilities
                     string displayName = (string)dataObj["displayName"];
                     if (displayName != "Windows Defender")
                     {
-                        return displayName;
+                        return true;
                     }
                 }
                 catch (ManagementException)
@@ -32,7 +32,7 @@ namespace Ryujinx.Common.Utilities
                 }
             }
 
-            return null;
+            return false;
         }
     }
 }

--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -4,6 +4,7 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.SystemInterop;
+using Ryujinx.Common.Utilities;
 using Ryujinx.Modules;
 using Ryujinx.SDL2.Common;
 using Ryujinx.UI;
@@ -340,6 +341,12 @@ namespace Ryujinx
         {
             Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
             SystemInfo.Gather().Print();
+
+            string avName = AVUtils.GetAVName();
+            if (avName != null)
+            {
+                Logger.Notice.Print(LogClass.Application, $"Detected AV: {avName}");
+            }
 
             var enabledLogs = Logger.GetEnabledLevels();
             Logger.Notice.Print(LogClass.Application, $"Logs Enabled: {(enabledLogs.Count == 0 ? "<None>" : string.Join(", ", enabledLogs))}");

--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -342,10 +342,9 @@ namespace Ryujinx
             Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
             SystemInfo.Gather().Print();
 
-            string avName = AVUtils.GetAVName();
-            if (avName != null)
+            if (AVUtils.IsRunningThirdPartyAV())
             {
-                Logger.Notice.Print(LogClass.Application, $"Detected AV: {avName}");
+                Logger.Notice.Print(LogClass.Application, $"Third-Party AV active");
             }
 
             var enabledLogs = Logger.GetEnabledLevels();

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -7,6 +7,7 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.SystemInterop;
+using Ryujinx.Common.Utilities;
 using Ryujinx.Modules;
 using Ryujinx.SDL2.Common;
 using Ryujinx.UI.Common;
@@ -213,6 +214,12 @@ namespace Ryujinx.Ava
         {
             Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
             SystemInfo.Gather().Print();
+
+            string avName = AVUtils.GetAVName();
+            if (avName != null)
+            {
+                Logger.Notice.Print(LogClass.Application, $"Detected AV: {avName}");
+            }
 
             Logger.Notice.Print(LogClass.Application, $"Logs Enabled: {(Logger.GetEnabledLevels().Count == 0 ? "<None>" : string.Join(", ", Logger.GetEnabledLevels()))}");
 

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -215,10 +215,9 @@ namespace Ryujinx.Ava
             Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
             SystemInfo.Gather().Print();
 
-            string avName = AVUtils.GetAVName();
-            if (avName != null)
+            if (AVUtils.IsRunningThirdPartyAV())
             {
-                Logger.Notice.Print(LogClass.Application, $"Detected AV: {avName}");
+                Logger.Notice.Print(LogClass.Application, $"Third-Party AV active");
             }
 
             Logger.Notice.Print(LogClass.Application, $"Logs Enabled: {(Logger.GetEnabledLevels().Count == 0 ? "<None>" : string.Join(", ", Logger.GetEnabledLevels()))}");


### PR DESCRIPTION
This adds a log message containing the AV's name when one is detected. It purposefully doesn't log when Windows Defender is detected to avoid log spam.

This Just Worked™ on my machine running Windows Defender, both in a debug build and a proper release build that I moved to another folder to avoid potential exclusions of my dev folder.
Testing is required to see if third-party AVs kill Ryujinx dead because of WMI access or not.

Obligatory test screenshot:
![image](https://github.com/Ryujinx/Ryujinx/assets/676069/b580d785-4cb1-464c-95fe-5cf203670506)

