### PR TITLE
Add missing Buffer attribute on NGC Check method

### DIFF
--- a/src/Ryujinx.Horizon/Ngc/Ipc/Service.cs
+++ b/src/Ryujinx.Horizon/Ngc/Ipc/Service.cs
@@ -26,7 +26,11 @@ namespace Ryujinx.Horizon.Ngc.Ipc
         }
 
         [CmifCommand(1)]
-        public Result Check(out uint checkMask, ReadOnlySpan<byte> text, uint regionMask, ProfanityFilterOption option)
+        public Result Check(
+            out uint checkMask,
+            [Buffer(HipcBufferFlags.In | HipcBufferFlags.MapAlias)] ReadOnlySpan<byte> text,
+            uint regionMask,
+            ProfanityFilterOption option)
         {
             lock (_profanityFilter)
             {


### PR DESCRIPTION
Somehow I forgot to add the buffer attribute on the text span for this method. This PR adds the missing attribute.
Fixes a crash on Teenage Mutant Ninja Turtles: Splintered Fate and other games that does profanity filter checks and targets firmware 16.0.0+.