### PR TITLE
SetProcessMemoryPermission address and size are always 64-bit

### DIFF
--- a/src/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -1546,8 +1546,8 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 #pragma warning disable CA1822 // Mark member as static
         public Result SetProcessMemoryPermission(
             int handle,
-            [PointerSized] ulong src,
-            [PointerSized] ulong size,
+            ulong src,
+            ulong size,
             KMemoryPermission permission)
         {
             if (!PageAligned(src))


### PR DESCRIPTION
There was wrong handling of the syscall, as it can be checked in https://switchbrew.org/wiki/SVC.
Without my patch, the arguments end up reversed, resulting in a 0xD401 (InvalidMemState) error.
My patch makes calls to this SVC work flawlessly under Aarch32 processes.