### PR TITLE
JIT: Coalesce copies on LSRA with simple register preferencing

### DIFF
--- a/src/ARMeilleure/CodeGen/RegisterAllocators/LiveInterval.cs
+++ b/src/ARMeilleure/CodeGen/RegisterAllocators/LiveInterval.cs
@@ -19,6 +19,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
             public LiveRange CurrRange;
 
             public LiveInterval Parent;
+            public LiveInterval CopySource;
 
             public UseList Uses;
             public LiveIntervalList Children;
@@ -37,6 +38,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
         private ref LiveRange CurrRange => ref _data->CurrRange;
         private ref LiveRange PrevRange => ref _data->PrevRange;
         private ref LiveInterval Parent => ref _data->Parent;
+        private ref LiveInterval CopySource => ref _data->CopySource;
         private ref UseList Uses => ref _data->Uses;
         private ref LiveIntervalList Children => ref _data->Children;
 
@@ -76,6 +78,39 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
             _data->IsFixed = true;
 
             Register = register;
+        }
+
+        public void SetCopySource(LiveInterval copySource)
+        {
+            CopySource = copySource;
+        }
+
+        public bool TryGetCopySource(out LiveInterval copySource)
+        {
+            if (CopySource._data != null)
+            {
+                copySource = CopySource;
+
+                return true;
+            }
+
+            copySource = default;
+
+            return false;
+        }
+
+        public bool TryGetCopySourceRegister(out int copySourceRegIndex)
+        {
+            if (CopySource._data != null)
+            {
+                copySourceRegIndex = CopySource.Register.Index;
+
+                return true;
+            }
+
+            copySourceRegIndex = 0;
+
+            return false;
         }
 
         public void Reset()

--- a/src/ARMeilleure/CodeGen/RegisterAllocators/LiveInterval.cs
+++ b/src/ARMeilleure/CodeGen/RegisterAllocators/LiveInterval.cs
@@ -85,20 +85,6 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
             CopySource = copySource;
         }
 
-        public bool TryGetCopySource(out LiveInterval copySource)
-        {
-            if (CopySource._data != null)
-            {
-                copySource = CopySource;
-
-                return true;
-            }
-
-            copySource = default;
-
-            return false;
-        }
-
         public bool TryGetCopySourceRegister(out int copySourceRegIndex)
         {
             if (CopySource._data != null)

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 6634; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 6950; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This effectively allows some copies to be coalesced on the JIT, when the `HighCq` mode is used.  It does not actually coalesce them, but rather, the register allocator tries to select the same register as the copy source for the destination. When both source and destination uses the same register, the backend will just skip the instruction since it basically does nothing.

This allows the elimination of some copies, such as those generated after Phi removal, or the ones inserted for instructions where the destination and first operand must use the same register on x86.

Examples (from Shantae and the Pirate's Curse `main`):
Before:
```nasm
mov r13, qword ptr [rbx + 0xf8]
mov eax, dword ptr [rbx + 0x410]
test eax, eax
je 0x169c
sub eax, 1
mov dword ptr [rbx + 0x410], eax
mov rax, r13
sub rax, 0x90
lea rcx, [rax + 0x70]
lea rdx, [rax + 0x78]
```
After:
```nasm
mov r13, qword ptr [rbx + 0xf8]
mov eax, dword ptr [rbx + 0x410]
test eax, eax
je 0x1647
sub eax, 1
mov dword ptr [rbx + 0x410], eax
sub r13, 0x90
lea rax, [r13 + 0x70]
lea rcx, [r13 + 0x78]
```
Before:
```nasm
mov rsi, qword ptr [rsp + 0xbc]
mov r8, qword ptr [rsp + 0x88]
mov rcx, qword ptr [rsp + 0xb0]
mov rbp, qword ptr [rsp + 0xa8]
mov r9d, dword ptr [rsp + 0xc4]
mov r15d, dword ptr [rsp + 0xb8]
mov rax, rsi
mov rdx, r12
mov rsi, r8
mov edi, r9d
mov r8d, r15d
mov r9d, r14d
mov r10d, r13d
mov r11, qword ptr [rax + 0xcafe]
add rax, 8
mov qword ptr [rbx + 0x40], r11
mov qword ptr [rbx + 0x48], rdx
mov qword ptr [rbx + 0x98], rax
mov qword ptr [rbx + 0xa0], rsi
mov qword ptr [rbx + 0xe8], rcx
mov qword ptr [rbx + 0xf0], 0x148
mov qword ptr [rbx + 0xf8], rbp
mov dword ptr [rbx + 0x370], edi
mov dword ptr [rbx + 0x374], r8d
mov dword ptr [rbx + 0x378], r9d
mov dword ptr [rbx + 0x37c], r10d
mov qword ptr [rbx + 0x418], r11
```
After:
```nasm
mov r8, qword ptr [rsp + 0x7c]
mov rcx, qword ptr [rsp + 0xa4]
mov rdx, qword ptr [rsp + 0xb0]
mov rbp, qword ptr [rsp + 0x9c]
mov r15d, dword ptr [rsp + 0xac]
mov rax, qword ptr [r8 + 0xcafe]
lea rsi, [r8 + 8]
mov qword ptr [rbx + 0x40], rax
mov qword ptr [rbx + 0x48], r12
mov qword ptr [rbx + 0x98], rsi
mov qword ptr [rbx + 0xa0], rcx
mov qword ptr [rbx + 0xe8], rdx
mov qword ptr [rbx + 0xf0], 0x148
mov qword ptr [rbx + 0xf8], rbp
mov dword ptr [rbx + 0x370], r9d
mov dword ptr [rbx + 0x374], r15d
mov dword ptr [rbx + 0x378], r14d
mov dword ptr [rbx + 0x37c], r13d
mov qword ptr [rbx + 0x418], rax
```
Generated code size decreased from 18634 KB to 18423 KB (-211 KB) in this example.
I tested a few other games and they also have a minor improvement.
Testing is welcome. Might show a minor performance improvement in some cases, but it's mostly to ensure there's no regressions.