### PR TITLE
Fix FileNotFoundException in TryGetApplicationsFromFile() and improve loading applications

### DIFF
--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -537,10 +537,18 @@ namespace Ryujinx.UI.App.Common
                             }
 
                             var fileInfo = new FileInfo(app);
-                            var fullPath = fileInfo.ResolveLinkTarget(true)?.FullName ?? fileInfo.FullName;
 
-                            applicationPaths.Add(fullPath);
-                            numApplicationsFound++;
+                            try
+                            {
+                                var fullPath = fileInfo.ResolveLinkTarget(true)?.FullName ?? fileInfo.FullName;
+
+                                applicationPaths.Add(fullPath);
+                                numApplicationsFound++;
+                            }
+                            catch (IOException exception)
+                            {
+                                Logger.Warning?.Print(LogClass.Application, $"Failed to resolve the full path to file: \"{app}\" Error: {exception}");
+                            }
                         }
                     }
                     catch (UnauthorizedAccessException)

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -266,8 +266,18 @@ namespace Ryujinx.UI.App.Common
         public bool TryGetApplicationsFromFile(string applicationPath, out List<ApplicationData> applications)
         {
             applications = [];
+            long fileSize;
 
-            long fileSize = new FileInfo(applicationPath).Length;
+            try
+            {
+                fileSize = new FileInfo(applicationPath).Length;
+            }
+            catch (FileNotFoundException)
+            {
+                Logger.Warning?.Print(LogClass.Application, $"The file was not found: '{applicationPath}'");
+
+                return false;
+            }
 
             BlitStruct<ApplicationControlProperty> controlHolder = new(1);
 

--- a/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationLibrary.cs
@@ -502,7 +502,13 @@ namespace Ryujinx.UI.App.Common
 
                     try
                     {
-                        IEnumerable<string> files = Directory.EnumerateFiles(appDir, "*", SearchOption.AllDirectories).Where(file =>
+                        EnumerationOptions options = new()
+                        {
+                            RecurseSubdirectories = true,
+                            IgnoreInaccessible = false,
+                        };
+
+                        IEnumerable<string> files = Directory.EnumerateFiles(appDir, "*", options).Where(file =>
                         {
                             return
                             (Path.GetExtension(file).ToLower() is ".nsp" && ConfigurationState.Instance.UI.ShownFileTypes.NSP.Value) ||
@@ -521,14 +527,10 @@ namespace Ryujinx.UI.App.Common
                             }
 
                             var fileInfo = new FileInfo(app);
-                            string extension = fileInfo.Extension.ToLower();
+                            var fullPath = fileInfo.ResolveLinkTarget(true)?.FullName ?? fileInfo.FullName;
 
-                            if (!fileInfo.Attributes.HasFlag(FileAttributes.Hidden) && extension is ".nsp" or ".pfs0" or ".xci" or ".nca" or ".nro" or ".nso")
-                            {
-                                var fullPath = fileInfo.ResolveLinkTarget(true)?.FullName ?? fileInfo.FullName;
-                                applicationPaths.Add(fullPath);
-                                numApplicationsFound++;
-                            }
+                            applicationPaths.Add(fullPath);
+                            numApplicationsFound++;
                         }
                     }
                     catch (UnauthorizedAccessException)


### PR DESCRIPTION
There is actually one person that managed to crash in `TryGetApplicationsFromFile()` even after the latest fix, so I guess we didn't actually catch every exception yet (https://github.com/Ryujinx/Ryujinx/pull/7046#issuecomment-2237597083).

This PR fixes the `FileNotFoundException` that occurs if we try to get the length of a directory or a non-existent file.

Additionally the log with that crash also showed that Ryujinx was trying to load games in a `.git` subdirectory, which is not ideal.
This was also addressed here, by using `EnumerationOptions` instead of `SearchOptions` for `Directory.EnumerateFiles()`.
The default options already exclude hidden and system files/dirs, so I only needed to adjust the remaining properties with the values from the old `SearchOptions`.

---

Log from the affected person: [Ryujinx_1.1.1350_2024-07-31_02-33-38.log](https://github.com/user-attachments/files/16462396/Ryujinx_1.1.1350_2024-07-31_02-33-38.log)
