### PR TITLE
fix:HLE/ModLoader: Cheat loading crashes if the content directory doesn't exist

### DIFF
--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -741,6 +741,11 @@ namespace Ryujinx.HLE.HOS
         internal static void EnableCheats(ulong applicationId, TamperMachine tamperMachine)
         {
             var contentDirectory = FindApplicationDir(new DirectoryInfo(Path.Combine(GetModsBasePath(), AmsContentsDir)), $"{applicationId:x16}");
+            if (contentDirectory == null)
+            {
+                return;
+            }
+
             string enabledCheatsPath = Path.Combine(contentDirectory.FullName, CheatDir, "enabled.txt");
 
             if (File.Exists(enabledCheatsPath))


### PR DESCRIPTION
I think this was happening because a game has mods but no cheats
OR
I opened edit cheats and closed without performing any operation
OR
A combination of both