### PR TITLE
Fix Skia saving screenshot with transparent background and incorrect origin

### DIFF
--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -367,29 +367,22 @@ namespace Ryujinx.Ava
                         }
 
                         var colorType = e.IsBgra ? SKColorType.Bgra8888 : SKColorType.Rgba8888;
-                        using var bitmap = new SKBitmap(new SKImageInfo(e.Width, e.Height, colorType, SKAlphaType.Premul));
+                        using SKBitmap bitmap = new SKBitmap(new SKImageInfo(e.Width, e.Height, colorType, SKAlphaType.Premul));
 
                         Marshal.Copy(e.Data, 0, bitmap.GetPixels(), e.Data.Length);
 
-                        SKBitmap bitmapToSave = null;
+                        using SKBitmap bitmapToSave = new SKBitmap(bitmap.Width, bitmap.Height);
+                        using SKCanvas canvas = new SKCanvas(bitmapToSave);
 
-                        if (e.FlipX || e.FlipY)
-                        {
-                            bitmapToSave = new SKBitmap(bitmap.Width, bitmap.Height);
+                        canvas.Clear(SKColors.Black);
 
-                            using var canvas = new SKCanvas(bitmapToSave);
+                        float scaleX = e.FlipX ? -1 : 1;
+                        float scaleY = e.FlipY ? -1 : 1;
 
-                            canvas.Clear(SKColors.Transparent);
+                        var matrix = SKMatrix.CreateScale(scaleX, scaleY, bitmap.Width / 2f, bitmap.Height / 2f);
 
-                            float scaleX = e.FlipX ? -1 : 1;
-                            float scaleY = e.FlipY ? -1 : 1;
-
-                            var matrix = SKMatrix.CreateScale(scaleX, scaleY, bitmap.Width / 2f, bitmap.Height / 2f);
-
-                            canvas.SetMatrix(matrix);
-
-                            canvas.DrawBitmap(bitmap, new SKPoint(e.FlipX ? -bitmap.Width : 0, e.FlipY ? -bitmap.Height : 0));
-                        }
+                        canvas.SetMatrix(matrix);
+                        canvas.DrawBitmap(bitmap, SKPoint.Empty);
 
                         SaveBitmapAsPng(bitmapToSave ?? bitmap, path);
                         bitmapToSave?.Dispose();

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -384,8 +384,7 @@ namespace Ryujinx.Ava
                         canvas.SetMatrix(matrix);
                         canvas.DrawBitmap(bitmap, SKPoint.Empty);
 
-                        SaveBitmapAsPng(bitmapToSave ?? bitmap, path);
-                        bitmapToSave?.Dispose();
+                        SaveBitmapAsPng(bitmapToSave, path);
 
                         Logger.Notice.Print(LogClass.Application, $"Screenshot saved to {path}", "Screenshot");
                     }


### PR DESCRIPTION
Fixes two regressions from #6269.
The first is that it "clearing" the destination bitmap with a transparent background. This is undesirable since the image being saved might also have transparency, but we don't want to save a screenshot with a transparent background, it should be black.
The second is that it was drawing the bitmap at a negative position:
```cs
canvas.DrawBitmap(bitmap, new SKPoint(e.FlipX ? -bitmap.Width : 0, e.FlipY ? -bitmap.Height : 0));
```
I have no idea why that was done, but it was causing the bitmap to not be drawn at all, so I set it to zero always.
I tested on a few games, and the saved images are now correct.
Fixes #7068.