### PR TITLE
Fix off-by-one on audio renderer PerformanceManager.GetNextEntry

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Server/Performance/PerformanceManager.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/Performance/PerformanceManager.cs
@@ -18,16 +18,12 @@ namespace Ryujinx.Audio.Renderer.Server.Performance
 
             if (version == 2)
             {
-                return (ulong)PerformanceManagerGeneric<PerformanceFrameHeaderVersion2,
-                                                 PerformanceEntryVersion2,
-                                                 PerformanceDetailVersion2>.GetRequiredBufferSizeForPerformanceMetricsPerFrame(ref parameter);
+                return (ulong)PerformanceManagerGeneric<PerformanceFrameHeaderVersion2, PerformanceEntryVersion2, PerformanceDetailVersion2>.GetRequiredBufferSizeForPerformanceMetricsPerFrame(ref parameter);
             }
 
             if (version == 1)
             {
-                return (ulong)PerformanceManagerGeneric<PerformanceFrameHeaderVersion1,
-                    PerformanceEntryVersion1,
-                    PerformanceDetailVersion1>.GetRequiredBufferSizeForPerformanceMetricsPerFrame(ref parameter);
+                return (ulong)PerformanceManagerGeneric<PerformanceFrameHeaderVersion1, PerformanceEntryVersion1, PerformanceDetailVersion1>.GetRequiredBufferSizeForPerformanceMetricsPerFrame(ref parameter);
             }
 
             throw new NotImplementedException($"Unknown Performance metrics data format version {version}");

--- a/src/Ryujinx.Audio/Renderer/Server/Performance/PerformanceManagerGeneric.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/Performance/PerformanceManagerGeneric.cs
@@ -234,7 +234,7 @@ namespace Ryujinx.Audio.Renderer.Server.Performance
         {
             performanceEntry = null;
 
-            if (_entryDetailIndex > MaxFrameDetailCount)
+            if (_entryDetailIndex >= MaxFrameDetailCount)
             {
                 return false;
             }
@@ -245,7 +245,7 @@ namespace Ryujinx.Audio.Renderer.Server.Performance
                 EntryCountOffset = (uint)CurrentHeader.GetEntryCountOffset(),
             };
 
-            uint baseEntryOffset = (uint)(Unsafe.SizeOf<THeader>() + GetEntriesSize() + Unsafe.SizeOf<IPerformanceDetailEntry>() * _entryDetailIndex);
+            uint baseEntryOffset = (uint)(Unsafe.SizeOf<THeader>() + GetEntriesSize() + Unsafe.SizeOf<TEntryDetail>() * _entryDetailIndex);
 
             ref TEntryDetail entryDetail = ref EntriesDetail[_entryDetailIndex];
 

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/Types/VsmsMappingArguments.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/Types/VsmsMappingArguments.cs
@@ -9,5 +9,6 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrlGpu.Types
         public byte Sm0TpcIndex;
         public byte Sm1GpcIndex;
         public byte Sm1TpcIndex;
+        public uint Reserved;
     }
 }


### PR DESCRIPTION
Fixes an off-by-one error that was causing an `IndexOutOfRangeException` on the `GetNextEntry` function. It returns early if `_entryDetailIndex` is greater than ``MaxFrameDetailCount`, but the check should be greater than *or equal* since the index being equal to the count is already out of range.

This also fixes other loosely related/unrelated issues (I will comment about them separately).

Fixes #7138.