### PR TITLE
Force dynamic state update after rasterizer discard disable on Adreno

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1020,6 +1020,13 @@ namespace Ryujinx.Graphics.Vulkan
         {
             _newState.RasterizerDiscardEnable = discard;
             SignalStateChange();
+
+            if (!discard && Gd.Vendor == Vendor.Qualcomm)
+            {
+                // On Adreno, enabling rasterizer discard somehow corrupts the viewport state.
+                // Force it to be updated on next use to work around this bug.
+                DynamicState.ForceAllDirty();
+            }
         }
 
         public void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMask)


### PR DESCRIPTION
There is a bug on Adreno drivers where the viewport state becomes corrupted after enabling rasterizer discard.
This change works around the issue by making dynamic state dirty after rasterizer discard is disabled. This will force the viewport and other dynamic state to be updated again on the next draw.

Improves rendering on Xenoblade Chronicles 2. It is not easy to see the difference right now due to all the barrier issues, but it causes some objects to disappear or move around. The screenshots below catches the "bad state" to make the difference more evident.
Before:
![Captura de tela 2024-07-07 224326](https://github.com/Ryujinx/Ryujinx/assets/5624669/778f1ead-6ec0-495f-ba6c-eab03f4e4d4f)
After:
![Captura de tela 2024-07-07 224311](https://github.com/Ryujinx/Ryujinx/assets/5624669/13fc33f8-b3f1-455b-a913-5829d555b98b)