### PR TITLE
Fix same textures with unmapped start being considered different

### DIFF
--- a/src/Ryujinx.Memory/Range/IMultiRangeItem.cs
+++ b/src/Ryujinx.Memory/Range/IMultiRangeItem.cs
@@ -4,6 +4,22 @@ namespace Ryujinx.Memory.Range
     {
         MultiRange Range { get; }
 
-        ulong BaseAddress => Range.GetSubRange(0).Address;
+        ulong BaseAddress
+        {
+            get
+            {
+                for (int index = 0; index < Range.Count; index++)
+                {
+                    MemoryRange subRange = Range.GetSubRange(index);
+
+                    if (subRange.Address != ulong.MaxValue)
+                    {
+                        return subRange.Address;
+                    }
+                }
+
+                return ulong.MaxValue;
+            }
+        }
     }
 }

--- a/src/Ryujinx.Memory/Range/IMultiRangeItem.cs
+++ b/src/Ryujinx.Memory/Range/IMultiRangeItem.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.Memory.Range
                     }
                 }
 
-                return ulong.MaxValue;
+                return MemoryRange.InvalidAddress;
             }
         }
     }

--- a/src/Ryujinx.Memory/Range/IMultiRangeItem.cs
+++ b/src/Ryujinx.Memory/Range/IMultiRangeItem.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Memory.Range
                 {
                     MemoryRange subRange = Range.GetSubRange(index);
 
-                    if (subRange.Address != ulong.MaxValue)
+                    if (!MemoryRange.IsInvalid(ref subRange))
                     {
                         return subRange.Address;
                     }

--- a/src/Ryujinx.Memory/Range/MemoryRange.cs
+++ b/src/Ryujinx.Memory/Range/MemoryRange.cs
@@ -59,6 +59,17 @@ namespace Ryujinx.Memory.Range
         }
 
         /// <summary>
+        /// Checks if a given sub-range of memory is invalid.
+        /// Those are used to represent unmapped memory regions (holes in the region mapping).
+        /// </summary>
+        /// <param name="subRange">Memory range to checl</param>
+        /// <returns>True if the memory range is considered invalid, false otherwise</returns>
+        internal static bool IsInvalid(ref MemoryRange subRange)
+        {
+            return subRange.Address == ulong.MaxValue;
+        }
+
+        /// <summary>
         /// Returns a string summary of the memory range.
         /// </summary>
         /// <returns>A string summary of the memory range</returns>

--- a/src/Ryujinx.Memory/Range/MemoryRange.cs
+++ b/src/Ryujinx.Memory/Range/MemoryRange.cs
@@ -67,7 +67,7 @@ namespace Ryujinx.Memory.Range
         /// Checks if a given sub-range of memory is invalid.
         /// Those are used to represent unmapped memory regions (holes in the region mapping).
         /// </summary>
-        /// <param name="subRange">Memory range to checl</param>
+        /// <param name="subRange">Memory range to check</param>
         /// <returns>True if the memory range is considered invalid, false otherwise</returns>
         internal static bool IsInvalid(ref MemoryRange subRange)
         {

--- a/src/Ryujinx.Memory/Range/MemoryRange.cs
+++ b/src/Ryujinx.Memory/Range/MemoryRange.cs
@@ -6,6 +6,11 @@ namespace Ryujinx.Memory.Range
     public readonly record struct MemoryRange
     {
         /// <summary>
+        /// Special address value used to indicate than an address is invalid.
+        /// </summary>
+        internal const ulong InvalidAddress = ulong.MaxValue;
+
+        /// <summary>
         /// An empty memory range, with a null address and zero size.
         /// </summary>
         public static MemoryRange Empty => new(0UL, 0);
@@ -66,7 +71,7 @@ namespace Ryujinx.Memory.Range
         /// <returns>True if the memory range is considered invalid, false otherwise</returns>
         internal static bool IsInvalid(ref MemoryRange subRange)
         {
-            return subRange.Address == ulong.MaxValue;
+            return subRange.Address == InvalidAddress;
         }
 
         /// <summary>
@@ -75,7 +80,7 @@ namespace Ryujinx.Memory.Range
         /// <returns>A string summary of the memory range</returns>
         public override string ToString()
         {
-            if (Address == ulong.MaxValue)
+            if (Address == InvalidAddress)
             {
                 return $"[Unmapped 0x{Size:X}]";
             }

--- a/src/Ryujinx.Memory/Range/MultiRangeList.cs
+++ b/src/Ryujinx.Memory/Range/MultiRangeList.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.Memory.Range
             {
                 var subrange = range.GetSubRange(i);
 
-                if (IsInvalid(ref subrange))
+                if (MemoryRange.IsInvalid(ref subrange))
                 {
                     continue;
                 }
@@ -56,7 +56,7 @@ namespace Ryujinx.Memory.Range
             {
                 var subrange = range.GetSubRange(i);
 
-                if (IsInvalid(ref subrange))
+                if (MemoryRange.IsInvalid(ref subrange))
                 {
                     continue;
                 }
@@ -99,7 +99,7 @@ namespace Ryujinx.Memory.Range
             {
                 var subrange = range.GetSubRange(i);
 
-                if (IsInvalid(ref subrange))
+                if (MemoryRange.IsInvalid(ref subrange))
                 {
                     continue;
                 }
@@ -140,17 +140,6 @@ namespace Ryujinx.Memory.Range
             }
 
             return overlapCount;
-        }
-
-        /// <summary>
-        /// Checks if a given sub-range of memory is invalid.
-        /// Those are used to represent unmapped memory regions (holes in the region mapping).
-        /// </summary>
-        /// <param name="subRange">Memory range to checl</param>
-        /// <returns>True if the memory range is considered invalid, false otherwise</returns>
-        private static bool IsInvalid(ref MemoryRange subRange)
-        {
-            return subRange.Address == ulong.MaxValue;
         }
 
         /// <summary>


### PR DESCRIPTION
When we get the address to find overlaps for a texture with unmapped start, we use the address of the first region that is mapped. This is done because otherwise, *all* textures with unmapped start would be considered a same address overlap (which is bad for performance if the game has a lot of them). The problem is that `IMultiRangeItem.BaseAddress` was not doing the same, so it would return the special all bits one value that is used for unmapped regions, and the `MultiRangeList<T>.FindOverlaps` check `if (output[i].BaseAddress == baseAddress)` would consider them different. The end result is that every time it tries to find a texture with unmapped start, it would not be able to find an exact match and would create a new view.

A side effect of the problem above is that an exception would be thrown on `AutoDeleteCache.AddShortCache`, because it assumes the same `TextureDescriptor` would always be "tied" to the same `Texture` object. Due to the bug above, this is not the case (it creates another view for the same `TextureDescriptor`), and when it is added to the short cache, it breaks because the key already exists in the dictionary.

This fixes the remaining issue on The Legend of Heroes: Kuro no Kiseki II (which as far as I can tell, is playable with this change, but I didn't really test it very far).
![image](https://github.com/user-attachments/assets/459de078-1429-4847-9d63-4cbe2ceaac08)
