### PR TITLE
Vulkan: Force topology to PatchList for Tessellation

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -439,7 +439,7 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     SType = StructureType.PipelineInputAssemblyStateCreateInfo,
                     PrimitiveRestartEnable = primitiveRestartEnable,
-                    Topology = Topology,
+                    Topology = HasTessellationControlShader ? PrimitiveTopology.PatchList : Topology,
                 };
 
                 var tessellationState = new PipelineTessellationStateCreateInfo


### PR DESCRIPTION
Vulkan spec states that input topology should always be PatchList when a tessellation stage is present. The AMD GPU driver on windows crashes so hard it BSODs the machine if this isn't the case, so it's forced here just in case.

Fixes a crash on Floor 15 of Luigi's Mansion 3.

I'm not sure what providing a different topology here would even do, as you'd think it would always be a patch list input.