### PR TITLE
JIT: Ensure entry block has no predecessors on RegisterUsage pass

### DIFF
--- a/src/ARMeilleure/Translation/ControlFlowGraph.cs
+++ b/src/ARMeilleure/Translation/ControlFlowGraph.cs
@@ -11,7 +11,7 @@ namespace ARMeilleure.Translation
         private int[] _postOrderMap;
 
         public int LocalsCount { get; private set; }
-        public BasicBlock Entry { get; }
+        public BasicBlock Entry { get; private set; }
         public IntrusiveList<BasicBlock> Blocks { get; }
         public BasicBlock[] PostOrderBlocks => _postOrderBlocks;
         public int[] PostOrderMap => _postOrderMap;
@@ -32,6 +32,15 @@ namespace ARMeilleure.Translation
             result.NumberLocal(++LocalsCount);
 
             return result;
+        }
+
+        public void UpdateEntry(BasicBlock newEntry)
+        {
+            newEntry.AddSuccessor(Entry);
+
+            Entry = newEntry;
+            Blocks.AddFirst(newEntry);
+            Update();
         }
 
         public void Update()


### PR DESCRIPTION
Currently `RegisterUsage` pass assumes that the entry block has 0 predecessors. This is always the case right now, but only because the interrupt check code is always inserted at the start of every function. This change updates the `RegisterUsage` pass to insert a new entry block if needed, for cases where the code jumps to the start of the function. Now if the `EmitSynchronization` call inside the `Translator.Translate` function is removed, the JIT no longer crashes.

Does not really change anything right now, but will be required if we decide to use signal based thread suspension in the future.