### PR TITLE
replace ByteMemoryPool usage in Ryujinx.HLE

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -474,9 +474,9 @@ namespace Ryujinx.HLE.HOS.Services
         {
             const int MessageSize = 0x100;
 
-            using IMemoryOwner<byte> reqDataOwner = ByteMemoryPool.Rent(MessageSize);
+            using SpanOwner<byte> reqDataOwner = SpanOwner<byte>.Rent(MessageSize);
 
-            Span<byte> reqDataSpan = reqDataOwner.Memory.Span;
+            Span<byte> reqDataSpan = reqDataOwner.Span;
 
             _selfProcess.CpuMemory.Read(_selfThread.TlsAddress, reqDataSpan);
 

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
@@ -85,9 +85,9 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             ReadOnlySpan<byte> inputParcel = context.Memory.GetSpan(dataPos, (int)dataSize);
 
-            using IMemoryOwner<byte> outputParcelOwner = ByteMemoryPool.RentCleared(replySize);
+            using SpanOwner<byte> outputParcelOwner = SpanOwner<byte>.RentCleared(checked((int)replySize));
 
-            Span<byte> outputParcel = outputParcelOwner.Memory.Span;
+            Span<byte> outputParcel = outputParcelOwner.Span;
 
             ResultCode result = OnTransact(binderId, code, flags, inputParcel, outputParcel);
 

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Parcel.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Parcel.cs
@@ -3,7 +3,6 @@ using Ryujinx.Common.Memory;
 using Ryujinx.Common.Utilities;
 using Ryujinx.HLE.HOS.Services.SurfaceFlinger.Types;
 using System;
-using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -13,7 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 {
     sealed class Parcel : IDisposable
     {
-        private readonly IMemoryOwner<byte> _rawDataOwner;
+        private readonly MemoryOwner<byte> _rawDataOwner;
 
         private Span<byte> Raw => _rawDataOwner.Memory.Span;
 
@@ -30,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         public Parcel(ReadOnlySpan<byte> data)
         {
-            _rawDataOwner = ByteMemoryPool.RentCopy(data);
+            _rawDataOwner = MemoryOwner<byte>.RentCopy(data);
 
             _payloadPosition = 0;
             _objectPosition = 0;
@@ -40,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             uint headerSize = (uint)Unsafe.SizeOf<ParcelHeader>();
 
-            _rawDataOwner = ByteMemoryPool.RentCleared(BitUtils.AlignUp<uint>(headerSize + payloadSize + objectsSize, 4));
+            _rawDataOwner = MemoryOwner<byte>.RentCleared(checked((int)BitUtils.AlignUp<uint>(headerSize + payloadSize + objectsSize, 4)));
 
             Header.PayloadSize = payloadSize;
             Header.ObjectsSize = objectsSize;


### PR DESCRIPTION
Replaces use of `ByteMemoryPool` with the new `MemoryOwner` and `SpanOwner` types in the Ryujinx.HLE project. 

It does use `SpanOwner` in 2 places to make those fully allocation-less, but otherwise these are all just different ways of using `System.Buffers.ArrayPool` and the before/after should be functionally identical.
