### PR TITLE
replace ByteMemoryPool usage in Ryujinx.Graphics

### DIFF
--- a/src/Ryujinx.Graphics.Device/DeviceMemoryManager.cs
+++ b/src/Ryujinx.Graphics.Device/DeviceMemoryManager.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common.Memory;
 using Ryujinx.Memory;
 using System;
-using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -145,9 +144,9 @@ namespace Ryujinx.Graphics.Device
             }
             else
             {
-                IMemoryOwner<byte> memoryOwner = ByteMemoryPool.Rent(size);
+                MemoryOwner<byte> memoryOwner = MemoryOwner<byte>.Rent(size);
 
-                GetSpan(va, size).CopyTo(memoryOwner.Memory.Span);
+                ReadImpl(va, memoryOwner.Span);
 
                 return new WritableRegion(this, va, memoryOwner, tracked: true);
             }

--- a/src/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -199,7 +199,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                     if (target != null)
                     {
                         target.SynchronizeMemory();
-                        var dataCopy = ByteMemoryPool.RentCopy(data);
+                        var dataCopy = MemoryOwner<byte>.RentCopy(data);
                         target.SetData(dataCopy, 0, 0, new GAL.Rectangle<int>(_dstX, _dstY, _lineLengthIn / target.Info.FormatInfo.BytesPerPixel, _lineCount));
                         target.SignalModified();
 

--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.Common.Memory;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Texture;
@@ -805,7 +806,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         sliceDepth,
                         levels,
                         layers,
-                        out IMemoryOwner<byte> decoded))
+                        out MemoryOwner<byte> decoded))
                     {
                         string texInfo = $"{Info.Target} {Info.FormatInfo.Format} {Info.Width}x{Info.Height}x{Info.DepthOrLayers} levels {Info.Levels}";
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -2,7 +2,6 @@ using Ryujinx.Common.Memory;
 using Ryujinx.Memory;
 using Ryujinx.Memory.Range;
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -242,9 +241,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                IMemoryOwner<byte> memoryOwner = ByteMemoryPool.Rent(size);
+                MemoryOwner<byte> memoryOwner = MemoryOwner<byte>.Rent(size);
 
-                GetSpan(va, size).CopyTo(memoryOwner.Memory.Span);
+                ReadImpl(va, memoryOwner.Span, tracked);
 
                 return new WritableRegion(this, va, memoryOwner, tracked);
             }

--- a/src/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -192,9 +192,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                IMemoryOwner<byte> memoryOwner = ByteMemoryPool.Rent(range.GetSize());
+                MemoryOwner<byte> memoryOwner = MemoryOwner<byte>.Rent(checked((int)range.GetSize()));
 
-                Memory<byte> memory = memoryOwner.Memory;
+                Span<byte> memorySpan = memoryOwner.Span;
 
                 int offset = 0;
                 for (int i = 0; i < range.Count; i++)
@@ -203,7 +203,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     int size = (int)currentRange.Size;
                     if (currentRange.Address != MemoryManager.PteUnmapped)
                     {
-                        GetSpan(currentRange.Address, size).CopyTo(memory.Span.Slice(offset, size));
+                        GetSpan(currentRange.Address, size).CopyTo(memorySpan.Slice(offset, size));
                     }
                     offset += size;
                 }

--- a/src/Ryujinx.Graphics.OpenGL/Image/FormatConverter.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Image/FormatConverter.cs
@@ -1,6 +1,5 @@
 using Ryujinx.Common.Memory;
 using System;
-using System.Buffers;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -10,11 +9,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
 {
     static class FormatConverter
     {
-        public unsafe static IMemoryOwner<byte> ConvertS8D24ToD24S8(ReadOnlySpan<byte> data)
+        public unsafe static MemoryOwner<byte> ConvertS8D24ToD24S8(ReadOnlySpan<byte> data)
         {
             MemoryOwner<byte> outputMemory = MemoryOwner<byte>.Rent(data.Length);
 
-            Span<byte> output = outputMemory.Memory.Span;
+            Span<byte> output = outputMemory.Span;
 
             int start = 0;
 

--- a/src/Ryujinx.Graphics.OpenGL/Image/FormatConverter.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Image/FormatConverter.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
     {
         public unsafe static IMemoryOwner<byte> ConvertS8D24ToD24S8(ReadOnlySpan<byte> data)
         {
-            IMemoryOwner<byte> outputMemory = ByteMemoryPool.Rent(data.Length);
+            MemoryOwner<byte> outputMemory = MemoryOwner<byte>.Rent(data.Length);
 
             Span<byte> output = outputMemory.Memory.Span;
 

--- a/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
+++ b/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common.Memory;
 using Ryujinx.Common.Utilities;
 using System;
-using System.Buffers;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -293,7 +292,7 @@ namespace Ryujinx.Graphics.Texture.Astc
             int depth,
             int levels,
             int layers,
-            out IMemoryOwner<byte> decoded)
+            out MemoryOwner<byte> decoded)
         {
             decoded = MemoryOwner<byte>.Rent(QueryDecompressedSize(width, height, depth, levels, layers));
 

--- a/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
+++ b/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
@@ -295,7 +295,7 @@ namespace Ryujinx.Graphics.Texture.Astc
             int layers,
             out IMemoryOwner<byte> decoded)
         {
-            decoded = ByteMemoryPool.Rent(QueryDecompressedSize(width, height, depth, levels, layers));
+            decoded = MemoryOwner<byte>.Rent(QueryDecompressedSize(width, height, depth, levels, layers));
 
             AstcDecoder decoder = new(data, decoded.Memory, blockWidth, blockHeight, width, height, depth, levels, layers);
 

--- a/src/Ryujinx.Graphics.Texture/BCnDecoder.cs
+++ b/src/Ryujinx.Graphics.Texture/BCnDecoder.cs
@@ -23,12 +23,12 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers * 4;
             }
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
 
             Span<byte> tile = stackalloc byte[BlockWidth * BlockHeight * 4];
 
             Span<uint> tileAsUint = MemoryMarshal.Cast<byte, uint>(tile);
-            Span<uint> outputAsUint = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputAsUint = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             Span<Vector128<byte>> tileAsVector128 = MemoryMarshal.Cast<byte, Vector128<byte>>(tile);
 
@@ -111,12 +111,12 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers * 4;
             }
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
 
             Span<byte> tile = stackalloc byte[BlockWidth * BlockHeight * 4];
 
             Span<uint> tileAsUint = MemoryMarshal.Cast<byte, uint>(tile);
-            Span<uint> outputAsUint = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputAsUint = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             Span<Vector128<byte>> tileAsVector128 = MemoryMarshal.Cast<byte, Vector128<byte>>(tile);
 
@@ -206,13 +206,13 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers * 4;
             }
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
 
             Span<byte> tile = stackalloc byte[BlockWidth * BlockHeight * 4];
             Span<byte> rPal = stackalloc byte[8];
 
             Span<uint> tileAsUint = MemoryMarshal.Cast<byte, uint>(tile);
-            Span<uint> outputAsUint = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputAsUint = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             Span<Vector128<byte>> tileAsVector128 = MemoryMarshal.Cast<byte, Vector128<byte>>(tile);
 
@@ -306,8 +306,8 @@ namespace Ryujinx.Graphics.Texture
             // Backends currently expect a stride alignment of 4 bytes, so output width must be aligned.
             int alignedWidth = BitUtils.AlignUp(width, 4);
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
-            Span<byte> outputSpan = output.Memory.Span;
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
+            Span<byte> outputSpan = output.Span;
 
             ReadOnlySpan<ulong> data64 = MemoryMarshal.Cast<byte, ulong>(data);
 
@@ -414,7 +414,7 @@ namespace Ryujinx.Graphics.Texture
             // Backends currently expect a stride alignment of 4 bytes, so output width must be aligned.
             int alignedWidth = BitUtils.AlignUp(width, 2);
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
 
             ReadOnlySpan<ulong> data64 = MemoryMarshal.Cast<byte, ulong>(data);
 
@@ -423,7 +423,7 @@ namespace Ryujinx.Graphics.Texture
             Span<byte> rPal = stackalloc byte[8];
             Span<byte> gPal = stackalloc byte[8];
 
-            Span<ushort> outputAsUshort = MemoryMarshal.Cast<byte, ushort>(output.Memory.Span);
+            Span<ushort> outputAsUshort = MemoryMarshal.Cast<byte, ushort>(output.Span);
 
             Span<uint> rTileAsUint = MemoryMarshal.Cast<byte, uint>(rTile);
             Span<uint> gTileAsUint = MemoryMarshal.Cast<byte, uint>(gTile);
@@ -536,8 +536,8 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers * 8;
             }
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
-            Span<byte> outputSpan = output.Memory.Span;
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
+            Span<byte> outputSpan = output.Span;
 
             int inputOffset = 0;
             int outputOffset = 0;
@@ -575,8 +575,8 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers * 4;
             }
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
-            Span<byte> outputSpan = output.Memory.Span;
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
+            Span<byte> outputSpan = output.Span;
 
             int inputOffset = 0;
             int outputOffset = 0;

--- a/src/Ryujinx.Graphics.Texture/BCnDecoder.cs
+++ b/src/Ryujinx.Graphics.Texture/BCnDecoder.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.Common.Memory;
 using System;
-using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -14,7 +13,7 @@ namespace Ryujinx.Graphics.Texture
         private const int BlockWidth = 4;
         private const int BlockHeight = 4;
 
-        public static IMemoryOwner<byte> DecodeBC1(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodeBC1(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             int size = 0;
 
@@ -102,7 +101,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeBC2(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodeBC2(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             int size = 0;
 
@@ -197,7 +196,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeBC3(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodeBC3(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             int size = 0;
 
@@ -294,7 +293,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeBC4(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
+        public static MemoryOwner<byte> DecodeBC4(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
         {
             int size = 0;
 
@@ -402,7 +401,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeBC5(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
+        public static MemoryOwner<byte> DecodeBC5(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
         {
             int size = 0;
 
@@ -527,7 +526,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeBC6(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
+        public static MemoryOwner<byte> DecodeBC6(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
         {
             int size = 0;
 
@@ -566,7 +565,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeBC7(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodeBC7(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             int size = 0;
 

--- a/src/Ryujinx.Graphics.Texture/BCnEncoder.cs
+++ b/src/Ryujinx.Graphics.Texture/BCnEncoder.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.Texture
                 size += w * h * 16 * Math.Max(1, depth >> l) * layers;
             }
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(size);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(size);
             Memory<byte> outputMemory = output.Memory;
 
             int imageBaseIOffs = 0;

--- a/src/Ryujinx.Graphics.Texture/BCnEncoder.cs
+++ b/src/Ryujinx.Graphics.Texture/BCnEncoder.cs
@@ -2,7 +2,6 @@ using Ryujinx.Common;
 using Ryujinx.Common.Memory;
 using Ryujinx.Graphics.Texture.Encoders;
 using System;
-using System.Buffers;
 
 namespace Ryujinx.Graphics.Texture
 {
@@ -11,7 +10,7 @@ namespace Ryujinx.Graphics.Texture
         private const int BlockWidth = 4;
         private const int BlockHeight = 4;
 
-        public static IMemoryOwner<byte> EncodeBC7(Memory<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> EncodeBC7(Memory<byte> data, int width, int height, int depth, int levels, int layers)
         {
             int size = 0;
 

--- a/src/Ryujinx.Graphics.Texture/ETC2Decoder.cs
+++ b/src/Ryujinx.Graphics.Texture/ETC2Decoder.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.Common.Memory;
 using System;
-using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 
@@ -51,7 +50,7 @@ namespace Ryujinx.Graphics.Texture
             new int[] { -3, -5, -7, -9, 2, 4, 6, 8 },
         };
 
-        public static IMemoryOwner<byte> DecodeRgb(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodeRgb(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             ReadOnlySpan<ulong> dataUlong = MemoryMarshal.Cast<byte, ulong>(data);
 
@@ -113,7 +112,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodePta(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodePta(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             ReadOnlySpan<ulong> dataUlong = MemoryMarshal.Cast<byte, ulong>(data);
 
@@ -170,7 +169,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> DecodeRgba(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
+        public static MemoryOwner<byte> DecodeRgba(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers)
         {
             ReadOnlySpan<ulong> dataUlong = MemoryMarshal.Cast<byte, ulong>(data);
 

--- a/src/Ryujinx.Graphics.Texture/ETC2Decoder.cs
+++ b/src/Ryujinx.Graphics.Texture/ETC2Decoder.cs
@@ -57,9 +57,9 @@ namespace Ryujinx.Graphics.Texture
 
             int inputOffset = 0;
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(CalculateOutputSize(width, height, depth, levels, layers));
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(CalculateOutputSize(width, height, depth, levels, layers));
 
-            Span<uint> outputUint = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputUint = MemoryMarshal.Cast<byte, uint>(output.Span);
             Span<uint> tile = stackalloc uint[BlockWidth * BlockHeight];
 
             int imageBaseOOffs = 0;
@@ -119,9 +119,9 @@ namespace Ryujinx.Graphics.Texture
 
             int inputOffset = 0;
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(CalculateOutputSize(width, height, depth, levels, layers));
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(CalculateOutputSize(width, height, depth, levels, layers));
 
-            Span<uint> outputUint = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputUint = MemoryMarshal.Cast<byte, uint>(output.Span);
             Span<uint> tile = stackalloc uint[BlockWidth * BlockHeight];
 
             int imageBaseOOffs = 0;
@@ -176,9 +176,9 @@ namespace Ryujinx.Graphics.Texture
 
             int inputOffset = 0;
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(CalculateOutputSize(width, height, depth, levels, layers));
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(CalculateOutputSize(width, height, depth, levels, layers));
 
-            Span<uint> outputUint = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputUint = MemoryMarshal.Cast<byte, uint>(output.Span);
             Span<uint> tile = stackalloc uint[BlockWidth * BlockHeight];
 
             int imageBaseOOffs = 0;

--- a/src/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/src/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.Common.Memory;
 using System;
-using System.Buffers;
 using System.Runtime.Intrinsics;
 using static Ryujinx.Graphics.Texture.BlockLinearConstants;
 
@@ -95,7 +94,7 @@ namespace Ryujinx.Graphics.Texture
             };
         }
 
-        public static IMemoryOwner<byte> ConvertBlockLinearToLinear(
+        public static MemoryOwner<byte> ConvertBlockLinearToLinear(
             int width,
             int height,
             int depth,
@@ -249,7 +248,7 @@ namespace Ryujinx.Graphics.Texture
             return outputOwner;
         }
 
-        public static IMemoryOwner<byte> ConvertLinearStridedToLinear(
+        public static MemoryOwner<byte> ConvertLinearStridedToLinear(
             int width,
             int height,
             int blockWidth,

--- a/src/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/src/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -121,8 +121,8 @@ namespace Ryujinx.Graphics.Texture
                 blockHeight,
                 bytesPerPixel);
 
-            IMemoryOwner<byte> outputOwner = ByteMemoryPool.Rent(outSize);
-            Span<byte> output = outputOwner.Memory.Span;
+            MemoryOwner<byte> outputOwner = MemoryOwner<byte>.Rent(outSize);
+            Span<byte> output = outputOwner.Span;
 
             int outOffs = 0;
 
@@ -265,8 +265,8 @@ namespace Ryujinx.Graphics.Texture
             int outStride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
             lineSize = Math.Min(lineSize, outStride);
 
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(h * outStride);
-            Span<byte> outSpan = output.Memory.Span;
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(h * outStride);
+            Span<byte> outSpan = output.Span;
 
             int outOffs = 0;
             int inOffs = 0;

--- a/src/Ryujinx.Graphics.Texture/PixelConverter.cs
+++ b/src/Ryujinx.Graphics.Texture/PixelConverter.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.Common.Memory;
 using System;
-using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -21,7 +20,7 @@ namespace Ryujinx.Graphics.Texture
             return (remainder, outRemainder, length / stride);
         }
 
-        public unsafe static IMemoryOwner<byte> ConvertR4G4ToR4G4B4A4(ReadOnlySpan<byte> data, int width)
+        public unsafe static MemoryOwner<byte> ConvertR4G4ToR4G4B4A4(ReadOnlySpan<byte> data, int width)
         {
             MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             Span<byte> outputSpan = output.Span;
@@ -73,7 +72,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> ConvertR5G6B5ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
+        public static MemoryOwner<byte> ConvertR5G6B5ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
         {
             MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
@@ -110,7 +109,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> ConvertR5G5B5ToR8G8B8A8(ReadOnlySpan<byte> data, int width, bool forceAlpha)
+        public static MemoryOwner<byte> ConvertR5G5B5ToR8G8B8A8(ReadOnlySpan<byte> data, int width, bool forceAlpha)
         {
             MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
@@ -147,7 +146,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> ConvertA1B5G5R5ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
+        public static MemoryOwner<byte> ConvertA1B5G5R5ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
         {
             MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
@@ -184,7 +183,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static IMemoryOwner<byte> ConvertR4G4B4A4ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
+        public static MemoryOwner<byte> ConvertR4G4B4A4ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
         {
             MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;

--- a/src/Ryujinx.Graphics.Texture/PixelConverter.cs
+++ b/src/Ryujinx.Graphics.Texture/PixelConverter.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.Graphics.Texture
 
             (int remainder, int outRemainder, int height) = GetLineRemainders(data.Length, width, 1, 2);
 
-            Span<ushort> outputSpan = MemoryMarshal.Cast<byte, ushort>(output.Memory.Span);
+            Span<ushort> outputSpanUInt16 = MemoryMarshal.Cast<byte, ushort>(outputSpan);
 
             if (remainder == 0)
             {
@@ -39,7 +39,7 @@ namespace Ryujinx.Graphics.Texture
                     int sizeTrunc = data.Length & ~7;
                     start = sizeTrunc;
 
-                    fixed (byte* inputPtr = data, outputPtr = output.Memory.Span)
+                    fixed (byte* inputPtr = data, outputPtr = outputSpan)
                     {
                         for (ulong offset = 0; offset < (ulong)sizeTrunc; offset += 8)
                         {
@@ -50,7 +50,7 @@ namespace Ryujinx.Graphics.Texture
 
                 for (int i = start; i < data.Length; i++)
                 {
-                    outputSpan[i] = data[i];
+                    outputSpanUInt16[i] = data[i];
                 }
             }
             else
@@ -62,7 +62,7 @@ namespace Ryujinx.Graphics.Texture
                 {
                     for (int x = 0; x < width; x++)
                     {
-                        outputSpan[outOffset++] = data[offset++];
+                        outputSpanUInt16[outOffset++] = data[offset++];
                     }
 
                     offset += remainder;

--- a/src/Ryujinx.Graphics.Texture/PixelConverter.cs
+++ b/src/Ryujinx.Graphics.Texture/PixelConverter.cs
@@ -23,7 +23,8 @@ namespace Ryujinx.Graphics.Texture
 
         public unsafe static IMemoryOwner<byte> ConvertR4G4ToR4G4B4A4(ReadOnlySpan<byte> data, int width)
         {
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(data.Length * 2);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
+            Span<byte> outputSpan = output.Span;
 
             (int remainder, int outRemainder, int height) = GetLineRemainders(data.Length, width, 1, 2);
 
@@ -74,14 +75,14 @@ namespace Ryujinx.Graphics.Texture
 
         public static IMemoryOwner<byte> ConvertR5G6B5ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
         {
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(data.Length * 2);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
             int outOffset = 0;
 
             (int remainder, int outRemainder, int height) = GetLineRemainders(data.Length, width, 2, 4);
 
             ReadOnlySpan<ushort> inputSpan = MemoryMarshal.Cast<byte, ushort>(data);
-            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             for (int y = 0; y < height; y++)
             {
@@ -111,14 +112,14 @@ namespace Ryujinx.Graphics.Texture
 
         public static IMemoryOwner<byte> ConvertR5G5B5ToR8G8B8A8(ReadOnlySpan<byte> data, int width, bool forceAlpha)
         {
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(data.Length * 2);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
             int outOffset = 0;
 
             (int remainder, int outRemainder, int height) = GetLineRemainders(data.Length, width, 2, 4);
 
             ReadOnlySpan<ushort> inputSpan = MemoryMarshal.Cast<byte, ushort>(data);
-            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             for (int y = 0; y < height; y++)
             {
@@ -148,14 +149,14 @@ namespace Ryujinx.Graphics.Texture
 
         public static IMemoryOwner<byte> ConvertA1B5G5R5ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
         {
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(data.Length * 2);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
             int outOffset = 0;
 
             (int remainder, int outRemainder, int height) = GetLineRemainders(data.Length, width, 2, 4);
 
             ReadOnlySpan<ushort> inputSpan = MemoryMarshal.Cast<byte, ushort>(data);
-            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             for (int y = 0; y < height; y++)
             {
@@ -185,14 +186,14 @@ namespace Ryujinx.Graphics.Texture
 
         public static IMemoryOwner<byte> ConvertR4G4B4A4ToR8G8B8A8(ReadOnlySpan<byte> data, int width)
         {
-            IMemoryOwner<byte> output = ByteMemoryPool.Rent(data.Length * 2);
+            MemoryOwner<byte> output = MemoryOwner<byte>.Rent(data.Length * 2);
             int offset = 0;
             int outOffset = 0;
 
             (int remainder, int outRemainder, int height) = GetLineRemainders(data.Length, width, 2, 4);
 
             ReadOnlySpan<ushort> inputSpan = MemoryMarshal.Cast<byte, ushort>(data);
-            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Memory.Span);
+            Span<uint> outputSpan = MemoryMarshal.Cast<byte, uint>(output.Span);
 
             for (int y = 0; y < height; y++)
             {

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -211,7 +211,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Initialize()
         {
-            IMemoryOwner<byte> dummyTextureData = ByteMemoryPool.RentCleared(4);
+            MemoryOwner<byte> dummyTextureData = MemoryOwner<byte>.RentCleared(4);
             _dummyTexture.SetData(dummyTextureData);
         }
 


### PR DESCRIPTION
Replaces use of `ByteMemoryPool` with `MemoryOwner<byte>`. These are both wrappers to the standard `ArrayPool` so there should be no functional changes.  Also replaces some uses of `IMemoryOwner<byte>` with `MemoryOwner<byte>` directly, with more of this planned after `ByteMemoryPool` is replaced/removed completely.