### PR TITLE
Fix shader RegisterUsage pass only taking first operation dest into account

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 6921;
+        private const uint CodeGenVersion = 7131;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/RegisterUsage.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/RegisterUsage.cs
@@ -155,9 +155,14 @@ namespace Ryujinx.Graphics.Shader.Translation
                         localInputs[block.Index] |= GetMask(register) & ~localOutputs[block.Index];
                     }
 
-                    if (operation.Dest != null && operation.Dest.Type == OperandType.Register)
+                    for (int dstIndex = 0; dstIndex < operation.DestsCount; dstIndex++)
                     {
-                        localOutputs[block.Index] |= GetMask(operation.Dest.GetRegister());
+                        Operand dest = operation.GetDest(dstIndex);
+
+                        if (dest != null && dest.Type == OperandType.Register)
+                        {
+                            localOutputs[block.Index] |= GetMask(dest.GetRegister());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The `RegisterUsage` pass, which computes all registers consumed (inputs) and modified (outputs) by a shader function, was not accounting for the fact that some operations can produce multiple results. One example of such operations is any texture operation, which can read up to 4 colour component values (RGBA). Because it was only accounting for the first one, only R (red) would be actually considered modified by the function.

Fixes red tint on "THE NEW DENPA MEN" (still needs ignore missing services).

Before:
![image](https://github.com/user-attachments/assets/2b46182a-756d-49f2-8057-b56fdab6ae22)
After:
![image](https://github.com/user-attachments/assets/4152d187-f4d7-4807-b2bd-1f1a93ffb675)
Fixes #7126.