### PR TITLE
Force Vulkan swapchain re-creation when window size changes

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Window.cs
@@ -623,7 +623,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public override void SetSize(int width, int height)
         {
-            // Not needed as we can get the size from the surface.
+            // We don't need to use width and height as we can get the size from the surface.
+            _swapchainIsDirty = true;
         }
 
         public override void ChangeVSyncMode(bool vsyncEnabled)


### PR DESCRIPTION
Most drivers returns an `ErrorOutOfDateKhr` or `SuboptimalKhr` error when the swapchain is used after the window is resized, but apparently not Adreno driver.
This forces a swapchain re-creation when the window size size changes.
Fixes incorrect render size after window resize on Adreno GPUs on Windows.

Before:

https://github.com/Ryujinx/Ryujinx/assets/5624669/8d4205b5-fbcd-45c9-88a1-f054ff1bb4ac

After:

https://github.com/Ryujinx/Ryujinx/assets/5624669/7a995cd3-d98c-41ba-8613-5e72cdb68500


