### PR TITLE
Vulkan: Defer guest barriers, and improve image barrier timings

### DIFF
--- a/src/Ryujinx.Graphics.GAL/ResourceLayout.cs
+++ b/src/Ryujinx.Graphics.GAL/ResourceLayout.cs
@@ -74,13 +74,15 @@ namespace Ryujinx.Graphics.GAL
         public int ArrayLength { get; }
         public ResourceType Type { get; }
         public ResourceStages Stages { get; }
+        public bool Write { get; }
 
-        public ResourceUsage(int binding, int arrayLength, ResourceType type, ResourceStages stages)
+        public ResourceUsage(int binding, int arrayLength, ResourceType type, ResourceStages stages, bool write)
         {
             Binding = binding;
             ArrayLength = arrayLength;
             Type = type;
             Stages = stages;
+            Write = write;
         }
 
         public override int GetHashCode()

--- a/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
@@ -333,7 +333,7 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
-                if (inRenderPass && _memoryBarriers.Count > 0 && _gd.IsTBDR)
+                if (inRenderPass && _memoryBarriers.Count > 0)
                 {
                     PipelineStageFlags allFlags = PipelineStageFlags.None;
 
@@ -342,9 +342,10 @@ namespace Ryujinx.Graphics.Vulkan
                         allFlags |= barrier.Flags.Dest;
                     }
 
-                    if (!_gd.SupportsRenderPassBarrier(allFlags))
+                    if (allFlags.HasFlag(PipelineStageFlags.DrawIndirectBit) || !_gd.SupportsRenderPassBarrier(allFlags))
                     {
                         endRenderPass();
+                        inRenderPass = false;
                     }
                 }
 

--- a/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
@@ -1,6 +1,7 @@
 using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -8,20 +9,62 @@ namespace Ryujinx.Graphics.Vulkan
     {
         private const int MaxBarriersPerCall = 16;
 
+        private const AccessFlags BaseAccess = AccessFlags.ShaderReadBit | AccessFlags.ShaderWriteBit;
+        private const AccessFlags BufferAccess = AccessFlags.IndexReadBit | AccessFlags.VertexAttributeReadBit | AccessFlags.UniformReadBit;
+        private const AccessFlags CommandBufferAccess = AccessFlags.IndirectCommandReadBit;
+
         private readonly VulkanRenderer _gd;
 
         private readonly NativeArray<MemoryBarrier> _memoryBarrierBatch = new(MaxBarriersPerCall);
         private readonly NativeArray<BufferMemoryBarrier> _bufferBarrierBatch = new(MaxBarriersPerCall);
         private readonly NativeArray<ImageMemoryBarrier> _imageBarrierBatch = new(MaxBarriersPerCall);
 
-        private readonly List<BarrierWithStageFlags<MemoryBarrier>> _memoryBarriers = new();
-        private readonly List<BarrierWithStageFlags<BufferMemoryBarrier>> _bufferBarriers = new();
-        private readonly List<BarrierWithStageFlags<ImageMemoryBarrier>> _imageBarriers = new();
+        private readonly List<BarrierWithStageFlags<MemoryBarrier, int>> _memoryBarriers = new();
+        private readonly List<BarrierWithStageFlags<BufferMemoryBarrier, int>> _bufferBarriers = new();
+        private readonly List<BarrierWithStageFlags<ImageMemoryBarrier, TextureStorage>> _imageBarriers = new();
         private int _queuedBarrierCount;
+
+        private enum IncoherentBarrierType
+        {
+            None,
+            Texture,
+            All,
+            CommandBuffer
+        }
+
+        private PipelineStageFlags _incoherentBufferWriteStages;
+        private PipelineStageFlags _incoherentTextureWriteStages;
+        private PipelineStageFlags _extraStages;
+        private IncoherentBarrierType _queuedIncoherentBarrier;
 
         public BarrierBatch(VulkanRenderer gd)
         {
             _gd = gd;
+        }
+
+        public static (AccessFlags Access, PipelineStageFlags Stages) GetSubpassAccessSuperset(VulkanRenderer gd)
+        {
+            AccessFlags access = BufferAccess;
+            PipelineStageFlags stages = PipelineStageFlags.AllGraphicsBit;
+
+            if (gd.TransformFeedbackApi != null)
+            {
+                access |= AccessFlags.TransformFeedbackWriteBitExt;
+                stages |= PipelineStageFlags.TransformFeedbackBitExt;
+            }
+
+            if (!gd.IsTBDR)
+            {
+                // Desktop GPUs can transform image barriers into memory barriers.
+
+                access |= AccessFlags.DepthStencilAttachmentWriteBit | AccessFlags.ColorAttachmentWriteBit;
+                access |= AccessFlags.DepthStencilAttachmentReadBit | AccessFlags.ColorAttachmentReadBit;
+
+                stages |= PipelineStageFlags.EarlyFragmentTestsBit | PipelineStageFlags.LateFragmentTestsBit;
+                stages |= PipelineStageFlags.ColorAttachmentOutputBit;
+            }
+
+            return (access, stages);
         }
 
         private readonly record struct StageFlags : IEquatable<StageFlags>
@@ -36,47 +79,130 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        private readonly struct BarrierWithStageFlags<T> where T : unmanaged
+        private readonly struct BarrierWithStageFlags<T, T2> where T : unmanaged
         {
             public readonly StageFlags Flags;
             public readonly T Barrier;
+            public readonly T2 Resource;
 
             public BarrierWithStageFlags(StageFlags flags, T barrier)
             {
                 Flags = flags;
                 Barrier = barrier;
+                Resource = default;
             }
 
-            public BarrierWithStageFlags(PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags, T barrier)
+            public BarrierWithStageFlags(PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags, T barrier, T2 resource)
             {
                 Flags = new StageFlags(srcStageFlags, dstStageFlags);
                 Barrier = barrier;
+                Resource = resource;
             }
         }
 
-        private void QueueBarrier<T>(List<BarrierWithStageFlags<T>> list, T barrier, PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags) where T : unmanaged
+        private void QueueBarrier<T, T2>(List<BarrierWithStageFlags<T, T2>> list, T barrier, T2 resource, PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags) where T : unmanaged
         {
-            list.Add(new BarrierWithStageFlags<T>(srcStageFlags, dstStageFlags, barrier));
+            list.Add(new BarrierWithStageFlags<T, T2>(srcStageFlags, dstStageFlags, barrier, resource));
             _queuedBarrierCount++;
         }
 
         public void QueueBarrier(MemoryBarrier barrier, PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags)
         {
-            QueueBarrier(_memoryBarriers, barrier, srcStageFlags, dstStageFlags);
+            QueueBarrier(_memoryBarriers, barrier, default, srcStageFlags, dstStageFlags);
         }
 
         public void QueueBarrier(BufferMemoryBarrier barrier, PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags)
         {
-            QueueBarrier(_bufferBarriers, barrier, srcStageFlags, dstStageFlags);
+            QueueBarrier(_bufferBarriers, barrier, default, srcStageFlags, dstStageFlags);
         }
 
-        public void QueueBarrier(ImageMemoryBarrier barrier, PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags)
+        public void QueueBarrier(ImageMemoryBarrier barrier, TextureStorage resource, PipelineStageFlags srcStageFlags, PipelineStageFlags dstStageFlags)
         {
-            QueueBarrier(_imageBarriers, barrier, srcStageFlags, dstStageFlags);
+            QueueBarrier(_imageBarriers, barrier, resource, srcStageFlags, dstStageFlags);
         }
 
-        public unsafe void Flush(CommandBuffer cb, bool insideRenderPass, Action endRenderPass)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void FlushMemoryBarrier(ShaderCollection program, bool inRenderPass)
         {
+            if (_queuedIncoherentBarrier > IncoherentBarrierType.None)
+            {
+                // We should emit a memory barrier if there's a write access in the program (current program, or program since last barrier)
+                bool hasTextureWrite = _incoherentTextureWriteStages != PipelineStageFlags.None;
+                bool hasBufferWrite = _incoherentBufferWriteStages != PipelineStageFlags.None;
+                bool hasBufferBarrier = _queuedIncoherentBarrier > IncoherentBarrierType.Texture;
+
+                if (hasTextureWrite || (hasBufferBarrier && hasBufferWrite))
+                {
+                    AccessFlags access = BaseAccess;
+
+                    PipelineStageFlags stages = inRenderPass ? PipelineStageFlags.AllGraphicsBit : PipelineStageFlags.AllCommandsBit;
+
+                    if (hasBufferBarrier && hasBufferWrite)
+                    {
+                        access |= BufferAccess;
+
+                        if (_gd.TransformFeedbackApi != null)
+                        {
+                            access |= AccessFlags.TransformFeedbackWriteBitExt;
+                            stages |= PipelineStageFlags.TransformFeedbackBitExt;
+                        }
+                    }
+
+                    if (_queuedIncoherentBarrier == IncoherentBarrierType.CommandBuffer)
+                    {
+                        access |= CommandBufferAccess;
+                        stages |= PipelineStageFlags.DrawIndirectBit;
+                    }
+
+                    MemoryBarrier barrier = new MemoryBarrier()
+                    {
+                        SType = StructureType.MemoryBarrier,
+                        SrcAccessMask = access,
+                        DstAccessMask = access
+                    };
+
+                    QueueBarrier(barrier, stages, stages);
+
+                    _incoherentTextureWriteStages = program?.IncoherentTextureWriteStages ?? PipelineStageFlags.None;
+
+                    if (_queuedIncoherentBarrier > IncoherentBarrierType.Texture)
+                    {
+                        if (program != null)
+                        {
+                            _incoherentBufferWriteStages = program.IncoherentBufferWriteStages | _extraStages;
+                        }
+                        else
+                        {
+                            _incoherentBufferWriteStages = PipelineStageFlags.None;
+                        }
+                    }
+
+                    _queuedIncoherentBarrier = IncoherentBarrierType.None;
+                }
+            }
+        }
+
+        public unsafe void Flush(CommandBufferScoped cbs, bool inRenderPass, RenderPassHolder rpHolder, Action endRenderPass)
+        {
+            Flush(cbs, null, inRenderPass, rpHolder, endRenderPass);
+        }
+
+        public unsafe void Flush(CommandBufferScoped cbs, ShaderCollection program, bool inRenderPass, RenderPassHolder rpHolder, Action endRenderPass)
+        {
+            if (program != null)
+            {
+                _incoherentBufferWriteStages |= program.IncoherentBufferWriteStages | _extraStages;
+                _incoherentTextureWriteStages |= program.IncoherentTextureWriteStages;
+            }
+
+            FlushMemoryBarrier(program, inRenderPass);
+
+            if (!inRenderPass && rpHolder != null)
+            {
+                // Render pass is about to begin. Queue any fences that normally interrupt the pass.
+                rpHolder.InsertForcedFences(cbs);
+            }
+
             while (_queuedBarrierCount > 0)
             {
                 int memoryCount = 0;
@@ -86,20 +212,20 @@ namespace Ryujinx.Graphics.Vulkan
                 bool hasBarrier = false;
                 StageFlags flags = default;
 
-                static void AddBarriers<T>(
+                static void AddBarriers<T, T2>(
                     Span<T> target,
                     ref int queuedBarrierCount,
                     ref bool hasBarrier,
                     ref StageFlags flags,
                     ref int count,
-                    List<BarrierWithStageFlags<T>> list) where T : unmanaged
+                    List<BarrierWithStageFlags<T, T2>> list) where T : unmanaged
                 {
                     int firstMatch = -1;
                     int end = list.Count;
 
                     for (int i = 0; i < list.Count; i++)
                     {
-                        BarrierWithStageFlags<T> barrier = list[i];
+                        BarrierWithStageFlags<T, T2> barrier = list[i];
 
                         if (!hasBarrier)
                         {
@@ -162,21 +288,38 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
-                if (insideRenderPass)
+                if (inRenderPass && _imageBarriers.Count > 0)
                 {
                     // Image barriers queued in the batch are meant to be globally scoped,
                     // but inside a render pass they're scoped to just the range of the render pass.
 
                     // On MoltenVK, we just break the rules and always use image barrier.
                     // On desktop GPUs, all barriers are globally scoped, so we just replace it with a generic memory barrier.
-                    // TODO: On certain GPUs, we need to split render pass so the barrier scope is global. When this is done,
-                    //       notify the resource that it should add a barrier as soon as a render pass ends to avoid this in future.
+                    // Generally, we want to avoid this from happening in the future, so flag the texture to immediately
+                    // emit a barrier whenever the current render pass is bound again.
 
-                    if (!_gd.IsMoltenVk)
+                    foreach (BarrierWithStageFlags<ImageMemoryBarrier, TextureStorage> barrier in _imageBarriers)
                     {
+                        rpHolder.AddForcedFence(barrier.Resource, barrier.Flags.Dest);
+                    }
+
+                    if (_gd.IsTBDR)
+                    {
+                        if (!_gd.IsMoltenVk)
+                        {
+                            // TBDR GPUs are sensitive to barriers, so we need to end the pass to ensure the data is available.
+                            // Metal already has hazard tracking so MVK doesn't need this.
+                            endRenderPass();
+                            inRenderPass = false;
+                        }
+                    }
+                    else
+                    {
+                        // Generic pipeline memory barriers will work for desktop GPUs.
+                        // They do require a few more access flags on the subpass dependency, though.
                         foreach (var barrier in _imageBarriers)
                         {
-                            _memoryBarriers.Add(new BarrierWithStageFlags<MemoryBarrier>(
+                            _memoryBarriers.Add(new BarrierWithStageFlags<MemoryBarrier, int>(
                                 barrier.Flags,
                                 new MemoryBarrier()
                                 {
@@ -190,6 +333,21 @@ namespace Ryujinx.Graphics.Vulkan
                     }
                 }
 
+                if (inRenderPass && _memoryBarriers.Count > 0 && _gd.IsTBDR)
+                {
+                    PipelineStageFlags allFlags = PipelineStageFlags.None;
+
+                    foreach (var barrier in _memoryBarriers)
+                    {
+                        allFlags |= barrier.Flags.Dest;
+                    }
+
+                    if (!_gd.SupportsRenderPassBarrier(allFlags))
+                    {
+                        endRenderPass();
+                    }
+                }
+
                 AddBarriers(_memoryBarrierBatch.AsSpan(), ref _queuedBarrierCount, ref hasBarrier, ref flags, ref memoryCount, _memoryBarriers);
                 AddBarriers(_bufferBarrierBatch.AsSpan(), ref _queuedBarrierCount, ref hasBarrier, ref flags, ref bufferCount, _bufferBarriers);
                 AddBarriers(_imageBarrierBatch.AsSpan(), ref _queuedBarrierCount, ref hasBarrier, ref flags, ref imageCount, _imageBarriers);
@@ -198,14 +356,14 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     PipelineStageFlags srcStageFlags = flags.Source;
 
-                    if (insideRenderPass)
+                    if (inRenderPass)
                     {
                         // Inside a render pass, barrier stages can only be from rasterization.
                         srcStageFlags &= ~PipelineStageFlags.ComputeShaderBit;
                     }
 
                     _gd.Api.CmdPipelineBarrier(
-                        cb,
+                        cbs.CommandBuffer,
                         srcStageFlags,
                         flags.Dest,
                         0,
@@ -216,6 +374,41 @@ namespace Ryujinx.Graphics.Vulkan
                         (uint)imageCount,
                         _imageBarrierBatch.Pointer);
                 }
+            }
+        }
+
+        private void QueueIncoherentBarrier(IncoherentBarrierType type)
+        {
+            if (type > _queuedIncoherentBarrier)
+            {
+                _queuedIncoherentBarrier = type;
+            }
+        }
+
+        public void QueueTextureBarrier()
+        {
+            QueueIncoherentBarrier(IncoherentBarrierType.Texture);
+        }
+
+        public void QueueMemoryBarrier()
+        {
+            QueueIncoherentBarrier(IncoherentBarrierType.All);
+        }
+
+        public void QueueCommandBufferBarrier()
+        {
+            QueueIncoherentBarrier(IncoherentBarrierType.CommandBuffer);
+        }
+
+        public void EnableTfbBarriers(bool enable)
+        {
+            if (enable)
+            {
+                _extraStages |= PipelineStageFlags.TransformFeedbackBitExt;
+            }
+            else
+            {
+                _extraStages &= ~PipelineStageFlags.TransformFeedbackBitExt;
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
@@ -59,14 +59,14 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             var scalingResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 2)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 1)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             var sharpeningResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 2)
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 3)
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 4)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 1)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             _sampler = _renderer.CreateSampler(SamplerCreateInfo.Create(MinFilter.Linear, MagFilter.Linear));
 

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             var resourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 2)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 1)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             _samplerLinear = _renderer.CreateSampler(SamplerCreateInfo.Create(MinFilter.Linear, MagFilter.Linear));
 

--- a/src/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
@@ -81,20 +81,20 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             var edgeResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 2)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 1)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             var blendResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 2)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 1)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 3)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 4)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             var neighbourResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 2)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 1)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 3)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             _samplerLinear = _renderer.CreateSampler(SamplerCreateInfo.Create(MinFilter.Linear, MagFilter.Linear));
 

--- a/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -289,6 +289,19 @@ namespace Ryujinx.Graphics.Vulkan
             gd.Barriers.Flush(cbs, false, null, null);
         }
 
+        public void AddStoreOpUsage()
+        {
+            if (_colors != null)
+            {
+                foreach (var color in _colors)
+                {
+                    color.Storage?.AddStoreOpUsage(false);
+                }
+            }
+
+            _depthStencil?.Storage?.AddStoreOpUsage(true);
+        }
+
         public (RenderPassHolder rpHolder, Auto<DisposableFramebuffer> framebuffer) GetPassAndFramebuffer(
             VulkanRenderer gd,
             Device device,

--- a/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -286,10 +286,10 @@ namespace Ryujinx.Graphics.Vulkan
 
             _depthStencil?.Storage?.QueueLoadOpBarrier(cbs, true);
 
-            gd.Barriers.Flush(cbs.CommandBuffer, false, null);
+            gd.Barriers.Flush(cbs, false, null, null);
         }
 
-        public (Auto<DisposableRenderPass> renderPass, Auto<DisposableFramebuffer> framebuffer) GetPassAndFramebuffer(
+        public (RenderPassHolder rpHolder, Auto<DisposableFramebuffer> framebuffer) GetPassAndFramebuffer(
             VulkanRenderer gd,
             Device device,
             CommandBufferScoped cbs)

--- a/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -115,7 +115,7 @@ namespace Ryujinx.Graphics.Vulkan
             var strideChangeResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 0)
                 .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 1)
-                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2).Build();
+                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2, true).Build();
 
             _programStrideChange = gd.CreateProgramWithMinimalLayout(new[]
             {
@@ -125,7 +125,7 @@ namespace Ryujinx.Graphics.Vulkan
             var colorCopyResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 0)
                 .Add(ResourceStages.Compute, ResourceType.TextureAndSampler, 0)
-                .Add(ResourceStages.Compute, ResourceType.Image, 0).Build();
+                .Add(ResourceStages.Compute, ResourceType.Image, 0, true).Build();
 
             _programColorCopyShortening = gd.CreateProgramWithMinimalLayout(new[]
             {
@@ -155,7 +155,7 @@ namespace Ryujinx.Graphics.Vulkan
             var convertD32S8ToD24S8ResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 0)
                 .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 1)
-                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2).Build();
+                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2, true).Build();
 
             _programConvertD32S8ToD24S8 = gd.CreateProgramWithMinimalLayout(new[]
             {
@@ -165,7 +165,7 @@ namespace Ryujinx.Graphics.Vulkan
             var convertIndexBufferResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 0)
                 .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 1)
-                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2).Build();
+                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2, true).Build();
 
             _programConvertIndexBuffer = gd.CreateProgramWithMinimalLayout(new[]
             {
@@ -175,7 +175,7 @@ namespace Ryujinx.Graphics.Vulkan
             var convertIndirectDataResourceLayout = new ResourceLayoutBuilder()
                 .Add(ResourceStages.Compute, ResourceType.UniformBuffer, 0)
                 .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 1)
-                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2)
+                .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 2, true)
                 .Add(ResourceStages.Compute, ResourceType.StorageBuffer, 3).Build();
 
             _programConvertIndirectData = gd.CreateProgramWithMinimalLayout(new[]

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1639,6 +1639,8 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (RenderPassActive)
             {
+                FramebufferParams.AddStoreOpUsage();
+
                 PauseTransformFeedbackInternal();
                 Gd.Api.CmdEndRenderPass(CommandBuffer);
                 SignalRenderPassEnd();

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -55,6 +55,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         protected FramebufferParams FramebufferParams;
         private Auto<DisposableFramebuffer> _framebuffer;
+        private RenderPassHolder _rpHolder;
         private Auto<DisposableRenderPass> _renderPass;
         private RenderPassHolder _nullRenderPass;
         private int _writtenAttachmentCount;
@@ -135,48 +136,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void Barrier()
         {
-            if (_drawCountSinceBarrier != DrawCount)
-            {
-                _drawCountSinceBarrier = DrawCount;
-
-                // Barriers are not supported inside a render pass on Apple GPUs.
-                // As a workaround, end the render pass.
-                if (Gd.Vendor == Vendor.Apple)
-                {
-                    EndRenderPass();
-                }
-            }
-
-            MemoryBarrier memoryBarrier = new()
-            {
-                SType = StructureType.MemoryBarrier,
-                SrcAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit,
-                DstAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit,
-            };
-
-            PipelineStageFlags pipelineStageFlags = PipelineStageFlags.VertexShaderBit | PipelineStageFlags.FragmentShaderBit;
-
-            if (Gd.Capabilities.SupportsGeometryShader)
-            {
-                pipelineStageFlags |= PipelineStageFlags.GeometryShaderBit;
-            }
-
-            if (Gd.Capabilities.SupportsTessellationShader)
-            {
-                pipelineStageFlags |= PipelineStageFlags.TessellationControlShaderBit | PipelineStageFlags.TessellationEvaluationShaderBit;
-            }
-
-            Gd.Api.CmdPipelineBarrier(
-                CommandBuffer,
-                pipelineStageFlags,
-                pipelineStageFlags,
-                0,
-                1,
-                memoryBarrier,
-                0,
-                null,
-                0,
-                null);
+            Gd.Barriers.QueueMemoryBarrier();
         }
 
         public void ComputeBarrier()
@@ -203,6 +163,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void BeginTransformFeedback(PrimitiveTopology topology)
         {
+            Gd.Barriers.EnableTfbBarriers(true);
             _tfEnabled = true;
         }
 
@@ -249,7 +210,7 @@ namespace Ryujinx.Graphics.Vulkan
                 CreateRenderPass();
             }
 
-            Gd.Barriers.Flush(Cbs.CommandBuffer, RenderPassActive, EndRenderPassDelegate);
+            Gd.Barriers.Flush(Cbs, RenderPassActive, _rpHolder, EndRenderPassDelegate);
 
             BeginRenderPass();
 
@@ -287,7 +248,7 @@ namespace Ryujinx.Graphics.Vulkan
                 CreateRenderPass();
             }
 
-            Gd.Barriers.Flush(Cbs.CommandBuffer, RenderPassActive, EndRenderPassDelegate);
+            Gd.Barriers.Flush(Cbs, RenderPassActive, _rpHolder, EndRenderPassDelegate);
 
             BeginRenderPass();
 
@@ -299,24 +260,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void CommandBufferBarrier()
         {
-            MemoryBarrier memoryBarrier = new()
-            {
-                SType = StructureType.MemoryBarrier,
-                SrcAccessMask = BufferHolder.DefaultAccessFlags,
-                DstAccessMask = AccessFlags.IndirectCommandReadBit,
-            };
-
-            Gd.Api.CmdPipelineBarrier(
-                CommandBuffer,
-                PipelineStageFlags.AllCommandsBit,
-                PipelineStageFlags.DrawIndirectBit,
-                0,
-                1,
-                memoryBarrier,
-                0,
-                null,
-                0,
-                null);
+            Gd.Barriers.QueueCommandBufferBarrier();
         }
 
         public void CopyBuffer(BufferHandle source, BufferHandle destination, int srcOffset, int dstOffset, int size)
@@ -722,6 +666,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void EndTransformFeedback()
         {
+            Gd.Barriers.EnableTfbBarriers(false);
             PauseTransformFeedbackInternal();
             _tfEnabled = false;
         }
@@ -1408,24 +1353,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void TextureBarrier()
         {
-            MemoryBarrier memoryBarrier = new()
-            {
-                SType = StructureType.MemoryBarrier,
-                SrcAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit,
-                DstAccessMask = AccessFlags.MemoryReadBit | AccessFlags.MemoryWriteBit,
-            };
-
-            Gd.Api.CmdPipelineBarrier(
-                CommandBuffer,
-                PipelineStageFlags.FragmentShaderBit,
-                PipelineStageFlags.FragmentShaderBit,
-                0,
-                1,
-                memoryBarrier,
-                0,
-                null,
-                0,
-                null);
+            Gd.Barriers.QueueTextureBarrier();
         }
 
         public void TextureBarrierTiled()
@@ -1532,12 +1460,15 @@ namespace Ryujinx.Graphics.Vulkan
                 // Use the null framebuffer.
                 _nullRenderPass ??= new RenderPassHolder(Gd, Device, new RenderPassCacheKey(), FramebufferParams);
 
+                _rpHolder = _nullRenderPass;
                 _renderPass = _nullRenderPass.GetRenderPass();
                 _framebuffer = _nullRenderPass.GetFramebuffer(Gd, Cbs, FramebufferParams);
             }
             else
             {
-                (_renderPass, _framebuffer) = FramebufferParams.GetPassAndFramebuffer(Gd, Device, Cbs);
+                (_rpHolder, _framebuffer) = FramebufferParams.GetPassAndFramebuffer(Gd, Device, Cbs);
+
+                _renderPass = _rpHolder.GetRenderPass();
             }
         }
 
@@ -1564,7 +1495,7 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            Gd.Barriers.Flush(Cbs.CommandBuffer, RenderPassActive, EndRenderPassDelegate);
+            Gd.Barriers.Flush(Cbs, _program, RenderPassActive, _rpHolder, EndRenderPassDelegate);
 
             _descriptorSetUpdater.UpdateAndBindDescriptorSets(Cbs, PipelineBindPoint.Compute);
         }
@@ -1629,7 +1560,7 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            Gd.Barriers.Flush(Cbs.CommandBuffer, RenderPassActive, EndRenderPassDelegate);
+            Gd.Barriers.Flush(Cbs, _program, RenderPassActive, _rpHolder, EndRenderPassDelegate);
 
             _descriptorSetUpdater.UpdateAndBindDescriptorSets(Cbs, PipelineBindPoint.Graphics);
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -86,8 +86,6 @@ namespace Ryujinx.Graphics.Vulkan
         private bool _tfActive;
 
         private readonly PipelineColorBlendAttachmentState[] _storedBlend;
-
-        private ulong _drawCountSinceBarrier;
         public ulong DrawCount { get; private set; }
         public bool RenderPassActive { get; private set; }
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -9,13 +9,6 @@ namespace Ryujinx.Graphics.Vulkan
 {
     static class PipelineConverter
     {
-        private const AccessFlags SubpassAccessMask =
-            AccessFlags.MemoryReadBit |
-            AccessFlags.MemoryWriteBit |
-            AccessFlags.ShaderReadBit |
-            AccessFlags.ColorAttachmentWriteBit |
-            AccessFlags.DepthStencilAttachmentWriteBit;
-
         public static unsafe DisposableRenderPass ToRenderPass(this ProgramPipelineState state, VulkanRenderer gd, Device device)
         {
             const int MaxAttachments = Constants.MaxRenderTargets + 1;
@@ -108,7 +101,7 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            var subpassDependency = CreateSubpassDependency();
+            var subpassDependency = CreateSubpassDependency(gd);
 
             fixed (AttachmentDescription* pAttachmentDescs = attachmentDescs)
             {
@@ -129,29 +122,33 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public static SubpassDependency CreateSubpassDependency()
+        public static SubpassDependency CreateSubpassDependency(VulkanRenderer gd)
         {
+            var (access, stages) = BarrierBatch.GetSubpassAccessSuperset(gd);
+
             return new SubpassDependency(
                 0,
                 0,
-                PipelineStageFlags.AllGraphicsBit,
-                PipelineStageFlags.AllGraphicsBit,
-                SubpassAccessMask,
-                SubpassAccessMask,
+                stages,
+                stages,
+                access,
+                access,
                 0);
         }
 
-        public unsafe static SubpassDependency2 CreateSubpassDependency2()
+        public unsafe static SubpassDependency2 CreateSubpassDependency2(VulkanRenderer gd)
         {
+            var (access, stages) = BarrierBatch.GetSubpassAccessSuperset(gd);
+
             return new SubpassDependency2(
                 StructureType.SubpassDependency2,
                 null,
                 0,
                 0,
-                PipelineStageFlags.AllGraphicsBit,
-                PipelineStageFlags.AllGraphicsBit,
-                SubpassAccessMask,
-                SubpassAccessMask,
+                stages,
+                stages,
+                access,
+                access,
                 0);
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -257,7 +257,7 @@ namespace Ryujinx.Graphics.Vulkan
                 PreloadCbs = null;
             }
 
-            Gd.Barriers.Flush(Cbs.CommandBuffer, false, null);
+            Gd.Barriers.Flush(Cbs, false, null, null);
             CommandBuffer = (Cbs = Gd.CommandBufferPool.ReturnAndRent(Cbs)).CommandBuffer;
             Gd.RegisterFlush();
 

--- a/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
@@ -192,6 +192,11 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        public bool ContainsAttachment(TextureStorage storage)
+        {
+            return _textures.Any(view => view.Storage == storage);
+        }
+
         public void Dispose()
         {
             // Dispose all framebuffers.

--- a/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
@@ -1,5 +1,7 @@
 using Silk.NET.Vulkan;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -29,10 +31,13 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        private readonly record struct ForcedFence(TextureStorage Texture, PipelineStageFlags StageFlags);
+
         private readonly TextureView[] _textures;
         private readonly Auto<DisposableRenderPass> _renderPass;
         private readonly HashTableSlim<FramebufferCacheKey, Auto<DisposableFramebuffer>> _framebuffers;
         private readonly RenderPassCacheKey _key;
+        private readonly List<ForcedFence> _forcedFences;
 
         public unsafe RenderPassHolder(VulkanRenderer gd, Device device, RenderPassCacheKey key, FramebufferParams fb)
         {
@@ -105,7 +110,7 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            var subpassDependency = PipelineConverter.CreateSubpassDependency();
+            var subpassDependency = PipelineConverter.CreateSubpassDependency(gd);
 
             fixed (AttachmentDescription* pAttachmentDescs = attachmentDescs)
             {
@@ -138,6 +143,8 @@ namespace Ryujinx.Graphics.Vulkan
 
             _textures = textures;
             _key = key;
+
+            _forcedFences = new List<ForcedFence>();
         }
 
         public Auto<DisposableFramebuffer> GetFramebuffer(VulkanRenderer gd, CommandBufferScoped cbs, FramebufferParams fb)
@@ -157,6 +164,32 @@ namespace Ryujinx.Graphics.Vulkan
         public Auto<DisposableRenderPass> GetRenderPass()
         {
             return _renderPass;
+        }
+
+        public void AddForcedFence(TextureStorage storage, PipelineStageFlags stageFlags)
+        {
+            if (!_forcedFences.Any(fence => fence.Texture == storage))
+            {
+                _forcedFences.Add(new ForcedFence(storage, stageFlags));
+            }
+        }
+
+        public void InsertForcedFences(CommandBufferScoped cbs)
+        {
+            if (_forcedFences.Count > 0)
+            {
+                _forcedFences.RemoveAll((entry) =>
+                {
+                    if (entry.Texture.Disposed)
+                    {
+                        return true;
+                    }
+
+                    entry.Texture.QueueWriteToReadBarrier(cbs, AccessFlags.ShaderReadBit, entry.StageFlags);
+
+                    return false;
+                });
+            }
         }
 
         public void Dispose()

--- a/src/Ryujinx.Graphics.Vulkan/ResourceLayoutBuilder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ResourceLayoutBuilder.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public ResourceLayoutBuilder Add(ResourceStages stages, ResourceType type, int binding)
+        public ResourceLayoutBuilder Add(ResourceStages stages, ResourceType type, int binding, bool write = false)
         {
             int setIndex = type switch
             {
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Vulkan
             };
 
             _resourceDescriptors[setIndex].Add(new ResourceDescriptor(binding, 1, type, stages));
-            _resourceUsages[setIndex].Add(new ResourceUsage(binding, 1, type, stages));
+            _resourceUsages[setIndex].Add(new ResourceUsage(binding, 1, type, stages, write));
 
             return this;
         }

--- a/src/Ryujinx.Graphics.Vulkan/TextureCopy.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureCopy.cs
@@ -407,7 +407,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ImageLayout.General,
                 ImageLayout.General);
 
-            var subpassDependency = PipelineConverter.CreateSubpassDependency2();
+            var subpassDependency = PipelineConverter.CreateSubpassDependency2(gd);
 
             fixed (AttachmentDescription2* pAttachmentDescs = attachmentDescs)
             {

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -38,6 +38,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public TextureCreateInfo Info => _info;
 
+        public bool Disposed { get; private set; }
+
         private readonly Image _image;
         private readonly Auto<DisposableImage> _imageAuto;
         private readonly Auto<MemoryAllocation> _allocationAuto;
@@ -458,7 +460,7 @@ namespace Ryujinx.Graphics.Vulkan
                     _info.GetLayers(),
                     _info.Levels);
 
-                _gd.Barriers.QueueBarrier(barrier, srcStageFlags, dstStageFlags);
+                _gd.Barriers.QueueBarrier(barrier, this, srcStageFlags, dstStageFlags);
 
                 _lastReadStage = PipelineStageFlags.None;
                 _lastReadAccess = AccessFlags.None;
@@ -491,7 +493,7 @@ namespace Ryujinx.Graphics.Vulkan
                     _info.GetLayers(),
                     _info.Levels);
 
-                _gd.Barriers.QueueBarrier(barrier, _lastModificationStage, dstStageFlags);
+                _gd.Barriers.QueueBarrier(barrier, this, _lastModificationStage, dstStageFlags);
 
                 _lastModificationAccess = AccessFlags.None;
             }
@@ -514,6 +516,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Dispose()
         {
+            Disposed = true;
+
             if (_aliasedStorages != null)
             {
                 foreach (var storage in _aliasedStorages.Values)

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -435,6 +435,17 @@ namespace Ryujinx.Graphics.Vulkan
             return FormatCapabilities.IsD24S8(Info.Format) && VkFormat == VkFormat.D32SfloatS8Uint;
         }
 
+        public void AddStoreOpUsage(bool depthStencil)
+        {
+            _lastModificationStage = depthStencil ?
+                PipelineStageFlags.LateFragmentTestsBit :
+                PipelineStageFlags.ColorAttachmentOutputBit;
+
+            _lastModificationAccess = depthStencil ?
+                AccessFlags.DepthStencilAttachmentWriteBit :
+                AccessFlags.ColorAttachmentWriteBit;
+        }
+
         public void QueueLoadOpBarrier(CommandBufferScoped cbs, bool depthStencil)
         {
             PipelineStageFlags srcStageFlags = _lastReadStage | _lastModificationStage;

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -993,7 +993,7 @@ namespace Ryujinx.Graphics.Vulkan
             throw new NotImplementedException();
         }
 
-        public (Auto<DisposableRenderPass> renderPass, Auto<DisposableFramebuffer> framebuffer) GetPassAndFramebuffer(
+        public (RenderPassHolder rpHolder, Auto<DisposableFramebuffer> framebuffer) GetPassAndFramebuffer(
             VulkanRenderer gd,
             Device device,
             CommandBufferScoped cbs,
@@ -1006,7 +1006,7 @@ namespace Ryujinx.Graphics.Vulkan
                 rpHolder = new RenderPassHolder(gd, device, key, fb);
             }
 
-            return (rpHolder.GetRenderPass(), rpHolder.GetFramebuffer(gd, cbs, fb));
+            return (rpHolder, rpHolder.GetFramebuffer(gd, cbs, fb));
         }
 
         public void AddRenderPass(RenderPassCacheKey key, RenderPassHolder renderPass)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -939,6 +939,11 @@ namespace Ryujinx.Graphics.Vulkan
             ScreenCaptured?.Invoke(this, bitmap);
         }
 
+        public bool SupportsRenderPassBarrier(PipelineStageFlags flags)
+        {
+            return !IsMoltenVk;
+        }
+
         public unsafe void Dispose()
         {
             if (!_initialized)

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -941,7 +941,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public bool SupportsRenderPassBarrier(PipelineStageFlags flags)
         {
-            return !(IsMoltenVk || Vendor == Vendor.Qualcomm);
+            return !(IsMoltenVk || IsQualcommProprietary);
         }
 
         public unsafe void Dispose()

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -941,7 +941,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public bool SupportsRenderPassBarrier(PipelineStageFlags flags)
         {
-            return !IsMoltenVk;
+            return !IsMoltenVk || Vendor == Vendor.Qualcomm;
         }
 
         public unsafe void Dispose()

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -941,7 +941,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public bool SupportsRenderPassBarrier(PipelineStageFlags flags)
         {
-            return !IsMoltenVk || Vendor == Vendor.Qualcomm;
+            return !(IsMoltenVk || Vendor == Vendor.Qualcomm);
         }
 
         public unsafe void Dispose()


### PR DESCRIPTION
This PR mostly aims to avoid visual bugs that can occur on platforms more susceptible to barrier issues, such as Adreno, but it will also eliminate unnecessary barriers that are already covered by our resource usage tracking.

The main observation is that there are two types of graphics barriers that we need to handle, and that they should be handled separately:

### Render pass <-> shader read barriers
- The guest handles these by writing the `TextureBarrier`/`TextureBarrierTiled` register in 3d class state. We discovered over time that these aren't reliable enough to make sure attachments are fully written before they are sampled or written again on basically any GPU past NVIDIA's pascal architecture, or from other vendors.
  - This type of access is **coherent**. When a game accesses a texture after it's sampled, there is _no reason to believe it wouldn't want to wait for it if necessary_. It should be fully handled by our bindings system and the guest's signals on where barriers should be are too unreliable to trust.  Maxwell has a ton of implicit barriers for certain operations that let the drivers get away with not requesting explicit barriers, so it's a lot better for us to handle entirely.
  - This is already mostly handled, but a few cases are causing bad barriers to emit right now, or barriers to go missing.

### Storage writes <-> any access
- Storage writes include storage buffers, image storage, transform feedback, etc. These are writes that come from a specific stage, that typically have more explicit barriers in guest APIs such as OpenGL due to reorderable invocations and memory caches that need flushed.
  - This type of access is **incoherent**. The accesses happen without guaranteed order and without waits. If the guest wants to wait for results, then it has to explicitly place a `Barrier` between draws or use atomic access.
 
### Deferred Guest Barriers

Firstly, the change passes down resource writes in the shader info, so that it can build a quick flag set of stages that have an incoherent write per program on the guest that can be checked easily per draw.

Secondly, guest barrier calls are now handled by BarrierBatch. When the guest requests a barrier, it is requested in the BarrierBatch. Every draw, internal flags are set when an incoherent stage flag is set on the active program. This becomes the union of all incoherent stage flags since the last barrier was emitted. If both a barrier is queued and these flags are set, a barrier is emitted with the stricted barrier type that has been queued since the last barrier. When a barrier is emitted, the stage flags are reset to those of the current program.

The end result is that barriers of each type are emitted on both `read -> barrier -> write` (current program has flags, barrier queued before) and `write -> barrier -> read` (previous program has flags, barrier queued after) situations. `Write -> barrier -> write` case is also handled as a side effect.

It's worth noting that operations like copies and blits always emit barriers right now, so they aren't considered when it comes to respecting guest barriers in this PR.

The guest barrier calls are interpreted as follows:

- TextureBarrier/TextureBarrierTiled: As explained above, this barrier type is typically used between an attachment write and a sample. However, the driver omits this barrier when it thinks the hardware doesn't need one, which is incorrect for newer NVIDIA GPUs and most other GPUs. TBDR GPUs tend to run vertex, fragment and tile load/store out of sync, so it's a lot more susceptible to these issues. As a result, it's not trustworthy at all.
  - While it hasn't been verified, one possible use for this barrier is for Image Storage. This technically modifies a texture, I haven't verified that this barrier also works for that, but because of the possibility it is not completely ignored by the barrier batch and will be triggered by image storage.
- Barrier: This barrier type is used very often for compute (perhaps unnecessarily due to inefficient driver, to ensure ordering for storage buffer accesses and between tfb write and read. I've made this barrier type cover every single guest managed buffer access read/write type, and the image load/store that TextureBarrier covers.
- CommandBufferBarrier: This barrier is emitted when the guest writes the `SetReference` register, typically when indicating that indirect data has been written to a command buffer. Deko3D calls this barrier type "full", so it covers all accesses that `Barrier` does, plus indirect draw. It also splits the render pass on all platforms right now.

The end result is that guest barriers are only respected around _incoherent_ accesses, such as buffer or image storage, so the majority of redundant barriers are ignored, and attachment barriers are entirely left up to our usage tracking.

### Attachment barrier changes

A few issues were identified and fixed with attachment load/store barriers:

- Barriers for texture sample after an attachment load/store could easily happen in the middle of a render pass. We can't emit image resource barriers in a render pass, so they were converted to pipeline barriers. These aren't good for actually representing the barrier, so were likely to fail on more sensitive vulkan drivers.
  - On TBDR GPUs, these barriers now stay as image barriers, and the render pass is forcibly ended.
  - This has potential to be slow, so the active render pass actually remembers textures that cause this to happen, and pre-emptively emits barriers for them right before it starts.
- Attachment feedback loops can eat barriers for a render pass before the render pass completes. This means that the draws after the feedback loop begins could disappear or be incomplete if sampled afterwards.
  - This was changed so that the feedback loop does emit the barrier, but _ending_ the render pass re-adds the access flags and stage to the attachments so they aren't lost.
  - Feedback loops need a lot more work in the future, since RDNA3 GPUs and potentially other future GPUs could react poorly to using the general image layout for them.

### Mid-pass barriers

Some drivers are not ready for modern GPU workloads and break or have lackluster mid-pass barriers. `SupportsRenderPassBarrier` flags these cases and forces the render pass to end if the driver might have some kind of problem with it. Deferring barriers and preventing mid-pass image barriers reduces the frequency of this happening.

### Adreno

On the Adreno proprietary driver, the following issues are expected to be fixed or worked around:
- Mid-renderpass barriers cause random memory corruption, seemingly both within the pass and random memory outside it (like the Ryujinx window itself). This is solved by splitting the render pass whenever we need to emit a mid-renderpass barrier. I really don't know how a driver could have a bug this fundamental. I suppose money sucking gacha trash won't ever use storage ops that need barriers.
  - Most of the work on this PR is focused around preventing these barriers from being emitted when unnecessary. That includes guest initiated barriers (which are now deferred) and image barriers.
- Render pass load/store into texture sampling can no longer emit a barrier in the middle of a render pass on TBDR GPUs. This could possibly cause the above issue, but could also cause textures to be read before they are finished being written, if the image barrier were to not do anything.
  - Now, these split the render pass, but also register themselves onto the render pass as resources that it might use. This allows us to wait for those barriers before the pass, avoiding any issues and also any render pass splits.
  - Desktop GPUs still use pipeline barriers when this happens the first time, but also do the render pass registration to stop it from happening multiple times.
- Attachment feedback loop issue as described above was more likely to cause issues on adreno.

### Testing
This PR changes how barriers work at a fundamental level. We no longer rely on guest barriers for attachment barriers _at all_, and we only emit explicit barriers when _we_ think they should be emitted. This means that if there are any errors in our barrier logic, it'll surface a lot easier. It'll be best to check as many games as possible with different engines to see if any of them react poorly to this change, on many different types of GPU. 