### PR TITLE
JIT: Sparse function table

### DIFF
--- a/src/ARMeilleure/Common/AddressTableLevel.cs
+++ b/src/ARMeilleure/Common/AddressTableLevel.cs
@@ -1,0 +1,44 @@
+namespace ARMeilleure.Common
+{
+    /// <summary>
+    /// Represents a level in an <see cref="IAddressTable{TEntry}"/>.
+    /// </summary>
+    public readonly struct AddressTableLevel
+    {
+        /// <summary>
+        /// Gets the index of the <see cref="Level"/> in the guest address.
+        /// </summary>
+        public int Index { get; }
+
+        /// <summary>
+        /// Gets the length of the <see cref="AddressTableLevel"/> in the guest address.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        /// Gets the mask which masks the bits used by the <see cref="AddressTableLevel"/>.
+        /// </summary>
+        public ulong Mask => ((1ul << Length) - 1) << Index;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddressTableLevel"/> structure with the specified
+        /// <paramref name="index"/> and <paramref name="length"/>.
+        /// </summary>
+        /// <param name="index">Index of the <see cref="AddressTableLevel"/></param>
+        /// <param name="length">Length of the <see cref="AddressTableLevel"/></param>
+        public AddressTableLevel(int index, int length)
+        {
+            (Index, Length) = (index, length);
+        }
+
+        /// <summary>
+        /// Gets the value of the <see cref="AddressTableLevel"/> from the specified guest <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">Guest address</param>
+        /// <returns>Value of the <see cref="AddressTableLevel"/> from the specified guest <paramref name="address"/></returns>
+        public int GetValue(ulong address)
+        {
+            return (int)((address & Mask) >> Index);
+        }
+    }
+}

--- a/src/ARMeilleure/Common/AddressTablePresets.cs
+++ b/src/ARMeilleure/Common/AddressTablePresets.cs
@@ -1,0 +1,51 @@
+namespace ARMeilleure.Common
+{
+    public static class AddressTablePresets
+    {
+        private static readonly AddressTableLevel[] _levels64Bit =
+            new AddressTableLevel[]
+            {
+                new(31, 17),
+                new(23,  8),
+                new(15,  8),
+                new( 7,  8),
+                new( 2,  5),
+            };
+
+        private static readonly AddressTableLevel[] _levels32Bit =
+            new AddressTableLevel[]
+            {
+                new(31, 17),
+                new(23,  8),
+                new(15,  8),
+                new( 7,  8),
+                new( 1,  6),
+            };
+
+        private static readonly AddressTableLevel[] _levels64BitSparse =
+            new AddressTableLevel[]
+            {
+                new(23, 16),
+                new( 2, 21),
+            };
+
+        private static readonly AddressTableLevel[] _levels32BitSparse =
+            new AddressTableLevel[]
+            {
+                new(22, 10),
+                new( 1, 21),
+            };
+
+        public static AddressTableLevel[] GetArmPreset(bool for64Bits, bool sparse)
+        {
+            if (sparse)
+            {
+                return for64Bits ? _levels64BitSparse : _levels32BitSparse;
+            }
+            else
+            {
+                return for64Bits ? _levels64Bit : _levels32Bit;
+            }
+        }
+    }
+}

--- a/src/ARMeilleure/Common/Allocator.cs
+++ b/src/ARMeilleure/Common/Allocator.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ARMeilleure.Common
 {
-    unsafe abstract class Allocator : IDisposable
+    public unsafe abstract class Allocator : IDisposable
     {
         public T* Allocate<T>(ulong count = 1) where T : unmanaged
         {

--- a/src/ARMeilleure/Common/IAddressTable.cs
+++ b/src/ARMeilleure/Common/IAddressTable.cs
@@ -5,12 +5,6 @@ namespace ARMeilleure.Common
     public interface IAddressTable<TEntry> : IDisposable where TEntry : unmanaged
     {
         /// <summary>
-        /// If true, the sparse 2-level table should be used to improve performance.
-        /// If false, the platform doesn't properly support it, or will be negatively impacted.
-        /// </summary>
-        static bool UseSparseTable { get; }
-
-        /// <summary>
         /// Gets the bits used by the <see cref="Levels"/> of the <see cref="AddressTable{TEntry}"/> instance.
         /// </summary>
         ulong Mask { get; }

--- a/src/ARMeilleure/Common/IAddressTable.cs
+++ b/src/ARMeilleure/Common/IAddressTable.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace ARMeilleure.Common
+{
+    public interface IAddressTable<TEntry> : IDisposable where TEntry : unmanaged
+    {
+        /// <summary>
+        /// If true, the sparse 2-level table should be used to improve performance.
+        /// If false, the platform doesn't properly support it, or will be negatively impacted.
+        /// </summary>
+        static bool UseSparseTable { get; }
+
+        /// <summary>
+        /// Gets the bits used by the <see cref="Levels"/> of the <see cref="AddressTable{TEntry}"/> instance.
+        /// </summary>
+        ulong Mask { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Level"/>s used by the <see cref="AddressTable{TEntry}"/> instance.
+        /// </summary>
+        AddressTableLevel[] Levels { get; }
+
+        /// <summary>
+        /// Gets or sets the default fill value of newly created leaf pages.
+        /// </summary>
+        TEntry Fill { get; set; }
+
+        /// <summary>
+        /// Gets the base address of the <see cref="EntryTable{TEntry}"/>.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException"><see cref="EntryTable{TEntry}"/> instance was disposed</exception>
+        IntPtr Base { get; }
+
+        /// <summary>
+        /// Determines if the specified <paramref name="address"/> is in the range of the
+        /// <see cref="AddressTable{TEntry}"/>.
+        /// </summary>
+        /// <param name="address">Guest address</param>
+        /// <returns><see langword="true"/> if is valid; otherwise <see langword="false"/></returns>
+        bool IsValid(ulong address);
+
+        /// <summary>
+        /// Gets a reference to the value at the specified guest <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">Guest address</param>
+        /// <returns>Reference to the value at the specified guest <paramref name="address"/></returns>
+        /// <exception cref="ObjectDisposedException"><see cref="EntryTable{TEntry}"/> instance was disposed</exception>
+        /// <exception cref="ArgumentException"><paramref name="address"/> is not mapped</exception>
+        ref TEntry GetValue(ulong address);
+    }
+}

--- a/src/ARMeilleure/Common/IAddressTable.cs
+++ b/src/ARMeilleure/Common/IAddressTable.cs
@@ -5,12 +5,18 @@ namespace ARMeilleure.Common
     public interface IAddressTable<TEntry> : IDisposable where TEntry : unmanaged
     {
         /// <summary>
-        /// Gets the bits used by the <see cref="Levels"/> of the <see cref="AddressTable{TEntry}"/> instance.
+        /// True if the address table's bottom level is sparsely mapped.
+        /// This also ensures the second bottom level is filled with a dummy page rather than 0.
+        /// </summary>
+        bool Sparse { get; }
+
+        /// <summary>
+        /// Gets the bits used by the <see cref="Levels"/> of the <see cref="IAddressTable{TEntry}"/> instance.
         /// </summary>
         ulong Mask { get; }
 
         /// <summary>
-        /// Gets the <see cref="Level"/>s used by the <see cref="AddressTable{TEntry}"/> instance.
+        /// Gets the <see cref="AddressTableLevel"/>s used by the <see cref="IAddressTable{TEntry}"/> instance.
         /// </summary>
         AddressTableLevel[] Levels { get; }
 
@@ -27,7 +33,7 @@ namespace ARMeilleure.Common
 
         /// <summary>
         /// Determines if the specified <paramref name="address"/> is in the range of the
-        /// <see cref="AddressTable{TEntry}"/>.
+        /// <see cref="IAddressTable{TEntry}"/>.
         /// </summary>
         /// <param name="address">Guest address</param>
         /// <returns><see langword="true"/> if is valid; otherwise <see langword="false"/></returns>

--- a/src/ARMeilleure/Common/NativeAllocator.cs
+++ b/src/ARMeilleure/Common/NativeAllocator.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace ARMeilleure.Common
 {
-    unsafe sealed class NativeAllocator : Allocator
+    public unsafe sealed class NativeAllocator : Allocator
     {
         public static NativeAllocator Instance { get; } = new();
 

--- a/src/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/src/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -205,7 +205,7 @@ namespace ARMeilleure.Instructions
 
                 hostAddress = context.Load(OperandType.I64, hostAddressAddr);
             }
-            else if (table.Levels.Length == 2)
+            else if (table.Sparse && table.Levels.Length == 2)
             {
                 // Inline table lookup. Only enabled when the sparse function table is enabled with 2 levels.
                 // Deliberately attempts to avoid branches.

--- a/src/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/src/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -211,9 +211,12 @@ namespace ARMeilleure.Instructions
                 // Deliberately attempts to avoid branches.
 
                 var level0 = table.Levels[0];
+                int clearBits0 = 64 - (level0.Index + level0.Length);
 
-                // Currently no bounds check. Maybe conditionally do this for unsafe host mapped.
-                Operand index = context.ShiftLeft(context.ShiftRightUI(guestAddress, Const(level0.Index)), Const(3));
+                Operand index = context.ShiftLeft(
+                    context.ShiftRightUI(context.ShiftLeft(guestAddress, Const(clearBits0)), Const(clearBits0 + level0.Index)),
+                    Const(3)
+                    );
 
                 Operand tableBase = !context.HasPtc ?
                     Const(table.Base) :
@@ -223,11 +226,10 @@ namespace ARMeilleure.Instructions
 
                 // Second level
                 var level1 = table.Levels[1];
-
-                int clearBits = 64 - (level1.Index + level1.Length);
+                int clearBits1 = 64 - (level1.Index + level1.Length);
 
                 Operand index2 = context.ShiftLeft(
-                    context.ShiftRightUI(context.ShiftLeft(guestAddress, Const(clearBits)), Const(clearBits + level1.Index)),
+                    context.ShiftRightUI(context.ShiftLeft(guestAddress, Const(clearBits1)), Const(clearBits1 + level1.Index)),
                     Const(3)
                     );
 

--- a/src/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/src/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -231,18 +231,7 @@ namespace ARMeilleure.Instructions
                     Const(3)
                     );
 
-                // TODO: could possibly make a fallback page that level 1 is filled with that contains dispatch stub on all pages
-                // Would save this load and the comparisons
-                // 16MB of the same value is a bit wasteful so it could replicate with remapping.
-
-                Operand fallback = !context.HasPtc ?
-                    Const((long)context.FunctionTable.Fallback) :
-                    Const((long)context.FunctionTable.Fallback, Ptc.DispatchFallbackSymbol);
-
-                Operand pageIsZero = context.ICompareEqual(page, Const(0L));
-
-                // Small trick to keep this branchless - if the page is zero, load a fallback table entry that always contains the dispatch stub.
-                hostAddress = context.Load(OperandType.I64, context.ConditionalSelect(pageIsZero, fallback, context.Add(page, index2)));
+                hostAddress = context.Load(OperandType.I64, context.Add(page, index2));
             }
             else
             {

--- a/src/ARMeilleure/Signal/NativeSignalHandlerGenerator.cs
+++ b/src/ARMeilleure/Signal/NativeSignalHandlerGenerator.cs
@@ -8,7 +8,7 @@ namespace ARMeilleure.Signal
 {
     public static class NativeSignalHandlerGenerator
     {
-        public const int MaxTrackedRanges = 8;
+        public const int MaxTrackedRanges = 16;
 
         private const int StructAddressOffset = 0;
         private const int StructWriteOffset = 4;

--- a/src/ARMeilleure/Translation/ArmEmitterContext.cs
+++ b/src/ARMeilleure/Translation/ArmEmitterContext.cs
@@ -46,7 +46,7 @@ namespace ARMeilleure.Translation
         public IMemoryManager Memory { get; }
 
         public EntryTable<uint> CountTable { get; }
-        public AddressTable<ulong> FunctionTable { get; }
+        public IAddressTable<ulong> FunctionTable { get; }
         public TranslatorStubs Stubs { get; }
 
         public ulong EntryAddress { get; }
@@ -62,7 +62,7 @@ namespace ARMeilleure.Translation
         public ArmEmitterContext(
             IMemoryManager memory,
             EntryTable<uint> countTable,
-            AddressTable<ulong> funcTable,
+            IAddressTable<ulong> funcTable,
             TranslatorStubs stubs,
             ulong entryAddress,
             bool highCq,

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 6950; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 26950; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 26957; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 26958; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -40,6 +40,8 @@ namespace ARMeilleure.Translation.PTC
         public static readonly Symbol PageTableSymbol = new(SymbolType.Special, 1);
         public static readonly Symbol CountTableSymbol = new(SymbolType.Special, 2);
         public static readonly Symbol DispatchStubSymbol = new(SymbolType.Special, 3);
+        public static readonly Symbol FunctionTableSymbol = new(SymbolType.Special, 4);
+        public static readonly Symbol DispatchFallbackSymbol = new(SymbolType.Special, 5);
 
         private const byte FillingByte = 0x00;
         private const CompressionLevel SaveCompressionLevel = CompressionLevel.Fastest;
@@ -704,6 +706,14 @@ namespace ARMeilleure.Translation.PTC
                 else if (symbol == DispatchStubSymbol)
                 {
                     imm = translator.Stubs.DispatchStub;
+                }
+                else if (symbol == FunctionTableSymbol)
+                {
+                    imm = translator.FunctionTable.Base;
+                }
+                else if (symbol == DispatchFallbackSymbol)
+                {
+                    imm = translator.FunctionTable.Fallback;
                 }
 
                 if (imm == null)

--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 26950; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 26957; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";
@@ -41,7 +41,6 @@ namespace ARMeilleure.Translation.PTC
         public static readonly Symbol CountTableSymbol = new(SymbolType.Special, 2);
         public static readonly Symbol DispatchStubSymbol = new(SymbolType.Special, 3);
         public static readonly Symbol FunctionTableSymbol = new(SymbolType.Special, 4);
-        public static readonly Symbol DispatchFallbackSymbol = new(SymbolType.Special, 5);
 
         private const byte FillingByte = 0x00;
         private const CompressionLevel SaveCompressionLevel = CompressionLevel.Fastest;
@@ -710,10 +709,6 @@ namespace ARMeilleure.Translation.PTC
                 else if (symbol == FunctionTableSymbol)
                 {
                     imm = translator.FunctionTable.Base;
-                }
-                else if (symbol == DispatchFallbackSymbol)
-                {
-                    imm = translator.FunctionTable.Fallback;
                 }
 
                 if (imm == null)

--- a/src/ARMeilleure/Translation/Translator.cs
+++ b/src/ARMeilleure/Translation/Translator.cs
@@ -22,8 +22,6 @@ namespace ARMeilleure.Translation
 {
     public class Translator
     {
-        private const bool UseSparseTable = true;
-
         private static readonly AddressTable<ulong>.Level[] _levels64Bit =
             new AddressTable<ulong>.Level[]
             {
@@ -88,7 +86,9 @@ namespace ARMeilleure.Translation
 
             AddressTable<ulong>.Level[] levels;
 
-            if (UseSparseTable)
+            bool useSparseTable = AddressTable<ulong>.UseSparseTable;
+
+            if (useSparseTable)
             {
                 levels = for64Bits ? _levels64BitSparse : _levels32BitSparse;
             }
@@ -99,7 +99,7 @@ namespace ARMeilleure.Translation
 
             CountTable = new EntryTable<uint>();
             Functions = new TranslatorCache<TranslatedFunction>();
-            FunctionTable = new AddressTable<ulong>(levels);
+            FunctionTable = new AddressTable<ulong>(levels, useSparseTable);
             Stubs = new TranslatorStubs(FunctionTable);
 
             FunctionTable.Fill = (ulong)Stubs.SlowDispatchStub;

--- a/src/ARMeilleure/Translation/Translator.cs
+++ b/src/ARMeilleure/Translation/Translator.cs
@@ -22,6 +22,8 @@ namespace ARMeilleure.Translation
 {
     public class Translator
     {
+        private const bool UseSparseTable = true;
+
         private static readonly AddressTable<ulong>.Level[] _levels64Bit =
             new AddressTable<ulong>.Level[]
             {
@@ -40,6 +42,20 @@ namespace ARMeilleure.Translation
                 new(15,  8),
                 new( 7,  8),
                 new( 1,  6),
+            };
+
+        private static readonly AddressTable<ulong>.Level[] _levels64BitSparse =
+            new AddressTable<ulong>.Level[]
+            {
+                new(23, 16),
+                new( 2, 21),
+            };
+
+        private static readonly AddressTable<ulong>.Level[] _levels32BitSparse =
+            new AddressTable<ulong>.Level[]
+            {
+                new(22, 10),
+                new( 1, 21),
             };
 
         private readonly IJitMemoryAllocator _allocator;
@@ -70,9 +86,20 @@ namespace ARMeilleure.Translation
 
             JitCache.Initialize(allocator);
 
+            AddressTable<ulong>.Level[] levels;
+
+            if (UseSparseTable)
+            {
+                levels = for64Bits ? _levels64BitSparse : _levels32BitSparse;
+            }
+            else
+            {
+                levels = for64Bits ? _levels64Bit : _levels32Bit;
+            }
+
             CountTable = new EntryTable<uint>();
             Functions = new TranslatorCache<TranslatedFunction>();
-            FunctionTable = new AddressTable<ulong>(for64Bits ? _levels64Bit : _levels32Bit);
+            FunctionTable = new AddressTable<ulong>(levels);
             Stubs = new TranslatorStubs(FunctionTable);
 
             FunctionTable.Fill = (ulong)Stubs.SlowDispatchStub;

--- a/src/ARMeilleure/Translation/TranslatorStubs.cs
+++ b/src/ARMeilleure/Translation/TranslatorStubs.cs
@@ -19,7 +19,7 @@ namespace ARMeilleure.Translation
 
         private bool _disposed;
 
-        private readonly AddressTable<ulong> _functionTable;
+        private readonly IAddressTable<ulong> _functionTable;
         private readonly Lazy<IntPtr> _dispatchStub;
         private readonly Lazy<DispatcherFunction> _dispatchLoop;
         private readonly Lazy<WrapperFunction> _contextWrapper;
@@ -86,7 +86,7 @@ namespace ARMeilleure.Translation
         /// </summary>
         /// <param name="functionTable">Function table used to store pointers to the functions that the guest code will call</param>
         /// <exception cref="ArgumentNullException"><paramref name="translator"/> is null</exception>
-        public TranslatorStubs(AddressTable<ulong> functionTable)
+        public TranslatorStubs(IAddressTable<ulong> functionTable)
         {
             ArgumentNullException.ThrowIfNull(functionTable);
 

--- a/src/Ryujinx.Cpu/AddressTable.cs
+++ b/src/Ryujinx.Cpu/AddressTable.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Memory;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.Cpu.Signal;
@@ -17,12 +18,6 @@ namespace ARMeilleure.Common
     /// <typeparam name="TEntry">Type of the value</typeparam>
     public unsafe class AddressTable<TEntry> : IAddressTable<TEntry> where TEntry : unmanaged
     {
-        /// <summary>
-        /// If true, the sparse 2-level table should be used to improve performance.
-        /// If false, the platform doesn't properly support it, or will be negatively impacted.
-        /// </summary>
-        public static bool UseSparseTable => true;
-
         private readonly struct AddressTablePage
         {
             public readonly bool IsSparse;
@@ -177,13 +172,15 @@ namespace ARMeilleure.Common
 
         /// <summary>
         /// Create an <see cref="AddressTable{TEntry}"/> instance for an ARM function table.
-        /// Selects the best table structure for A32/A64, taking into account whether sparse mapping is supported.
+        /// Selects the best table structure for A32/A64, taking into account the selected memory manager type.
         /// </summary>
         /// <param name="for64Bits">True if the guest is A64, false otherwise</param>
+        /// <param name="type">Memory manager type</param>
         /// <returns>An <see cref="AddressTable{TEntry}"/> for ARM function lookup</returns>
-        public static AddressTable<TEntry> CreateForArm(bool for64Bits)
+        public static AddressTable<TEntry> CreateForArm(bool for64Bits, MemoryManagerType type)
         {
-            bool sparse = UseSparseTable;
+            // Assume software memory means that we don't want to use any signal handlers.
+            bool sparse = type != MemoryManagerType.SoftwareMmu && type != MemoryManagerType.SoftwarePageTable;
 
             return new AddressTable<TEntry>(AddressTablePresets.GetArmPreset(for64Bits, sparse), sparse);
         }

--- a/src/Ryujinx.Cpu/AddressTable.cs
+++ b/src/Ryujinx.Cpu/AddressTable.cs
@@ -1,6 +1,5 @@
 using ARMeilleure.Memory;
 using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Cpu.Signal;
 using Ryujinx.Memory;
 using System;
@@ -54,8 +53,6 @@ namespace ARMeilleure.Common
 
                 _trackingEvent = (ulong address, ulong size, bool write) =>
                 {
-                    Logger.Error?.PrintMsg(LogClass.Cpu, $"Triggered from exception");
-
                     ulong pointer = (ulong)block.Block.Pointer + address;
 
                     ensureMapped((IntPtr)pointer);
@@ -355,9 +352,6 @@ namespace ARMeilleure.Common
             return _table;
         }
 
-        private int initedSize = 0;
-        private int reservedSize = 0;
-
         /// <summary>
         /// Initialize a leaf page with the fill value.
         /// </summary>
@@ -365,10 +359,6 @@ namespace ARMeilleure.Common
         private void InitLeafPage(Span<byte> page)
         {
             MemoryMarshal.Cast<byte, TEntry>(page).Fill(_fill);
-
-            initedSize += page.Length;
-
-            Ryujinx.Common.Logging.Logger.Info?.PrintMsg(LogClass.Cpu, $"Using memory {initedSize}/{reservedSize} bytes");
         }
 
         /// <summary>
@@ -396,8 +386,6 @@ namespace ARMeilleure.Common
         private IntPtr Allocate<T>(int length, T fill, bool leaf) where T : unmanaged
         {
             var size = sizeof(T) * length;
-
-            reservedSize += size;
 
             AddressTablePage page;
 

--- a/src/Ryujinx.Cpu/Jit/JitCpuContext.cs
+++ b/src/Ryujinx.Cpu/Jit/JitCpuContext.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Cpu.Jit
         public JitCpuContext(ITickSource tickSource, IMemoryManager memory, bool for64Bit)
         {
             _tickSource = tickSource;
-            _functionTable = AddressTable<ulong>.CreateForArm(for64Bit);
+            _functionTable = AddressTable<ulong>.CreateForArm(for64Bit, memory.Type);
 
             _translator = new Translator(new JitMemoryAllocator(forJit: true), memory, _functionTable);
 

--- a/src/Ryujinx.Cpu/Jit/JitCpuContext.cs
+++ b/src/Ryujinx.Cpu/Jit/JitCpuContext.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Common;
 using ARMeilleure.Memory;
 using ARMeilleure.Translation;
 using Ryujinx.Cpu.Signal;
@@ -9,11 +10,14 @@ namespace Ryujinx.Cpu.Jit
     {
         private readonly ITickSource _tickSource;
         private readonly Translator _translator;
+        private readonly AddressTable<ulong> _functionTable;
 
         public JitCpuContext(ITickSource tickSource, IMemoryManager memory, bool for64Bit)
         {
             _tickSource = tickSource;
-            _translator = new Translator(new JitMemoryAllocator(forJit: true), memory, for64Bit);
+            _functionTable = AddressTable<ulong>.CreateForArm(for64Bit);
+
+            _translator = new Translator(new JitMemoryAllocator(forJit: true), memory, _functionTable);
 
             if (memory.Type.IsHostMappedOrTracked())
             {

--- a/src/Ryujinx.Cpu/Jit/JitCpuContext.cs
+++ b/src/Ryujinx.Cpu/Jit/JitCpuContext.cs
@@ -59,6 +59,7 @@ namespace Ryujinx.Cpu.Jit
         /// <inheritdoc/>
         public void PrepareCodeRange(ulong address, ulong size)
         {
+            _functionTable.SignalCodeRange(address, size);
             _translator.PrepareCodeRange(address, size);
         }
 

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
@@ -214,17 +214,8 @@ namespace Ryujinx.Cpu.LightningJit.Arm32.Target.Arm64
                 asm.Ubfx(indexReg, guestAddress, level1.Index, level1.Length);
                 asm.Lsl(indexReg, indexReg, Const(3));
 
-                // Is the page address zero? Make sure to use the fallback if it is.
-                asm.Tst(rn, rn);
-
                 // Index into the page.
                 asm.Add(rn, rn, indexReg);
-
-                // Reuse the index register for the fallback
-                ulong fallback = (ulong)funcTable.Fallback;
-                asm.Mov(indexReg, fallback);
-
-                asm.Csel(rn, indexReg, rn, ArmCondition.Eq);
 
                 // Load the final branch address
                 asm.LdrRiUn(rn, rn, 0);

--- a/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm32/Target/Arm64/InstEmitFlow.cs
@@ -142,7 +142,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm32.Target.Arm64
             int tempRegister;
             int tempGuestAddress = -1;
 
-            bool inlineLookup = guestAddress.Kind != OperandKind.Constant && funcTable != null && funcTable.Levels.Length == 2;
+            bool inlineLookup = guestAddress.Kind != OperandKind.Constant && funcTable != null && funcTable.Sparse && funcTable.Levels.Length == 2;
 
             if (guestAddress.Kind == OperandKind.Constant)
             {

--- a/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
@@ -307,7 +307,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
             int tempRegister;
             int tempGuestAddress = -1;
 
-            bool inlineLookup = guestAddress.Kind != OperandKind.Constant && funcTable != null && funcTable.Levels.Length == 2;
+            bool inlineLookup = guestAddress.Kind != OperandKind.Constant && funcTable != null && funcTable.Sparse && funcTable.Levels.Length == 2;
 
             if (guestAddress.Kind == OperandKind.Constant)
             {

--- a/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
@@ -305,6 +305,9 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
             bool isTail = false)
         {
             int tempRegister;
+            int tempGuestAddress = 0;
+
+            bool inlineLookup = guestAddress.Kind != OperandKind.Constant && funcTable != null && funcTable.Levels.Length == 2;
 
             if (guestAddress.Kind == OperandKind.Constant)
             {
@@ -318,6 +321,13 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
             else
             {
                 asm.StrRiUn(guestAddress, Register(regAlloc.FixedContextRegister), NativeContextOffsets.DispatchAddressOffset);
+
+                if (inlineLookup)
+                {
+                    // Might be overwritten. Move the address to a temp register.
+                    tempGuestAddress = regAlloc.AllocateTempGprRegister();
+                    asm.Mov(Register(tempGuestAddress), guestAddress);
+                }
             }
 
             tempRegister = regAlloc.FixedContextRegister == 1 ? 2 : 1;
@@ -340,6 +350,47 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
 
                 asm.Mov(rn, funcPtrLoc & ~0xfffUL);
                 asm.LdrRiUn(rn, rn, (int)(funcPtrLoc & 0xfffUL));
+            }
+            else if (inlineLookup)
+            {
+                // Inline table lookup. Only enabled when the sparse function table is enabled with 2 levels.
+
+                Operand indexReg = Register(3);
+                guestAddress = Register(tempGuestAddress);
+
+                var level0 = funcTable.Levels[0];
+                asm.Ubfx(indexReg, guestAddress, level0.Index, level0.Length);
+                asm.Lsl(indexReg, indexReg, Const(3));
+
+                ulong tableBase = (ulong)funcTable.Base;
+
+                // Index into the table.
+                asm.Mov(rn, tableBase);
+                asm.Add(rn, rn, indexReg);
+
+                // Load the page address.
+                asm.LdrRiUn(rn, rn, 0);
+
+                var level1 = funcTable.Levels[1];
+                asm.Ubfx(indexReg, guestAddress, level1.Index, level1.Length);
+                asm.Lsl(indexReg, indexReg, Const(3));
+
+                // Is the page address zero? Make sure to use the fallback if it is.
+                asm.Tst(rn, rn);
+
+                // Index into the page.
+                asm.Add(rn, rn, indexReg);
+
+                // Reuse the index register for the fallback
+                ulong fallback = (ulong)funcTable.Fallback;
+                asm.Mov(indexReg, fallback);
+
+                asm.Csel(rn, indexReg, rn, ArmCondition.Eq);
+
+                // Load the final branch address
+                asm.LdrRiUn(rn, rn, 0);
+
+                regAlloc.FreeTempGprRegister(tempGuestAddress);
             }
             else
             {
@@ -612,6 +663,11 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
         private static Operand Register(int register, OperandType type = OperandType.I64)
         {
             return new Operand(register, RegisterType.Integer, type);
+        }
+
+        private static Operand Const(long value, OperandType type = OperandType.I64)
+        {
+            return new Operand(type, (ulong)value);
         }
     }
 }

--- a/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
@@ -385,12 +385,6 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
                 // Index into the page.
                 asm.Add(rn, rn, indexReg);
 
-                // Reuse the index register for the fallback
-                ulong fallback = (ulong)funcTable.Fallback;
-                asm.Mov(indexReg, fallback);
-
-                asm.Csel(rn, indexReg, rn, ArmCondition.Eq);
-
                 // Load the final branch address
                 asm.LdrRiUn(rn, rn, 0);
 

--- a/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Arm64/Target/Arm64/InstEmitSystem.cs
@@ -305,7 +305,7 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
             bool isTail = false)
         {
             int tempRegister;
-            int tempGuestAddress = 0;
+            int tempGuestAddress = -1;
 
             bool inlineLookup = guestAddress.Kind != OperandKind.Constant && funcTable != null && funcTable.Levels.Length == 2;
 
@@ -322,15 +322,15 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
             {
                 asm.StrRiUn(guestAddress, Register(regAlloc.FixedContextRegister), NativeContextOffsets.DispatchAddressOffset);
 
-                if (inlineLookup)
+                if (inlineLookup && guestAddress.Value == 0)
                 {
-                    // Might be overwritten. Move the address to a temp register.
+                    // X0 will be overwritten. Move the address to a temp register.
                     tempGuestAddress = regAlloc.AllocateTempGprRegister();
                     asm.Mov(Register(tempGuestAddress), guestAddress);
                 }
             }
 
-            tempRegister = regAlloc.FixedContextRegister == 1 ? 2 : 1;
+            tempRegister = NextFreeRegister(1, tempGuestAddress);
 
             if (!isTail)
             {
@@ -355,8 +355,12 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
             {
                 // Inline table lookup. Only enabled when the sparse function table is enabled with 2 levels.
 
-                Operand indexReg = Register(3);
-                guestAddress = Register(tempGuestAddress);
+                Operand indexReg = Register(NextFreeRegister(tempRegister + 1, tempGuestAddress));
+
+                if (tempGuestAddress != -1)
+                {
+                    guestAddress = Register(tempGuestAddress);
+                }
 
                 var level0 = funcTable.Levels[0];
                 asm.Ubfx(indexReg, guestAddress, level0.Index, level0.Length);
@@ -390,7 +394,10 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
                 // Load the final branch address
                 asm.LdrRiUn(rn, rn, 0);
 
-                regAlloc.FreeTempGprRegister(tempGuestAddress);
+                if (tempGuestAddress != -1)
+                {
+                    regAlloc.FreeTempGprRegister(tempGuestAddress);
+                }
             }
             else
             {
@@ -668,6 +675,16 @@ namespace Ryujinx.Cpu.LightningJit.Arm64.Target.Arm64
         private static Operand Const(long value, OperandType type = OperandType.I64)
         {
             return new Operand(type, (ulong)value);
+        }
+
+        private static int NextFreeRegister(int start, int avoid)
+        {
+            if (start == avoid)
+            {
+                start++;
+            }
+
+            return start;
         }
     }
 }

--- a/src/Ryujinx.Cpu/LightningJit/LightningJitCpuContext.cs
+++ b/src/Ryujinx.Cpu/LightningJit/LightningJitCpuContext.cs
@@ -53,6 +53,7 @@ namespace Ryujinx.Cpu.LightningJit
         /// <inheritdoc/>
         public void PrepareCodeRange(ulong address, ulong size)
         {
+            _functionTable.SignalCodeRange(address, size);
         }
 
         public void Dispose()

--- a/src/Ryujinx.Cpu/LightningJit/LightningJitCpuContext.cs
+++ b/src/Ryujinx.Cpu/LightningJit/LightningJitCpuContext.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Common;
 using ARMeilleure.Memory;
 using Ryujinx.Cpu.Jit;
 using Ryujinx.Cpu.LightningJit.State;
@@ -8,11 +9,15 @@ namespace Ryujinx.Cpu.LightningJit
     {
         private readonly ITickSource _tickSource;
         private readonly Translator _translator;
+        private readonly AddressTable<ulong> _functionTable;
 
         public LightningJitCpuContext(ITickSource tickSource, IMemoryManager memory, bool for64Bit)
         {
             _tickSource = tickSource;
-            _translator = new Translator(memory, for64Bit);
+            _functionTable = AddressTable<ulong>.CreateForArm(for64Bit);
+
+            _translator = new Translator(memory, _functionTable);
+
             memory.UnmapEvent += UnmapHandler;
         }
 

--- a/src/Ryujinx.Cpu/LightningJit/LightningJitCpuContext.cs
+++ b/src/Ryujinx.Cpu/LightningJit/LightningJitCpuContext.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Cpu.LightningJit
         public LightningJitCpuContext(ITickSource tickSource, IMemoryManager memory, bool for64Bit)
         {
             _tickSource = tickSource;
-            _functionTable = AddressTable<ulong>.CreateForArm(for64Bit);
+            _functionTable = AddressTable<ulong>.CreateForArm(for64Bit, memory.Type);
 
             _translator = new Translator(memory, _functionTable);
 

--- a/src/Ryujinx.Cpu/LightningJit/Translator.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Translator.cs
@@ -16,8 +16,6 @@ namespace Ryujinx.Cpu.LightningJit
 {
     class Translator : IDisposable
     {
-        private const bool UseSparseTable = true;
-
         // Should be enabled on platforms that enforce W^X.
         private static bool IsNoWxPlatform => false;
 
@@ -78,9 +76,11 @@ namespace Ryujinx.Cpu.LightningJit
                 JitCache.Initialize(new JitMemoryAllocator(forJit: true));
             }
 
+            bool useSparseTable = AddressTable<ulong>.UseSparseTable;
+
             AddressTable<ulong>.Level[] levels;
 
-            if (UseSparseTable)
+            if (useSparseTable)
             {
                 levels = for64Bits ? _levels64BitSparse : _levels32BitSparse;
             }
@@ -90,7 +90,7 @@ namespace Ryujinx.Cpu.LightningJit
             }
 
             Functions = new TranslatorCache<TranslatedFunction>();
-            FunctionTable = new AddressTable<ulong>(levels);
+            FunctionTable = new AddressTable<ulong>(levels, useSparseTable);
             Stubs = new TranslatorStubs(FunctionTable, _noWxCache);
 
             FunctionTable.Fill = (ulong)Stubs.SlowDispatchStub;

--- a/src/Ryujinx.Memory/SparseMemoryBlock.cs
+++ b/src/Ryujinx.Memory/SparseMemoryBlock.cs
@@ -1,0 +1,120 @@
+using Ryujinx.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ryujinx.Memory
+{
+    public delegate void PageInitDelegate(Span<byte> page);
+
+    public class SparseMemoryBlock : IDisposable
+    {
+        private const ulong MapGranularity = 1UL << 17;
+
+        private readonly PageInitDelegate _pageInit;
+
+        private readonly object _lock = new object();
+        private readonly ulong _pageSize;
+        private readonly MemoryBlock _reservedBlock;
+        private readonly List<MemoryBlock> _mappedBlocks;
+        private ulong _mappedBlockUsage;
+
+        private readonly ulong[] _mappedPageBitmap;
+
+        public MemoryBlock Block => _reservedBlock;
+
+        public SparseMemoryBlock(ulong size, PageInitDelegate pageInit, MemoryBlock fill)
+        {
+            _pageSize = MemoryBlock.GetPageSize();
+            _reservedBlock = new MemoryBlock(size, MemoryAllocationFlags.Reserve | MemoryAllocationFlags.ViewCompatible);
+            _mappedBlocks = new List<MemoryBlock>();
+            _pageInit = pageInit;
+
+            int pages = (int)BitUtils.DivRoundUp(size, _pageSize);
+            int bitmapEntries = BitUtils.DivRoundUp(pages, 64);
+            _mappedPageBitmap = new ulong[bitmapEntries];
+
+            if (fill != null)
+            {
+                // Fill the block with mappings from the fill block.
+
+                if (fill.Size % _pageSize != 0)
+                {
+                    throw new ArgumentException("Fill memory block should be page aligned.", nameof(fill));
+                }
+
+                int repeats = (int)BitUtils.DivRoundUp(size, fill.Size);
+
+                ulong offset = 0;
+                for (int i = 0; i < repeats; i++)
+                {
+                    _reservedBlock.MapView(fill, 0, offset, Math.Min(fill.Size, size - offset));
+                    offset += fill.Size;
+                }
+            }
+
+            // If a fill block isn't provided, the pages that aren't EnsureMapped are unmapped.
+            // The caller can rely on signal handler to fill empty pages instead.
+        }
+
+        private void MapPage(ulong pageOffset)
+        {
+            // Take a page from the latest mapped block.
+            MemoryBlock block = _mappedBlocks.LastOrDefault();
+
+            if (block == null || _mappedBlockUsage == MapGranularity)
+            {
+                // Need to map some more memory.
+
+                block = new MemoryBlock(MapGranularity, MemoryAllocationFlags.Mirrorable | MemoryAllocationFlags.NoMap);
+
+                _mappedBlocks.Add(block);
+
+                _mappedBlockUsage = 0;
+            }
+
+            _reservedBlock.MapView(block, _mappedBlockUsage, pageOffset, _pageSize);
+            _pageInit(_reservedBlock.GetSpan(pageOffset, (int)_pageSize));
+
+            _mappedBlockUsage += _pageSize;
+        }
+
+        public void EnsureMapped(ulong offset)
+        {
+            int pageIndex = (int)(offset / _pageSize);
+            int bitmapIndex = pageIndex >> 6;
+
+            ref ulong entry = ref _mappedPageBitmap[bitmapIndex];
+            ulong bit = 1UL << (pageIndex & 63);
+
+            if ((entry & bit) == 0)
+            {
+                // Not mapped.
+
+                lock (_lock)
+                {
+                    // Check the bit while locked to make sure that this only happens once.
+
+                    if ((entry & bit) == 0)
+                    {
+                        MapPage(offset & ~(_pageSize - 1));
+
+                        entry |= bit;
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _reservedBlock.Dispose();
+
+            foreach (MemoryBlock block in _mappedBlocks)
+            {
+                block.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an alternate mode for the existing multi-level page table that uses only 2 levels, and inlines the function lookup instead of calling through a stub. The bottom level is 16MB per page, but uses a reserved region that isn't initially mapped. As the guest accesses unmapped pages, or the JIT tries to insert new functions, they are mapped and filled with the stub value to simulate sparse mapping. Additionally, the top level of the table is filled with pointers to a dummy page filled with the stub (really just a 64k fill of the stub address repeated across a 16MB page) to avoid any branches.

This is essentially a memory for performance tradeoff - it gets a much faster lookup (around 10 instructions on ARM, 2 memory reads) for a table with 4096/16384 byte granularity at the bottom, and some mapping/signal handling overhead. Due to the use of the signal handler, this mode is disabled when Software memory is used, as we assume the user doesn't want a signal handler in that mode.

This tends to make indirect branches (branches to an address held by a register rather than a constant address) a lot faster. The two most popular cases where indirect branches are used are SDK imports (pokemon really spams these) and switch statements, though any kind of virtualized method will also count.

Performance benefits are expected to be seen in games _where the FIFO% measurement is notably lower than 100%_, as those are most likely to be bottlenecked by the JIT.

## Notes

I considered just using `Commit()` to commit pages of the sparse mapping instead of using mapped views, but this would leave some time where the values in the page would be uninitialized, and the code deliberately avoids any kind of check and just throws the page read result into a branch.

Could save 2 instructions on x86 with the bitfield extensions similar to ARM, but that could be used on more than just this.

## Improvements

Improvements are most noticeable on x86. ARM target is very fast and the problem is usually GPU there, though it could reduce power usage.

**Notable benefit:**
- Animal Crossing: New Horizons
- Pokemon Legends: Arceus
- Pokemon Scarlet & Violet
- Paper Mario: TTYD (allegedly)

**Small benefit, depends on GPU behaviour and game area:**
- TOTK/BOTW

## Table and code size comparisons

TODO. Usually around half of the full sparse region is committed in A64 with 4k pages, a little more with 16k pages. Less is used with A32 games.

Code size will be larger, as it inlines branches rather than calling the stub. Hopefully not by too much.

## Testing Notes

It would be interesting to see how this behaves on SSBU, since that game constantly loads and unloads NROs it might just keep allocating more table and eventually run out of tracking regions. It'll probably run out of JIT cache first, though. It really needs to be dealt with separately, plus it would be nice to change the native signal handler to support a much larger number of tracked regions without the unrolled loop becoming hilariously large. It's also JIT bottlenecked, so it might be faster on average, at least until it horribly crashes.