### PR TITLE
Upgrade to nunit 4 1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,8 +25,8 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageVersion Include="NUnit" Version="4.1.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />

--- a/src/Ryujinx.Tests.Memory/Ryujinx.Tests.Memory.csproj
+++ b/src/Ryujinx.Tests.Memory/Ryujinx.Tests.Memory.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <!--
-    NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace, To be transparent with the test code, we alias it to Assert.
+    NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace. To be transparent with the test code, we alias it to Assert.
     https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
     https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertions.html
   -->

--- a/src/Ryujinx.Tests.Memory/Ryujinx.Tests.Memory.csproj
+++ b/src/Ryujinx.Tests.Memory/Ryujinx.Tests.Memory.csproj
@@ -11,6 +11,15 @@
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
+  <!--
+    NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace, To be transparent with the test code, we alias it to Assert.
+    https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
+    https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertions.html
+  -->
+  <ItemGroup>
+    <Using Include="NUnit.Framework.Legacy.ClassicAssert" Alias="Assert" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj" />
   </ItemGroup>

--- a/src/Ryujinx.Tests.Memory/TrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/TrackingTests.cs
@@ -191,7 +191,7 @@ namespace Ryujinx.Tests.Memory
             Assert.False(alignedAfterTriggers);
         }
 
-        [Test, Explicit, Timeout(1000)]
+        [Test, Explicit, CancelAfter(1000)]
         public void Multithreading()
         {
             // Multithreading sanity test

--- a/src/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/src/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <!--
-    NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace, To be transparent with the test code, we alias it to Assert.
+    NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace. To be transparent with the test code, we alias it to Assert.
     https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
     https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertions.html
   -->

--- a/src/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/src/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -23,6 +23,15 @@
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
+  <!--
+    NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace, To be transparent with the test code, we alias it to Assert.
+    https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
+    https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertions.html
+  -->
+  <ItemGroup>
+    <Using Include="NUnit.Framework.Legacy.ClassicAssert" Alias="Assert" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
     <ProjectReference Include="..\Ryujinx.Cpu\Ryujinx.Cpu.csproj" />


### PR DESCRIPTION
Upgrade to the latest NUnit 4

NUnit 4+ moved the original/non-constraint Asserts into ClassicAssert namespace. To be transparent with the test code, we alias it to Assert.

Changes:
1. Set Assert as alias for ClassicAssert
2. TimeoutAttribute is obsolete. NET No longer supports aborting threads as it is not a safe thing to do. Update to use CancelAfterAttribute instead

See more details:
https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertions.html