### PR TITLE
discord: Fix TruncateToByteLength() not taking the string length into account before trimming

### DIFF
--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -104,8 +104,13 @@ namespace Ryujinx.UI.Common
             // Find the length to trim the string to guarantee we have space for the trailing ellipsis.
             int trimLimit = byteLimit - Encoding.UTF8.GetByteCount(Ellipsis);
 
-            // Basic trim to best case scenario of 1 byte characters.
-            input = input[..trimLimit];
+            // Make sure the string is long enough to perform the basic trim.
+            // Amount of bytes != Length of the string
+            if (input.Length > trimLimit)
+            {
+                // Basic trim to best case scenario of 1 byte characters.
+                input = input[..trimLimit];
+            }
 
             while (Encoding.UTF8.GetByteCount(input) > trimLimit)
             {


### PR DESCRIPTION
This tiny PR adds a check to make sure the string we are trimming is long enough for the basic trim.

The bytes of the string can exceed the limit, while actual length of the string can still be a lot lower than that.
As a test I used a string of length 50, which could be represented as a byte array with 130 elements.

---

Fixes #6981