### PR TITLE
Use draw clear on Adreno, instead of vkCmdClearAttachments

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/BackgroundResources.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BackgroundResources.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Vulkan
                         queue,
                         queueLock,
                         _gd.QueueFamilyIndex,
-                        _gd.IsConcurrentFenceWaitUnsupported,
+                        _gd.IsQualcommProprietary,
                         isLight: true);
                 }
             }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1021,7 +1021,7 @@ namespace Ryujinx.Graphics.Vulkan
             _newState.RasterizerDiscardEnable = discard;
             SignalStateChange();
 
-            if (!discard && Gd.Vendor == Vendor.Qualcomm)
+            if (!discard && Gd.IsQualcommProprietary)
             {
                 // On Adreno, enabling rasterizer discard somehow corrupts the viewport state.
                 // Force it to be updated on next use to work around this bug.

--- a/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -47,10 +47,11 @@ namespace Ryujinx.Graphics.Vulkan
                 return;
             }
 
-            if (componentMask != 0xf)
+            if (componentMask != 0xf || Gd.IsQualcommProprietary)
             {
                 // We can't use CmdClearAttachments if not writing all components,
                 // because on Vulkan, the pipeline state does not affect clears.
+                // On proprietary Adreno drivers, CmdClearAttachments appears to execute out of order, so it's better to not use it at all.
                 var dstTexture = FramebufferParams.GetColorView(index);
                 if (dstTexture == null)
                 {
@@ -87,10 +88,11 @@ namespace Ryujinx.Graphics.Vulkan
                 return;
             }
 
-            if (stencilMask != 0 && stencilMask != 0xff)
+            if ((stencilMask != 0 && stencilMask != 0xff) || Gd.IsQualcommProprietary)
             {
                 // We can't use CmdClearAttachments if not clearing all (mask is all ones, 0xFF) or none (mask is 0) of the stencil bits,
                 // because on Vulkan, the pipeline state does not affect clears.
+                // On proprietary Adreno drivers, CmdClearAttachments appears to execute out of order, so it's better to not use it at all.
                 var dstTexture = FramebufferParams.GetDepthStencilView();
                 if (dstTexture == null)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -133,7 +133,7 @@ namespace Ryujinx.Graphics.Vulkan
             Templates = BuildTemplates(usePushDescriptors);
 
             // Updating buffer texture bindings using template updates crashes the Adreno driver on Windows.
-            UpdateTexturesWithoutTemplate = gd.Vendor == Vendor.Qualcomm && usesBufferTextures;
+            UpdateTexturesWithoutTemplate = gd.IsQualcommProprietary && usesBufferTextures;
 
             _compileTask = Task.CompletedTask;
             _firstBackgroundUse = false;

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -87,10 +87,10 @@ namespace Ryujinx.Graphics.Vulkan
         internal bool IsAmdGcn { get; private set; }
         internal bool IsNvidiaPreTuring { get; private set; }
         internal bool IsIntelArc { get; private set; }
+        internal bool IsQualcommProprietary { get; private set; }
         internal bool IsMoltenVk { get; private set; }
         internal bool IsTBDR { get; private set; }
         internal bool IsSharedMemory { get; private set; }
-        internal bool IsConcurrentFenceWaitUnsupported { get; private set; }
 
         public string GpuVendor { get; private set; }
         public string GpuDriver { get; private set; }
@@ -325,8 +325,6 @@ namespace Ryujinx.Graphics.Vulkan
                 Vendor == Vendor.Broadcom ||
                 Vendor == Vendor.ImgTec;
 
-            IsConcurrentFenceWaitUnsupported = Vendor == Vendor.Qualcomm;
-
             GpuVendor = VendorUtils.GetNameFromId(properties.VendorID);
             GpuDriver = hasDriverProperties && !OperatingSystem.IsMacOS() ?
                 VendorUtils.GetFriendlyDriverName(driverProperties.DriverID) : GpuVendor; // Fallback to vendor name if driver is unavailable or on MacOS where vendor is preferred.
@@ -357,6 +355,8 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 IsIntelArc = GpuRenderer.StartsWith("Intel(R) Arc(TM)");
             }
+
+            IsQualcommProprietary = hasDriverProperties && driverProperties.DriverID == DriverId.QualcommProprietary;
 
             ulong minResourceAlignment = Math.Max(
                 Math.Max(
@@ -415,7 +415,7 @@ namespace Ryujinx.Graphics.Vulkan
             Api.TryGetDeviceExtension(_instance.Instance, _device, out ExtExternalMemoryHost hostMemoryApi);
             HostMemoryAllocator = new HostMemoryAllocator(MemoryAllocator, Api, hostMemoryApi, _device);
 
-            CommandBufferPool = new CommandBufferPool(Api, _device, Queue, QueueLock, queueFamilyIndex, IsConcurrentFenceWaitUnsupported);
+            CommandBufferPool = new CommandBufferPool(Api, _device, Queue, QueueLock, queueFamilyIndex, IsQualcommProprietary);
 
             PipelineLayoutCache = new PipelineLayoutCache();
 
@@ -692,7 +692,7 @@ namespace Ryujinx.Graphics.Vulkan
                 GpuVendor,
                 memoryType: memoryType,
                 hasFrontFacingBug: IsIntelWindows,
-                hasVectorIndexingBug: Vendor == Vendor.Qualcomm,
+                hasVectorIndexingBug: IsQualcommProprietary,
                 needsFragmentOutputSpecialization: IsMoltenVk,
                 reduceShaderPrecision: IsMoltenVk,
                 supportsAstcCompression: features2.Features.TextureCompressionAstcLdr && supportsAstcFormats,

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -346,7 +346,7 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     IsNvidiaPreTuring = gpuNumber < 2000;
                 }
-                else if (GpuDriver.Contains("TITAN") && !GpuDriver.Contains("RTX"))
+                else if (GpuRenderer.Contains("TITAN") && !GpuRenderer.Contains("RTX"))
                 {
                     IsNvidiaPreTuring = true;
                 }


### PR DESCRIPTION
`vkCmdClearAttachments` does not work properly on the proprietary Adreno driver, and appears to race with subsequent draw commands, which causes the texture to be cleared too late and effectively clears what is supposed to be rendered. As a workaround, this change will now use clears with draw, which is normally used on scenarios not supported by `vkCmdClearAttachments`, but for Adreno it will be used for all clears (at least until we use render pass clears).

This additionally adds a new `IsQualcommProprietary ` and makes use of it in all places where we previously checked if the vendor is Qualcomm. This avoids triggering those workarounds on the Turnip driver, which does not suffer from those issues and should not be penalized for the proprietary driver bugs.

Also fixes a bug on GTX TITAN GPUs recognition.

On Adreno GPUs, fixes waterfall not rendering properly or at all from some angles in Cascade Kingdom on Super Mario Odyssey:
Before:
![Captura de tela 2024-07-10 002754](https://github.com/Ryujinx/Ryujinx/assets/5624669/70521fc0-af52-4e0a-b9f7-bc2941b98513)
After:
![Captura de tela 2024-07-10 013136](https://github.com/Ryujinx/Ryujinx/assets/5624669/f09f6cd4-a72b-4e58-bfea-d7dac61d98ac)
(Also fixes shadow flickering, not visible in those screenshots).
Allows Astral Chain to go in-game (previously it would just freeze without ever displaying anything):
![Captura de tela 2024-07-10 013519](https://github.com/Ryujinx/Ryujinx/assets/5624669/430869bf-a2c7-43fb-b0ad-53362979db12)
(Still has many issues).

All those were tested in combination with #7012 to eliminate other glitches.