### PR TITLE
Fix NRE when using image array from constant buffer

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/ImageArray.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ImageArray.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             _cachedCommandBufferIndex = -1;
             _storages = null;
-            SetDirty(_gd);
+            SetDirty(_gd, isImage: true);
         }
 
         public void QueueWriteToReadBarriers(CommandBufferScoped cbs, PipelineStageFlags stageFlags)

--- a/src/Ryujinx.Graphics.Vulkan/ResourceArray.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ResourceArray.cs
@@ -14,13 +14,20 @@ namespace Ryujinx.Graphics.Vulkan
 
         private int _bindCount;
 
-        protected void SetDirty(VulkanRenderer gd)
+        protected void SetDirty(VulkanRenderer gd, bool isImage)
         {
             ReleaseDescriptorSet();
 
             if (_bindCount != 0)
             {
-                gd.PipelineInternal.ForceTextureDirty();
+                if (isImage)
+                {
+                    gd.PipelineInternal.ForceImageDirty();
+                }
+                else
+                {
+                    gd.PipelineInternal.ForceTextureDirty();
+                }
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/TextureArray.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureArray.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             _cachedCommandBufferIndex = -1;
             _storages = null;
-            SetDirty(_gd);
+            SetDirty(_gd, isImage: false);
         }
 
         public void QueueWriteToReadBarriers(CommandBufferScoped cbs, PipelineStageFlags stageFlags)


### PR DESCRIPTION
Storage images does not use a sampler, so we pass a null sampler pool for those. However, some functions did not expect to receive a null sampler pool. This changes updates those functions to work with null sampler pool. This also fixes an issue on the Vulkan backend where image arrays bindings would not be dirtied if one of the image array textures change.

This fixes a crash on World of Goo 2, but the game still does not work due to a corrupt compute shader.