### PR TITLE
Fix LocaleExtension SetRawSource usages + language perf improvement

### DIFF
--- a/src/Ryujinx/Common/Locale/LocaleExtension.cs
+++ b/src/Ryujinx/Common/Locale/LocaleExtension.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Ava.Common.Locale
 
             var builder = new CompiledBindingPathBuilder();
 
-            builder.SetRawSource(LocaleManager.Instance)
+            builder
                 .Property(new ClrPropertyInfo("Item",
                 obj => (LocaleManager.Instance[keyToUse]),
                 null,
@@ -32,7 +32,10 @@ namespace Ryujinx.Ava.Common.Locale
 
             var path = builder.Build();
 
-            var binding = new CompiledBindingExtension(path);
+            var binding = new CompiledBindingExtension(path)
+            {
+                Source = LocaleManager.Instance
+            };
 
             return binding.ProvideValue(serviceProvider);
         }

--- a/src/Ryujinx/Common/Locale/LocaleManager.cs
+++ b/src/Ryujinx/Common/Locale/LocaleManager.cs
@@ -139,8 +139,10 @@ namespace Ryujinx.Ava.Common.Locale
 
             foreach (var item in locale)
             {
-                this[item.Key] = item.Value;
+                _localeStrings[item.Key] = item.Value;
             }
+
+            OnPropertyChanged("Item");
 
             LocaleChanged?.Invoke();
         }


### PR DESCRIPTION
`LocaleExtension` currently uses `CompiledBindingPathBuilder.SetRawSource()`, which while public wasn't really meant to be used, and isn't even generated at all by the Avalonia XAML compiler.

In Avalonia 11.1, `SetRawSource()` won't do anything - see https://github.com/AvaloniaUI/Avalonia/issues/16430#issuecomment-2254462844 
This PR replaces it with `Binding.Source`, which is the supported way and works in all versions.

Additionally, I noticed that changing the language was abnormally slow (there's a noticeable UI freeze).
`OnPropertyChanged("Item")` is triggered for every item set in `LocaleManager.LoadLanguage()`, which forces all localization bindings in the application to refresh every time. Said another way, the operation is currently O(N²). This PR now raises `PropertyChanged` only once instead.