### PR TITLE
Ava: Wait for CheckLaunchState() to complete to handle exceptions properly

### DIFF
--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -474,9 +474,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             LoadApplications();
 
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            CheckLaunchState();
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            CheckLaunchState().Wait();
         }
 
         private void SetMainContent(Control content = null)


### PR DESCRIPTION
This PR fixes an issue where Ava would just lock up instead of handling the thrown exception when a game was launched was directly launched by the command line (or by a shortcut).

We made a conscious decision before to no wait for `CheckLaunchState()` to complete, but I couldn't figure out why.

During testing I couldn't find any issues with waiting for it to complete.
If you want to test this for yourself I recommend throwing an exception in any of the Load* methods in `Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs` and launching an application from the command line.

Waiting for `CheckLaunchState()` allows exceptions to be handled properly by the unhandled exception handler, which cause Ryujinx to crash as expected instead of locking up.