### PR TITLE
Fix a few issues while loading applications

### DIFF
--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -256,6 +256,12 @@ namespace Ryujinx
             MainWindow mainWindow = new();
             mainWindow.Show();
 
+            // Load the game table if no application was requested by the command line
+            if (CommandLineState.LaunchPathArg == null)
+            {
+                mainWindow.UpdateGameTable();
+            }
+
             if (OperatingSystem.IsLinux())
             {
                 int currentVmMaxMapCount = LinuxHelper.VmMaxMapCount;

--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -331,15 +331,13 @@ namespace Ryujinx
             {
                 if (mainWindow.ApplicationLibrary.TryGetApplicationsFromFile(CommandLineState.LaunchPathArg, out List<ApplicationData> applications))
                 {
-                    ApplicationData applicationData;
-
                     if (CommandLineState.LaunchApplicationId != null)
                     {
-                        applicationData = applications.Find(application => application.IdString == CommandLineState.LaunchApplicationId);
+                        int applicationIndex = applications.FindIndex(application => application.IdString.Equals(CommandLineState.LaunchApplicationId, StringComparison.InvariantCultureIgnoreCase));
 
-                        if (applicationData != null)
+                        if (applicationIndex != -1)
                         {
-                            mainWindow.RunApplication(applicationData, CommandLineState.StartFullscreenArg);
+                            mainWindow.RunApplication(applications[applicationIndex], CommandLineState.StartFullscreenArg);
                         }
                         else
                         {
@@ -349,8 +347,7 @@ namespace Ryujinx
                     }
                     else
                     {
-                        applicationData = applications[0];
-                        mainWindow.RunApplication(applicationData, CommandLineState.StartFullscreenArg);
+                        mainWindow.RunApplication(applications[0], CommandLineState.StartFullscreenArg);
                     }
                 }
                 else

--- a/src/Ryujinx.Gtk3/UI/MainWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/MainWindow.cs
@@ -325,7 +325,6 @@ namespace Ryujinx.UI
             _hideUI.Label = _hideUI.Label.Replace("SHOWUIKEY", ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUI.ToString());
 
             UpdateColumns();
-            UpdateGameTable();
 
             ConfigurationState.Instance.UI.GameDirs.Event += (sender, args) =>
             {

--- a/src/Ryujinx.Gtk3/UI/MainWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/MainWindow.cs
@@ -187,7 +187,10 @@ namespace Ryujinx.UI
                 : IntegrityCheckLevel.None;
 
             // Instantiate GUI objects.
-            ApplicationLibrary = new ApplicationLibrary(_virtualFileSystem, checkLevel);
+            ApplicationLibrary = new ApplicationLibrary(_virtualFileSystem, checkLevel)
+            {
+                DesiredTitleLanguage = ConfigurationState.Instance.System.Language,
+            };
             _uiHandler = new GtkHostUIHandler(this);
             _deviceExitStatus = new AutoResetEvent(false);
 
@@ -737,7 +740,8 @@ namespace Ryujinx.UI
 
             Thread applicationLibraryThread = new(() =>
             {
-                ApplicationLibrary.LoadApplications(ConfigurationState.Instance.UI.GameDirs, ConfigurationState.Instance.System.Language);
+                ApplicationLibrary.DesiredTitleLanguage = ConfigurationState.Instance.System.Language;
+                ApplicationLibrary.LoadApplications(ConfigurationState.Instance.UI.GameDirs);
 
                 _updatingGameTable = false;
             })

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -556,19 +556,13 @@ namespace Ryujinx.UI.App.Common
                             {
                                 AppData = application,
                             });
-                        }
 
-                        if (applications.Count > 1)
-                        {
-                            numApplicationsFound += applications.Count - 1;
+                            numApplicationsFound++;
+                            numApplicationsLoaded++;
                         }
+                    }
 
-                        numApplicationsLoaded += applications.Count;
-                    }
-                    else
-                    {
-                        numApplicationsFound--;
-                    }
+                    numApplicationsFound--;
 
                     OnApplicationCountUpdated(new ApplicationCountUpdatedEventArgs
                     {

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -34,6 +34,7 @@ namespace Ryujinx.UI.App.Common
 {
     public class ApplicationLibrary
     {
+        public Language DesiredTitleLanguage { get; set; }
         public event EventHandler<ApplicationAddedEventArgs> ApplicationAdded;
         public event EventHandler<ApplicationCountUpdatedEventArgs> ApplicationCountUpdated;
 
@@ -45,7 +46,6 @@ namespace Ryujinx.UI.App.Common
 
         private readonly VirtualFileSystem _virtualFileSystem;
         private readonly IntegrityCheckLevel _checkLevel;
-        private Language _desiredTitleLanguage;
         private CancellationTokenSource _cancellationToken;
 
         private static readonly ApplicationJsonSerializerContext _serializerContext = new(JsonHelper.GetDefaultSerializerOptions());
@@ -221,7 +221,7 @@ namespace Ryujinx.UI.App.Common
                 {
                     using UniqueRef<IFile> icon = new();
 
-                    controlFs.OpenFile(ref icon.Ref, $"/icon_{_desiredTitleLanguage}.dat".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                    controlFs.OpenFile(ref icon.Ref, $"/icon_{DesiredTitleLanguage}.dat".ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
                     using MemoryStream stream = new();
 
@@ -477,12 +477,10 @@ namespace Ryujinx.UI.App.Common
             controlFile.Get.Read(out _, 0, outProperty, ReadOption.None).ThrowIfFailure();
         }
 
-        public void LoadApplications(List<string> appDirs, Language desiredTitleLanguage)
+        public void LoadApplications(List<string> appDirs)
         {
             int numApplicationsFound = 0;
             int numApplicationsLoaded = 0;
-
-            _desiredTitleLanguage = desiredTitleLanguage;
 
             _cancellationToken = new CancellationTokenSource();
 
@@ -832,7 +830,7 @@ namespace Ryujinx.UI.App.Common
 
         private void GetApplicationInformation(ref ApplicationControlProperty controlData, ref ApplicationData data)
         {
-            _ = Enum.TryParse(_desiredTitleLanguage.ToString(), out TitleLanguage desiredTitleLanguage);
+            _ = Enum.TryParse(DesiredTitleLanguage.ToString(), out TitleLanguage desiredTitleLanguage);
 
             if (controlData.Title.ItemsRo.Length > (int)desiredTitleLanguage)
             {

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -422,35 +422,40 @@ namespace Ryujinx.UI.App.Common
 
             foreach (var data in applications)
             {
-                ApplicationMetadata appMetadata = LoadAndSaveMetaData(data.IdString, appMetadata =>
+                // Only load metadata for applications with an ID
+                if (data.Id != 0)
                 {
-                    appMetadata.Title = data.Name;
-
-                    // Only do the migration if time_played has a value and timespan_played hasn't been updated yet.
-                    if (appMetadata.TimePlayedOld != default && appMetadata.TimePlayed == TimeSpan.Zero)
+                    ApplicationMetadata appMetadata = LoadAndSaveMetaData(data.IdString, appMetadata =>
                     {
-                        appMetadata.TimePlayed = TimeSpan.FromSeconds(appMetadata.TimePlayedOld);
-                        appMetadata.TimePlayedOld = default;
-                    }
+                        appMetadata.Title = data.Name;
 
-                    // Only do the migration if last_played has a value and last_played_utc doesn't exist yet.
-                    if (appMetadata.LastPlayedOld != default && !appMetadata.LastPlayed.HasValue)
-                    {
-                        // Migrate from string-based last_played to DateTime-based last_played_utc.
-                        if (DateTime.TryParse(appMetadata.LastPlayedOld, out DateTime lastPlayedOldParsed))
+                        // Only do the migration if time_played has a value and timespan_played hasn't been updated yet.
+                        if (appMetadata.TimePlayedOld != default && appMetadata.TimePlayed == TimeSpan.Zero)
                         {
-                            appMetadata.LastPlayed = lastPlayedOldParsed;
-
-                            // Migration successful: deleting last_played from the metadata file.
-                            appMetadata.LastPlayedOld = default;
+                            appMetadata.TimePlayed = TimeSpan.FromSeconds(appMetadata.TimePlayedOld);
+                            appMetadata.TimePlayedOld = default;
                         }
 
-                    }
-                });
+                        // Only do the migration if last_played has a value and last_played_utc doesn't exist yet.
+                        if (appMetadata.LastPlayedOld != default && !appMetadata.LastPlayed.HasValue)
+                        {
+                            // Migrate from string-based last_played to DateTime-based last_played_utc.
+                            if (DateTime.TryParse(appMetadata.LastPlayedOld, out DateTime lastPlayedOldParsed))
+                            {
+                                appMetadata.LastPlayed = lastPlayedOldParsed;
 
-                data.Favorite = appMetadata.Favorite;
-                data.TimePlayed = appMetadata.TimePlayed;
-                data.LastPlayed = appMetadata.LastPlayed;
+                                // Migration successful: deleting last_played from the metadata file.
+                                appMetadata.LastPlayedOld = default;
+                            }
+
+                        }
+                    });
+
+                    data.Favorite = appMetadata.Favorite;
+                    data.TimePlayed = appMetadata.TimePlayed;
+                    data.LastPlayed = appMetadata.LastPlayed;
+                }
+
                 data.FileExtension = Path.GetExtension(applicationPath).TrimStart('.').ToUpper();
                 data.FileSize = fileSize;
                 data.Path = applicationPath;

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -325,15 +325,13 @@ namespace Ryujinx.Ava.UI.Windows
 
                     if (ApplicationLibrary.TryGetApplicationsFromFile(_launchPath, out List<ApplicationData> applications))
                     {
-                        ApplicationData applicationData;
-
                         if (_launchApplicationId != null)
                         {
-                            applicationData = applications.Find(application => application.IdString == _launchApplicationId);
+                            int applicationIndex = applications.FindIndex(application => application.IdString.Equals(_launchApplicationId, StringComparison.InvariantCultureIgnoreCase));
 
-                            if (applicationData != null)
+                            if (applicationIndex != -1)
                             {
-                                await ViewModel.LoadApplication(applicationData, _startFullscreen);
+                                await ViewModel.LoadApplication(applications[applicationIndex], _startFullscreen);
                             }
                             else
                             {
@@ -343,8 +341,7 @@ namespace Ryujinx.Ava.UI.Windows
                         }
                         else
                         {
-                            applicationData = applications[0];
-                            await ViewModel.LoadApplication(applicationData, _startFullscreen);
+                            await ViewModel.LoadApplication(applications[0], _startFullscreen);
                         }
                     }
                     else

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -37,6 +37,7 @@ namespace Ryujinx.Ava.UI.Windows
         internal static MainWindowViewModel MainWindowViewModel { get; private set; }
 
         private bool _isLoading;
+        private bool _applicationsLoadedOnce;
 
         private UserChannelPersistence _userChannelPersistence;
         private static bool _deferLoad;
@@ -472,7 +473,11 @@ namespace Ryujinx.Ava.UI.Windows
 
             ViewModel.RefreshFirmwareStatus();
 
-            LoadApplications();
+            // Load applications if no application was requested by the command line
+            if (!_deferLoad)
+            {
+                LoadApplications();
+            }
 
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             CheckLaunchState();
@@ -485,6 +490,12 @@ namespace Ryujinx.Ava.UI.Windows
 
             if (MainContent.Content != content)
             {
+                // Load applications while switching to the GameLibrary if we haven't done that yet
+                if (!_applicationsLoadedOnce && content == GameLibrary)
+                {
+                    LoadApplications();
+                }
+
                 MainContent.Content = content;
             }
         }
@@ -581,6 +592,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         public void LoadApplications()
         {
+            _applicationsLoadedOnce = true;
             ViewModel.Applications.Clear();
 
             StatusBarView.LoadProgressBar.IsVisible = true;

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -225,7 +225,10 @@ namespace Ryujinx.Ava.UI.Windows
                 ? IntegrityCheckLevel.ErrorOnInvalid
                 : IntegrityCheckLevel.None;
 
-            ApplicationLibrary = new ApplicationLibrary(VirtualFileSystem, checkLevel);
+            ApplicationLibrary = new ApplicationLibrary(VirtualFileSystem, checkLevel)
+            {
+                DesiredTitleLanguage = ConfigurationState.Instance.System.Language,
+            };
 
             // Save data created before we supported extra data in directory save data will not work properly if
             // given empty extra data. Luckily some of that extra data can be created using the data from the
@@ -634,7 +637,8 @@ namespace Ryujinx.Ava.UI.Windows
 
             Thread applicationLibraryThread = new(() =>
             {
-                ApplicationLibrary.LoadApplications(ConfigurationState.Instance.UI.GameDirs, ConfigurationState.Instance.System.Language);
+                ApplicationLibrary.DesiredTitleLanguage = ConfigurationState.Instance.System.Language;
+                ApplicationLibrary.LoadApplications(ConfigurationState.Instance.UI.GameDirs);
 
                 _isLoading = false;
             })


### PR DESCRIPTION
This PR contains:
- an optimization that prevents `LoadApplications()` from enumerating the list of found applications multiple times.
- an improvement to the code that handles loading a specific application id from the command line.
  -  This should fix cases where an application couldn't be loaded because the application id was written in uppercase letters on the command line. (Though I'm not sure if people ran into that yet.)
- better exception handling in `PartitionFileSystemExtensions.TryLoad()`, so that it hopefully doesn't throw any exceptions anymore.
  - This resolves Ava locking up when failing to load an application from the command line. (There are two separate issues at play here. The lock up issue gets addressed in #7122)

---

As always I'll mark this PR as draft until the dependent PRs are merged.

---

Depends on #7116 