### PR TITLE
Disable descriptor set template updates for buffer textures on Adreno

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -73,7 +73,6 @@ namespace Ryujinx.Graphics.Vulkan
 
         private readonly VulkanRenderer _gd;
         private readonly Device _device;
-        private readonly PipelineBase _pipeline;
         private ShaderCollection _program;
 
         private readonly BufferRef[] _uniformBufferRefs;
@@ -125,11 +124,10 @@ namespace Ryujinx.Graphics.Vulkan
         private readonly TextureView _dummyTexture;
         private readonly SamplerHolder _dummySampler;
 
-        public DescriptorSetUpdater(VulkanRenderer gd, Device device, PipelineBase pipeline)
+        public DescriptorSetUpdater(VulkanRenderer gd, Device device)
         {
             _gd = gd;
             _device = device;
-            _pipeline = pipeline;
 
             // Some of the bindings counts needs to be multiplied by 2 because we have buffer and
             // regular textures/images interleaved on the same descriptor set.

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -684,12 +684,26 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_dirty.HasFlag(DirtyFlags.Texture))
             {
-                UpdateAndBind(cbs, program, PipelineBase.TextureSetIndex, pbp);
+                if (program.UpdateTexturesWithoutTemplate)
+                {
+                    UpdateAndBindTexturesWithoutTemplate(cbs, program, pbp);
+                }
+                else
+                {
+                    UpdateAndBind(cbs, program, PipelineBase.TextureSetIndex, pbp);
+                }
             }
 
             if (_dirty.HasFlag(DirtyFlags.Image))
             {
-                UpdateAndBind(cbs, program, PipelineBase.ImageSetIndex, pbp);
+                if (program.UpdateImagesWithoutTemplate)
+                {
+                    UpdateAndBindImagesWithoutTemplate(cbs, program, pbp);
+                }
+                else
+                {
+                    UpdateAndBind(cbs, program, PipelineBase.ImageSetIndex, pbp);
+                }
             }
 
             if (program.BindingSegments.Length > PipelineBase.DescriptorSetLayouts)
@@ -914,6 +928,152 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sets = dsc.GetSets();
             _templateUpdater.Commit(_gd, _device, sets[0]);
+
+            _gd.Api.CmdBindDescriptorSets(cbs.CommandBuffer, pbp, _program.PipelineLayout, (uint)setIndex, 1, sets, 0, ReadOnlySpan<uint>.Empty);
+        }
+
+        private void UpdateAndBindTexturesWithoutTemplate(CommandBufferScoped cbs, ShaderCollection program, PipelineBindPoint pbp)
+        {
+            int setIndex = PipelineBase.TextureSetIndex;
+            var bindingSegments = program.BindingSegments[setIndex];
+
+            if (bindingSegments.Length == 0)
+            {
+                return;
+            }
+
+            if (_updateDescriptorCacheCbIndex)
+            {
+                _updateDescriptorCacheCbIndex = false;
+                program.UpdateDescriptorCacheCommandBufferIndex(cbs.CommandBufferIndex);
+            }
+
+            var dsc = program.GetNewDescriptorSetCollection(setIndex, out _).Get(cbs);
+
+            foreach (ResourceBindingSegment segment in bindingSegments)
+            {
+                int binding = segment.Binding;
+                int count = segment.Count;
+
+                if (!segment.IsArray)
+                {
+                    if (segment.Type != ResourceType.BufferTexture)
+                    {
+                        Span<DescriptorImageInfo> textures = _textures;
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            ref var texture = ref textures[i];
+                            ref var refs = ref _textureRefs[binding + i];
+
+                            texture.ImageView = refs.View?.Get(cbs).Value ?? default;
+                            texture.Sampler = refs.Sampler?.Get(cbs).Value ?? default;
+
+                            if (texture.ImageView.Handle == 0)
+                            {
+                                texture.ImageView = _dummyTexture.GetImageView().Get(cbs).Value;
+                            }
+
+                            if (texture.Sampler.Handle == 0)
+                            {
+                                texture.Sampler = _dummySampler.GetSampler().Get(cbs).Value;
+                            }
+                        }
+
+                        dsc.UpdateImages(0, binding, textures[..count], DescriptorType.CombinedImageSampler);
+                    }
+                    else
+                    {
+                        Span<BufferView> bufferTextures = _bufferTextures;
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            bufferTextures[i] = _bufferTextureRefs[binding + i]?.GetBufferView(cbs, false) ?? default;
+                        }
+
+                        dsc.UpdateBufferImages(0, binding, bufferTextures[..count], DescriptorType.UniformTexelBuffer);
+                    }
+                }
+                else
+                {
+                    if (segment.Type != ResourceType.BufferTexture)
+                    {
+                        dsc.UpdateImages(0, binding, _textureArrayRefs[binding].Array.GetImageInfos(_gd, cbs, _dummyTexture, _dummySampler), DescriptorType.CombinedImageSampler);
+                    }
+                    else
+                    {
+                        dsc.UpdateBufferImages(0, binding, _textureArrayRefs[binding].Array.GetBufferViews(cbs), DescriptorType.UniformTexelBuffer);
+                    }
+                }
+            }
+
+            var sets = dsc.GetSets();
+
+            _gd.Api.CmdBindDescriptorSets(cbs.CommandBuffer, pbp, _program.PipelineLayout, (uint)setIndex, 1, sets, 0, ReadOnlySpan<uint>.Empty);
+        }
+
+        private void UpdateAndBindImagesWithoutTemplate(CommandBufferScoped cbs, ShaderCollection program, PipelineBindPoint pbp)
+        {
+            int setIndex = PipelineBase.ImageSetIndex;
+            var bindingSegments = program.BindingSegments[setIndex];
+
+            if (bindingSegments.Length == 0)
+            {
+                return;
+            }
+
+            if (_updateDescriptorCacheCbIndex)
+            {
+                _updateDescriptorCacheCbIndex = false;
+                program.UpdateDescriptorCacheCommandBufferIndex(cbs.CommandBufferIndex);
+            }
+
+            var dsc = program.GetNewDescriptorSetCollection(setIndex, out _).Get(cbs);
+
+            foreach (ResourceBindingSegment segment in bindingSegments)
+            {
+                int binding = segment.Binding;
+                int count = segment.Count;
+
+                if (!segment.IsArray)
+                {
+                    if (segment.Type != ResourceType.BufferImage)
+                    {
+                        Span<DescriptorImageInfo> images = _images;
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            images[i].ImageView = _imageRefs[binding + i].View?.Get(cbs).Value ?? default;
+                        }
+
+                        dsc.UpdateImages(0, binding, images[..count], DescriptorType.StorageImage);
+                    }
+                    else
+                    {
+                        Span<BufferView> bufferImages = _bufferImages;
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            bufferImages[i] = _bufferImageRefs[binding + i]?.GetBufferView(cbs, _bufferImageFormats[binding + i], true) ?? default;
+                        }
+
+                        dsc.UpdateBufferImages(0, binding, bufferImages[..count], DescriptorType.StorageTexelBuffer);
+                    }
+                }
+                else
+                {
+                    if (segment.Type != ResourceType.BufferTexture)
+                    {
+                        dsc.UpdateImages(0, binding, _imageArrayRefs[binding].Array.GetImageInfos(_gd, cbs, _dummyTexture), DescriptorType.StorageImage);
+                    }
+                    else
+                    {
+                        dsc.UpdateBufferImages(0, binding, _imageArrayRefs[binding].Array.GetBufferViews(cbs), DescriptorType.StorageTexelBuffer);
+                    }
+                }
+            }
+
+            var sets = dsc.GetSets();
 
             _gd.Api.CmdBindDescriptorSets(cbs.CommandBuffer, pbp, _program.PipelineLayout, (uint)setIndex, 1, sets, 0, ReadOnlySpan<uint>.Empty);
         }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -105,7 +105,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             gd.Api.CreatePipelineCache(device, pipelineCacheCreateInfo, null, out PipelineCache).ThrowOnError();
 
-            _descriptorSetUpdater = new DescriptorSetUpdater(gd, device, this);
+            _descriptorSetUpdater = new DescriptorSetUpdater(gd, device);
             _vertexBufferUpdater = new VertexBufferUpdater(gd);
 
             _transformFeedbackBuffers = new BufferState[Constants.MaxTransformFeedbackBuffers];

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -24,7 +24,6 @@ namespace Ryujinx.Graphics.Vulkan
         public bool HasTessellationControlShader => (Stages & (1u << 3)) != 0;
 
         public bool UpdateTexturesWithoutTemplate { get; }
-        public bool UpdateImagesWithoutTemplate { get; }
 
         public uint Stages { get; }
 
@@ -144,10 +143,7 @@ namespace Ryujinx.Graphics.Vulkan
                         if (bindingSegment.Type == ResourceType.BufferTexture)
                         {
                             UpdateTexturesWithoutTemplate = true;
-                        }
-                        else if (bindingSegment.Type == ResourceType.BufferImage)
-                        {
-                            UpdateImagesWithoutTemplate = true;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Buffer texture updates are currently causing the Adreno driver to crash on Windows. To work around the issue, this change disables template updates for buffer textures on Adreno.

Allows UE4 games and a few others (like Mario + Rabbids) to run.
Note that this was tested with #7001, otherwise it crashes pretty quickly when waiting for fences.

![Captura de tela 2024-07-06 151141](https://github.com/Ryujinx/Ryujinx/assets/5624669/076eb824-da01-4cef-a2c1-76c3fe05cfc8)
