### PR TITLE
Infra: Update Microsoft.IdentityModel.JsonWebTokens

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="LibHac" Version="0.19.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="LibHac" Version="0.19.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />

--- a/src/Ryujinx/UI/ViewModels/UserProfileViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/UserProfileViewModel.cs
@@ -1,7 +1,7 @@
-using Microsoft.IdentityModel.Tokens;
 using Ryujinx.Ava.UI.Models;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Ryujinx.Ava.UI.ViewModels
 {
@@ -11,7 +11,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             Profiles = new ObservableCollection<BaseModel>();
             LostProfiles = new ObservableCollection<UserProfile>();
-            IsEmpty = LostProfiles.IsNullOrEmpty();
+            IsEmpty = !LostProfiles.Any();
         }
 
         public ObservableCollection<BaseModel> Profiles { get; set; }


### PR DESCRIPTION
Supersedes #7034.

Ava had a weird dependency on a random static helper method from an implicitly installed package from `Microsoft.IdentityModel.JsonWebTokens` which was removed in 8.0.0, causing the dependabot PR to fail.