### PR TITLE
Unlink server sessions from multi-wait when service stops processing requests

### DIFF
--- a/src/Ryujinx.Horizon/Sdk/OsTypes/Impl/MultiWaitImpl.cs
+++ b/src/Ryujinx.Horizon/Sdk/OsTypes/Impl/MultiWaitImpl.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.Horizon.Sdk.OsTypes.Impl
 
         public long CurrentTime { get; private set; }
 
+        public IEnumerable<MultiWaitHolderBase> MultiWaits => _multiWaits;
+
         public MultiWaitImpl()
         {
             _multiWaits = new List<MultiWaitHolderBase>();

--- a/src/Ryujinx.Horizon/Sdk/OsTypes/MultiWait.cs
+++ b/src/Ryujinx.Horizon/Sdk/OsTypes/MultiWait.cs
@@ -1,10 +1,13 @@
 using Ryujinx.Horizon.Sdk.OsTypes.Impl;
+using System.Collections.Generic;
 
 namespace Ryujinx.Horizon.Sdk.OsTypes
 {
     class MultiWait
     {
         private readonly MultiWaitImpl _impl;
+
+        public IEnumerable<MultiWaitHolderBase> MultiWaits => _impl.MultiWaits;
 
         public MultiWait()
         {

--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/ServerManagerBase.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/ServerManagerBase.cs
@@ -3,6 +3,7 @@ using Ryujinx.Horizon.Sdk.OsTypes;
 using Ryujinx.Horizon.Sdk.Sf.Cmif;
 using Ryujinx.Horizon.Sdk.Sm;
 using System;
+using System.Linq;
 
 namespace Ryujinx.Horizon.Sdk.Sf.Hipc
 {
@@ -115,6 +116,18 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
         {
             while (WaitAndProcessRequestsImpl())
             {
+            }
+
+            // Unlink pending sessions, dispose expects them to be already unlinked.
+
+            ServerSession[] serverSessions = Enumerable.OfType<ServerSession>(_multiWait.MultiWaits).ToArray();
+
+            foreach (ServerSession serverSession in serverSessions)
+            {
+                if (serverSession.IsLinked)
+                {
+                    serverSession.UnlinkFromMultiWaitHolder();
+                }
             }
         }
 


### PR DESCRIPTION
Some code paths do not unlink the server session object from the multi-wait list (such as the one that catches a `ThreadTerminatedException`). This ensures they are unlinked before the dispose method for the `ServerManager` is called, since dispose expects them to be unlinked.

This fixes an assert that may happen when emulation is stopped, but that only affects debug builds, release builds do not have this issue and thus should not be affected.