### PR TITLE
Vulkan: Feedback loop detection and barriers

### DIFF
--- a/src/Ryujinx.Common/GraphicsDriver/DriverUtilities.cs
+++ b/src/Ryujinx.Common/GraphicsDriver/DriverUtilities.cs
@@ -1,13 +1,33 @@
+using Ryujinx.Common.Utilities;
 using System;
 
 namespace Ryujinx.Common.GraphicsDriver
 {
     public static class DriverUtilities
     {
+        private static void AddMesaFlags(string envVar, string newFlags)
+        {
+            string existingFlags = Environment.GetEnvironmentVariable(envVar);
+
+            string flags = existingFlags == null ? newFlags : $"{existingFlags},{newFlags}";
+
+            OsUtils.SetEnvironmentVariableNoCaching(envVar, flags);
+        }
+
+        public static void InitDriverConfig(bool oglThreading)
+        {
+            if (OperatingSystem.IsLinux())
+            {
+                AddMesaFlags("RADV_DEBUG", "nodcc");
+            }
+
+            ToggleOGLThreading(oglThreading);
+        }
+
         public static void ToggleOGLThreading(bool enabled)
         {
-            Environment.SetEnvironmentVariable("mesa_glthread", enabled.ToString().ToLower());
-            Environment.SetEnvironmentVariable("__GL_THREADED_OPTIMIZATIONS", enabled ? "1" : "0");
+            OsUtils.SetEnvironmentVariableNoCaching("mesa_glthread", enabled.ToString().ToLower());
+            OsUtils.SetEnvironmentVariableNoCaching("__GL_THREADED_OPTIMIZATIONS", enabled ? "1" : "0");
 
             try
             {

--- a/src/Ryujinx.Common/Utilities/OsUtils.cs
+++ b/src/Ryujinx.Common/Utilities/OsUtils.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Common.Utilities
+{
+    public partial class OsUtils
+    {
+        [LibraryImport("libc", SetLastError = true)]
+        private static partial int setenv([MarshalAs(UnmanagedType.LPStr)] string name, [MarshalAs(UnmanagedType.LPStr)] string value, int overwrite);
+
+        public static void SetEnvironmentVariableNoCaching(string key, string value)
+        {
+            // Set the value in the cached environment variables, too.
+            Environment.SetEnvironmentVariable(key, value);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                int res = setenv(key, value, 1);
+                Debug.Assert(res != -1);
+            }
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
@@ -32,10 +32,12 @@ namespace Ryujinx.Graphics.Vulkan
             CommandBuffer
         }
 
+        private bool _feedbackLoopActive;
         private PipelineStageFlags _incoherentBufferWriteStages;
         private PipelineStageFlags _incoherentTextureWriteStages;
         private PipelineStageFlags _extraStages;
         private IncoherentBarrierType _queuedIncoherentBarrier;
+        private bool _queuedFeedbackLoopBarrier;
 
         public BarrierBatch(VulkanRenderer gd)
         {
@@ -56,12 +58,15 @@ namespace Ryujinx.Graphics.Vulkan
             if (!gd.IsTBDR)
             {
                 // Desktop GPUs can transform image barriers into memory barriers.
+                // ...but these cause VUID-VkSubpassDependency-srcSubpass-06809
 
+                /*
                 access |= AccessFlags.DepthStencilAttachmentWriteBit | AccessFlags.ColorAttachmentWriteBit;
                 access |= AccessFlags.DepthStencilAttachmentReadBit | AccessFlags.ColorAttachmentReadBit;
 
                 stages |= PipelineStageFlags.EarlyFragmentTestsBit | PipelineStageFlags.LateFragmentTestsBit;
                 stages |= PipelineStageFlags.ColorAttachmentOutputBit;
+                */
             }
 
             return (access, stages);
@@ -178,22 +183,42 @@ namespace Ryujinx.Graphics.Vulkan
                     }
 
                     _queuedIncoherentBarrier = IncoherentBarrierType.None;
+                    _queuedFeedbackLoopBarrier = false;
                 }
+                else if (_feedbackLoopActive && _queuedFeedbackLoopBarrier)
+                {
+                    // Feedback loop barrier.
+
+                    MemoryBarrier barrier = new MemoryBarrier()
+                    {
+                        SType = StructureType.MemoryBarrier,
+                        SrcAccessMask = AccessFlags.ShaderWriteBit,
+                        DstAccessMask = AccessFlags.ShaderReadBit
+                    };
+
+                    QueueBarrier(barrier, PipelineStageFlags.FragmentShaderBit, PipelineStageFlags.AllGraphicsBit);
+
+                    _queuedFeedbackLoopBarrier = false;
+                }
+
+                _feedbackLoopActive = false;
             }
         }
 
         public unsafe void Flush(CommandBufferScoped cbs, bool inRenderPass, RenderPassHolder rpHolder, Action endRenderPass)
         {
-            Flush(cbs, null, inRenderPass, rpHolder, endRenderPass);
+            Flush(cbs, null, false, inRenderPass, rpHolder, endRenderPass);
         }
 
-        public unsafe void Flush(CommandBufferScoped cbs, ShaderCollection program, bool inRenderPass, RenderPassHolder rpHolder, Action endRenderPass)
+        public unsafe void Flush(CommandBufferScoped cbs, ShaderCollection program, bool feedbackLoopActive, bool inRenderPass, RenderPassHolder rpHolder, Action endRenderPass)
         {
             if (program != null)
             {
                 _incoherentBufferWriteStages |= program.IncoherentBufferWriteStages | _extraStages;
                 _incoherentTextureWriteStages |= program.IncoherentTextureWriteStages;
             }
+
+            _feedbackLoopActive |= feedbackLoopActive;
 
             FlushMemoryBarrier(program, inRenderPass);
 
@@ -406,6 +431,8 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 _queuedIncoherentBarrier = type;
             }
+
+            _queuedFeedbackLoopBarrier = true;
         }
 
         public void QueueTextureBarrier()

--- a/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BarrierBatch.cs
@@ -55,20 +55,6 @@ namespace Ryujinx.Graphics.Vulkan
                 stages |= PipelineStageFlags.TransformFeedbackBitExt;
             }
 
-            if (!gd.IsTBDR)
-            {
-                // Desktop GPUs can transform image barriers into memory barriers.
-                // ...but these cause VUID-VkSubpassDependency-srcSubpass-06809
-
-                /*
-                access |= AccessFlags.DepthStencilAttachmentWriteBit | AccessFlags.ColorAttachmentWriteBit;
-                access |= AccessFlags.DepthStencilAttachmentReadBit | AccessFlags.ColorAttachmentReadBit;
-
-                stages |= PipelineStageFlags.EarlyFragmentTestsBit | PipelineStageFlags.LateFragmentTestsBit;
-                stages |= PipelineStageFlags.ColorAttachmentOutputBit;
-                */
-            }
-
             return (access, stages);
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/FeedbackLoopAspects.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FeedbackLoopAspects.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    [Flags]
+    internal enum FeedbackLoopAspects
+    {
+        None = 0,
+        Color = 1 << 0,
+        Depth = 1 << 1,
+    }
+}

--- a/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -302,6 +302,27 @@ namespace Ryujinx.Graphics.Vulkan
             _depthStencil?.Storage?.AddStoreOpUsage(true);
         }
 
+        public void ClearBindings()
+        {
+            _depthStencil?.Storage.ClearBindings();
+
+            for (int i = 0; i < _colorsCanonical.Length; i++)
+            {
+                _colorsCanonical[i]?.Storage.ClearBindings();
+            }
+        }
+
+        public void AddBindings()
+        {
+            _depthStencil?.Storage.AddBinding(_depthStencil);
+
+            for (int i = 0; i < _colorsCanonical.Length; i++)
+            {
+                TextureView color = _colorsCanonical[i];
+                color?.Storage.AddBinding(color);
+            }
+        }
+
         public (RenderPassHolder rpHolder, Auto<DisposableFramebuffer> framebuffer) GetPassAndFramebuffer(
             VulkanRenderer gd,
             Device device,

--- a/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -47,6 +47,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly bool SupportsHostImportedMemory;
         public readonly bool SupportsDepthClipControl;
         public readonly bool SupportsAttachmentFeedbackLoop;
+        public readonly bool SupportsDynamicAttachmentFeedbackLoop;
         public readonly uint SubgroupSize;
         public readonly SampleCountFlags SupportedSampleCounts;
         public readonly PortabilitySubsetFlags PortabilitySubset;
@@ -86,6 +87,7 @@ namespace Ryujinx.Graphics.Vulkan
             bool supportsHostImportedMemory,
             bool supportsDepthClipControl,
             bool supportsAttachmentFeedbackLoop,
+            bool supportsDynamicAttachmentFeedbackLoop,
             uint subgroupSize,
             SampleCountFlags supportedSampleCounts,
             PortabilitySubsetFlags portabilitySubset,

--- a/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -46,6 +46,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly bool SupportsViewportArray2;
         public readonly bool SupportsHostImportedMemory;
         public readonly bool SupportsDepthClipControl;
+        public readonly bool SupportsAttachmentFeedbackLoop;
         public readonly uint SubgroupSize;
         public readonly SampleCountFlags SupportedSampleCounts;
         public readonly PortabilitySubsetFlags PortabilitySubset;
@@ -84,6 +85,7 @@ namespace Ryujinx.Graphics.Vulkan
             bool supportsViewportArray2,
             bool supportsHostImportedMemory,
             bool supportsDepthClipControl,
+            bool supportsAttachmentFeedbackLoop,
             uint subgroupSize,
             SampleCountFlags supportedSampleCounts,
             PortabilitySubsetFlags portabilitySubset,
@@ -121,6 +123,7 @@ namespace Ryujinx.Graphics.Vulkan
             SupportsViewportArray2 = supportsViewportArray2;
             SupportsHostImportedMemory = supportsHostImportedMemory;
             SupportsDepthClipControl = supportsDepthClipControl;
+            SupportsAttachmentFeedbackLoop = supportsAttachmentFeedbackLoop;
             SubgroupSize = subgroupSize;
             SupportedSampleCounts = supportedSampleCounts;
             PortabilitySubset = portabilitySubset;

--- a/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -126,6 +126,7 @@ namespace Ryujinx.Graphics.Vulkan
             SupportsHostImportedMemory = supportsHostImportedMemory;
             SupportsDepthClipControl = supportsDepthClipControl;
             SupportsAttachmentFeedbackLoop = supportsAttachmentFeedbackLoop;
+            SupportsDynamicAttachmentFeedbackLoop = supportsDynamicAttachmentFeedbackLoop;
             SubgroupSize = subgroupSize;
             SupportedSampleCounts = supportedSampleCounts;
             PortabilitySubset = portabilitySubset;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -2,6 +2,7 @@ using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Shader;
 using Silk.NET.Vulkan;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -33,6 +34,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly Action EndRenderPassDelegate;
 
         protected PipelineDynamicState DynamicState;
+        protected bool IsMainPipeline;
         private PipelineState _newState;
         private bool _graphicsStateDirty;
         private bool _computeStateDirty;
@@ -85,6 +87,16 @@ namespace Ryujinx.Graphics.Vulkan
         private bool _tfEnabled;
         private bool _tfActive;
 
+        [Flags]
+        private enum FeedbackLoopAspects
+        {
+            Color = 1 << 0,
+            Depth = 1 << 1,
+        };
+
+        private FeedbackLoopAspects _feedbackLoop;
+        private bool _passWritesDepthStencil;
+
         private readonly PipelineColorBlendAttachmentState[] _storedBlend;
         public ulong DrawCount { get; private set; }
         public bool RenderPassActive { get; private set; }
@@ -126,7 +138,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Initialize()
         {
-            _descriptorSetUpdater.Initialize();
+            _descriptorSetUpdater.Initialize(IsMainPipeline);
 
             QuadsToTrisPattern = new IndexBufferPattern(Gd, 4, 6, 0, new[] { 0, 1, 2, 0, 2, 3 }, 4, false);
             TriFanToTrisPattern = new IndexBufferPattern(Gd, 3, 3, 2, new[] { int.MinValue, -1, 0 }, 1, true);
@@ -814,6 +826,8 @@ namespace Ryujinx.Graphics.Vulkan
             _newState.DepthTestEnable = depthTest.TestEnable;
             _newState.DepthWriteEnable = depthTest.WriteEnable;
             _newState.DepthCompareOp = depthTest.Func.Convert();
+
+            UpdatePassDepthStencil();
             SignalStateChange();
         }
 
@@ -1079,6 +1093,8 @@ namespace Ryujinx.Graphics.Vulkan
             _newState.StencilFrontPassOp = stencilTest.FrontDpPass.Convert();
             _newState.StencilFrontDepthFailOp = stencilTest.FrontDpFail.Convert();
             _newState.StencilFrontCompareOp = stencilTest.FrontFunc.Convert();
+
+            UpdatePassDepthStencil();
             SignalStateChange();
         }
 
@@ -1426,7 +1442,24 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
+            if (IsMainPipeline)
+            {
+                FramebufferParams?.ClearBindings();
+            }
+
             FramebufferParams = new FramebufferParams(Device, colors, depthStencil);
+
+            if (IsMainPipeline)
+            {
+                FramebufferParams.AddBindings();
+
+                _newState.FeedbackLoopColor = false;
+                _newState.FeedbackLoopDepth = false;
+                _bindingBarriersDirty = true;
+            }
+
+            _passWritesDepthStencil = false;
+            UpdatePassDepthStencil();
             UpdatePipelineAttachmentFormats();
         }
 
@@ -1493,9 +1526,73 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            Gd.Barriers.Flush(Cbs, _program, RenderPassActive, _rpHolder, EndRenderPassDelegate);
+            Gd.Barriers.Flush(Cbs, _program, _feedbackLoop != 0, RenderPassActive, _rpHolder, EndRenderPassDelegate);
 
             _descriptorSetUpdater.UpdateAndBindDescriptorSets(Cbs, PipelineBindPoint.Compute);
+        }
+
+        private bool ChangeFeedbackLoop(FeedbackLoopAspects aspects)
+        {
+            if (_feedbackLoop != aspects)
+            {
+                _newState.FeedbackLoopColor = (aspects & FeedbackLoopAspects.Color) != 0;
+                _newState.FeedbackLoopDepth = (aspects & FeedbackLoopAspects.Depth) != 0;
+
+                _feedbackLoop = aspects;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool UpdateFeedbackLoop()
+        {
+            List<TextureView> hazards = _descriptorSetUpdater.FeedbackLoopHazards;
+
+            if ((hazards?.Count ?? 0) > 0)
+            {
+                FeedbackLoopAspects aspects = 0;
+
+                foreach (TextureView view in hazards)
+                {
+                    // TODO: enforce layout
+
+                    if (view.Info.Format.IsDepthOrStencil())
+                    {
+                        if (_passWritesDepthStencil)
+                        {
+                            // If depth/stencil isn't written in the pass, it doesn't count as a feedback loop.
+
+                            aspects |= FeedbackLoopAspects.Depth;
+                        }
+                    }
+                    else
+                    {
+                        aspects |= FeedbackLoopAspects.Color;
+                    }
+                }
+
+                return ChangeFeedbackLoop(aspects);
+            }
+            else if (_feedbackLoop != 0)
+            {
+                return ChangeFeedbackLoop(0);
+            }
+
+            return false;
+        }
+
+        private void UpdatePassDepthStencil()
+        {
+            if (!RenderPassActive)
+            {
+                _passWritesDepthStencil = false;
+            }
+
+            // Stencil test being enabled doesn't necessarily mean a write, but it's not critical to check.
+            _passWritesDepthStencil |= (_newState.DepthTestEnable && _newState.DepthWriteEnable) || _newState.StencilTestEnable;
         }
 
         private bool RecreateGraphicsPipelineIfNeeded()
@@ -1539,7 +1636,15 @@ namespace Ryujinx.Graphics.Vulkan
                 _vertexBufferUpdater.Commit(Cbs);
             }
 
-            if (_graphicsStateDirty || Pbp != PipelineBindPoint.Graphics)
+            if (_bindingBarriersDirty)
+            {
+                // Stale barriers may have been activated by switching program. Emit any that are relevant.
+                _descriptorSetUpdater.InsertBindingBarriers(Cbs);
+
+                _bindingBarriersDirty = false;
+            }
+
+            if (UpdateFeedbackLoop() || _graphicsStateDirty || Pbp != PipelineBindPoint.Graphics)
             {
                 if (!CreatePipeline(PipelineBindPoint.Graphics))
                 {
@@ -1548,17 +1653,9 @@ namespace Ryujinx.Graphics.Vulkan
 
                 _graphicsStateDirty = false;
                 Pbp = PipelineBindPoint.Graphics;
-
-                if (_bindingBarriersDirty)
-                {
-                    // Stale barriers may have been activated by switching program. Emit any that are relevant.
-                    _descriptorSetUpdater.InsertBindingBarriers(Cbs);
-
-                    _bindingBarriersDirty = false;
-                }
             }
 
-            Gd.Barriers.Flush(Cbs, _program, RenderPassActive, _rpHolder, EndRenderPassDelegate);
+            Gd.Barriers.Flush(Cbs, _program, _feedbackLoop != 0, RenderPassActive, _rpHolder, EndRenderPassDelegate);
 
             _descriptorSetUpdater.UpdateAndBindDescriptorSets(Cbs, PipelineBindPoint.Graphics);
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1535,8 +1535,17 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_feedbackLoop != aspects)
             {
-                _newState.FeedbackLoopColor = (aspects & FeedbackLoopAspects.Color) != 0;
-                _newState.FeedbackLoopDepth = (aspects & FeedbackLoopAspects.Depth) != 0;
+                if (Gd.Capabilities.SupportsDynamicAttachmentFeedbackLoop)
+                {
+                    DynamicState.SetFeedbackLoop(
+                        (aspects & FeedbackLoopAspects.Color) != 0,
+                        (aspects & FeedbackLoopAspects.Depth) != 0);
+                }
+                else
+                {
+                    _newState.FeedbackLoopColor = (aspects & FeedbackLoopAspects.Color) != 0;
+                    _newState.FeedbackLoopDepth = (aspects & FeedbackLoopAspects.Depth) != 0;
+                }
 
                 _feedbackLoop = aspects;
 
@@ -1602,7 +1611,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Gd.FlushAllCommands();
             }
 
-            DynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
+            DynamicState.ReplayIfDirty(Gd, CommandBuffer);
 
             if (_needsIndexBufferRebind && _indexBufferPattern == null)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1566,7 +1566,8 @@ namespace Ryujinx.Graphics.Vulkan
 
                 foreach (TextureView view in hazards)
                 {
-                    // TODO: enforce layout
+                    // May need to enforce feedback loop layout here in the future.
+                    // Though technically, it should always work with the general layout.
 
                     if (view.Info.Format.IsDepthOrStencil())
                     {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -87,13 +87,6 @@ namespace Ryujinx.Graphics.Vulkan
         private bool _tfEnabled;
         private bool _tfActive;
 
-        [Flags]
-        private enum FeedbackLoopAspects
-        {
-            Color = 1 << 0,
-            Depth = 1 << 1,
-        };
-
         private FeedbackLoopAspects _feedbackLoop;
         private bool _passWritesDepthStencil;
 
@@ -1453,8 +1446,7 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 FramebufferParams.AddBindings();
 
-                _newState.FeedbackLoopColor = false;
-                _newState.FeedbackLoopDepth = false;
+                _newState.FeedbackLoopAspects = FeedbackLoopAspects.None;
                 _bindingBarriersDirty = true;
             }
 
@@ -1537,14 +1529,11 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 if (Gd.Capabilities.SupportsDynamicAttachmentFeedbackLoop)
                 {
-                    DynamicState.SetFeedbackLoop(
-                        (aspects & FeedbackLoopAspects.Color) != 0,
-                        (aspects & FeedbackLoopAspects.Depth) != 0);
+                    DynamicState.SetFeedbackLoop(aspects);
                 }
                 else
                 {
-                    _newState.FeedbackLoopColor = (aspects & FeedbackLoopAspects.Color) != 0;
-                    _newState.FeedbackLoopDepth = (aspects & FeedbackLoopAspects.Depth) != 0;
+                    _newState.FeedbackLoopAspects = aspects;
                 }
 
                 _feedbackLoop = aspects;
@@ -1588,7 +1577,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
             else if (_feedbackLoop != 0)
             {
-                return ChangeFeedbackLoop(0);
+                return ChangeFeedbackLoop(FeedbackLoopAspects.None);
             }
 
             return false;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Common.Memory;
 using Silk.NET.Vulkan;
+using Silk.NET.Vulkan.Extensions.EXT;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -21,6 +22,9 @@ namespace Ryujinx.Graphics.Vulkan
 
         private Array4<float> _blendConstants;
 
+        private bool _feedbackLoopColor;
+        private bool _feedbackLoopDepth;
+
         public uint ViewportsCount;
         public Array16<Viewport> Viewports;
 
@@ -32,7 +36,8 @@ namespace Ryujinx.Graphics.Vulkan
             Scissor = 1 << 2,
             Stencil = 1 << 3,
             Viewport = 1 << 4,
-            All = Blend | DepthBias | Scissor | Stencil | Viewport,
+            FeedbackLoop = 1 << 5,
+            All = Blend | DepthBias | Scissor | Stencil | Viewport | FeedbackLoop,
         }
 
         private DirtyFlags _dirty;
@@ -99,13 +104,23 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        public void SetFeedbackLoop(bool color, bool depth)
+        {
+            _feedbackLoopColor = color;
+            _feedbackLoopDepth = depth;
+
+            _dirty |= DirtyFlags.FeedbackLoop;
+        }
+
         public void ForceAllDirty()
         {
             _dirty = DirtyFlags.All;
         }
 
-        public void ReplayIfDirty(Vk api, CommandBuffer commandBuffer)
+        public void ReplayIfDirty(VulkanRenderer gd, CommandBuffer commandBuffer)
         {
+            Vk api = gd.Api;
+
             if (_dirty.HasFlag(DirtyFlags.Blend))
             {
                 RecordBlend(api, commandBuffer);
@@ -129,6 +144,11 @@ namespace Ryujinx.Graphics.Vulkan
             if (_dirty.HasFlag(DirtyFlags.Viewport))
             {
                 RecordViewport(api, commandBuffer);
+            }
+
+            if (_dirty.HasFlag(DirtyFlags.FeedbackLoop) && gd.Capabilities.SupportsDynamicAttachmentFeedbackLoop)
+            {
+                RecordFeedbackLoop(gd.DynamicFeedbackLoopApi, commandBuffer);
             }
 
             _dirty = DirtyFlags.None;
@@ -168,6 +188,18 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 api.CmdSetViewport(commandBuffer, 0, ViewportsCount, Viewports.AsSpan());
             }
+        }
+
+        private void RecordFeedbackLoop(ExtAttachmentFeedbackLoopDynamicState api, CommandBuffer commandBuffer)
+        {
+            ImageAspectFlags aspects = _feedbackLoopColor ? ImageAspectFlags.ColorBit : 0;
+
+            if (_feedbackLoopDepth)
+            {
+                aspects |= ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
+            }
+
+            api.CmdSetAttachmentFeedbackLoopEnable(commandBuffer, aspects);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
@@ -22,8 +22,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private Array4<float> _blendConstants;
 
-        private bool _feedbackLoopColor;
-        private bool _feedbackLoopDepth;
+        private FeedbackLoopAspects _feedbackLoopAspects;
 
         public uint ViewportsCount;
         public Array16<Viewport> Viewports;
@@ -104,10 +103,9 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public void SetFeedbackLoop(bool color, bool depth)
+        public void SetFeedbackLoop(FeedbackLoopAspects aspects)
         {
-            _feedbackLoopColor = color;
-            _feedbackLoopDepth = depth;
+            _feedbackLoopAspects = aspects;
 
             _dirty |= DirtyFlags.FeedbackLoop;
         }
@@ -192,9 +190,9 @@ namespace Ryujinx.Graphics.Vulkan
 
         private readonly void RecordFeedbackLoop(ExtAttachmentFeedbackLoopDynamicState api, CommandBuffer commandBuffer)
         {
-            ImageAspectFlags aspects = _feedbackLoopColor ? ImageAspectFlags.ColorBit : 0;
+            ImageAspectFlags aspects = (_feedbackLoopAspects & FeedbackLoopAspects.Color) != 0 ? ImageAspectFlags.ColorBit : 0;
 
-            if (_feedbackLoopDepth)
+            if ((_feedbackLoopAspects & FeedbackLoopAspects.Depth) != 0)
             {
                 aspects |= ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
             }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
@@ -190,7 +190,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        private void RecordFeedbackLoop(ExtAttachmentFeedbackLoopDynamicState api, CommandBuffer commandBuffer)
+        private readonly void RecordFeedbackLoop(ExtAttachmentFeedbackLoopDynamicState api, CommandBuffer commandBuffer)
         {
             ImageAspectFlags aspects = _feedbackLoopColor ? ImageAspectFlags.ColorBit : 0;
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -237,7 +237,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (Pipeline != null && Pbp == PipelineBindPoint.Graphics)
             {
-                DynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
+                DynamicState.ReplayIfDirty(Gd, CommandBuffer);
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -28,6 +28,8 @@ namespace Ryujinx.Graphics.Vulkan
             _activeBufferMirrors = new();
 
             CommandBuffer = (Cbs = gd.CommandBufferPool.Rent()).CommandBuffer;
+
+            IsMainPipeline = true;
         }
 
         private void CopyPendingQuery()

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -299,6 +299,18 @@ namespace Ryujinx.Graphics.Vulkan
             set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFBF) | ((value ? 1UL : 0UL) << 6);
         }
 
+        public bool FeedbackLoopColor
+        {
+            readonly get => ((Internal.Id8 >> 7) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFF7F) | ((value ? 1UL : 0UL) << 7);
+        }
+
+        public bool FeedbackLoopDepth
+        {
+            readonly get => ((Internal.Id8 >> 8) & 0x1) != 0UL;
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFEFF) | ((value ? 1UL : 0UL) << 8);
+        }
+
         public bool HasTessellationControlShader;
         public NativeArray<PipelineShaderStageCreateInfo> Stages;
         public PipelineLayout PipelineLayout;
@@ -588,9 +600,25 @@ namespace Ryujinx.Graphics.Vulkan
                     PDynamicStates = dynamicStates,
                 };
 
+                PipelineCreateFlags flags = 0;
+
+                if (gd.Capabilities.SupportsAttachmentFeedbackLoop)
+                {
+                    if (FeedbackLoopColor)
+                    {
+                        flags |= PipelineCreateFlags.CreateColorAttachmentFeedbackLoopBitExt;
+                    }
+
+                    if (FeedbackLoopDepth)
+                    {
+                        flags |= PipelineCreateFlags.CreateDepthStencilAttachmentFeedbackLoopBitExt;
+                    }
+                }
+
                 var pipelineCreateInfo = new GraphicsPipelineCreateInfo
                 {
                     SType = StructureType.GraphicsPipelineCreateInfo,
+                    Flags = flags,
                     StageCount = StagesCount,
                     PStages = Stages.Pointer,
                     PVertexInputState = &vertexInputState,

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -300,16 +300,10 @@ namespace Ryujinx.Graphics.Vulkan
             set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFFBF) | ((value ? 1UL : 0UL) << 6);
         }
 
-        public bool FeedbackLoopColor
+        public FeedbackLoopAspects FeedbackLoopAspects
         {
-            readonly get => ((Internal.Id8 >> 7) & 0x1) != 0UL;
-            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFF7F) | ((value ? 1UL : 0UL) << 7);
-        }
-
-        public bool FeedbackLoopDepth
-        {
-            readonly get => ((Internal.Id8 >> 8) & 0x1) != 0UL;
-            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFEFF) | ((value ? 1UL : 0UL) << 8);
+            readonly get => (FeedbackLoopAspects)((Internal.Id8 >> 7) & 0x3);
+            set => Internal.Id8 = (Internal.Id8 & 0xFFFFFFFFFFFFFE7F) | (((ulong)value) << 7);
         }
 
         public bool HasTessellationControlShader;
@@ -612,12 +606,14 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (gd.Capabilities.SupportsAttachmentFeedbackLoop)
                 {
-                    if (FeedbackLoopColor)
+                    FeedbackLoopAspects aspects = FeedbackLoopAspects;
+
+                    if ((aspects & FeedbackLoopAspects.Color) != 0)
                     {
                         flags |= PipelineCreateFlags.CreateColorAttachmentFeedbackLoopBitExt;
                     }
 
-                    if (FeedbackLoopDepth)
+                    if ((aspects & FeedbackLoopAspects.Depth) != 0)
                     {
                         flags |= PipelineCreateFlags.CreateDepthStencilAttachmentFeedbackLoopBitExt;
                     }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.Graphics.Vulkan
     struct PipelineState : IDisposable
     {
         private const int RequiredSubgroupSize = 32;
+        private const int MaxDynamicStatesCount = 9;
 
         public PipelineUid Internal;
 
@@ -576,9 +577,11 @@ namespace Ryujinx.Graphics.Vulkan
                 }
 
                 bool supportsExtDynamicState = gd.Capabilities.SupportsExtendedDynamicState;
-                int dynamicStatesCount = supportsExtDynamicState ? 8 : 7;
+                bool supportsFeedbackLoopDynamicState = gd.Capabilities.SupportsDynamicAttachmentFeedbackLoop;
 
-                DynamicState* dynamicStates = stackalloc DynamicState[dynamicStatesCount];
+                DynamicState* dynamicStates = stackalloc DynamicState[MaxDynamicStatesCount];
+
+                int dynamicStatesCount = 7;
 
                 dynamicStates[0] = DynamicState.Viewport;
                 dynamicStates[1] = DynamicState.Scissor;
@@ -590,7 +593,12 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (supportsExtDynamicState)
                 {
-                    dynamicStates[7] = DynamicState.VertexInputBindingStrideExt;
+                    dynamicStates[dynamicStatesCount++] = DynamicState.VertexInputBindingStrideExt;
+                }
+
+                if (supportsFeedbackLoopDynamicState)
+                {
+                    dynamicStates[dynamicStatesCount++] = DynamicState.AttachmentFeedbackLoopEnableExt;
                 }
 
                 var pipelineDynamicStateCreateInfo = new PipelineDynamicStateCreateInfo

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -4,6 +4,7 @@ using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Format = Ryujinx.Graphics.GAL.Format;
 using VkBuffer = Silk.NET.Vulkan.Buffer;
 using VkFormat = Silk.NET.Vulkan.Format;
@@ -12,6 +13,11 @@ namespace Ryujinx.Graphics.Vulkan
 {
     class TextureStorage : IDisposable
     {
+        private struct TextureSliceInfo
+        {
+            public int BindCount;
+        }
+
         private const MemoryPropertyFlags DefaultImageMemoryFlags =
             MemoryPropertyFlags.DeviceLocalBit;
 
@@ -43,6 +49,7 @@ namespace Ryujinx.Graphics.Vulkan
         private readonly Image _image;
         private readonly Auto<DisposableImage> _imageAuto;
         private readonly Auto<MemoryAllocation> _allocationAuto;
+        private readonly int _depthOrLayers;
         private Auto<MemoryAllocation> _foreignAllocationAuto;
 
         private Dictionary<Format, TextureStorage> _aliasedStorages;
@@ -54,6 +61,9 @@ namespace Ryujinx.Graphics.Vulkan
 
         private int _viewsCount;
         private readonly ulong _size;
+
+        private int _bindCount;
+        private TextureSliceInfo[] _slices;
 
         public VkFormat VkFormat { get; }
 
@@ -73,6 +83,7 @@ namespace Ryujinx.Graphics.Vulkan
             var depth = (uint)(info.Target == Target.Texture3D ? info.Depth : 1);
 
             VkFormat = format;
+            _depthOrLayers = info.GetDepthOrLayers();
 
             var type = info.Target.Convert();
 
@@ -80,7 +91,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sampleCountFlags = ConvertToSampleCountFlags(gd.Capabilities.SupportedSampleCounts, (uint)info.Samples);
 
-            var usage = GetImageUsage(info.Format, info.Target, gd.Capabilities.SupportsShaderStorageImageMultisample);
+            var usage = GetImageUsage(info.Format, info.Target, gd.Capabilities);
 
             var flags = ImageCreateFlags.CreateMutableFormatBit | ImageCreateFlags.CreateExtendedUsageBit;
 
@@ -148,6 +159,8 @@ namespace Ryujinx.Graphics.Vulkan
 
                 InitialTransition(ImageLayout.Preinitialized, ImageLayout.General);
             }
+
+            _slices = new TextureSliceInfo[levels * _depthOrLayers];
         }
 
         public TextureStorage CreateAliasedColorForDepthStorageUnsafe(Format format)
@@ -292,7 +305,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        public static ImageUsageFlags GetImageUsage(Format format, Target target, bool supportsMsStorage)
+        public static ImageUsageFlags GetImageUsage(Format format, Target target, in HardwareCapabilities capabilities)
         {
             var usage = DefaultUsageFlags;
 
@@ -305,9 +318,17 @@ namespace Ryujinx.Graphics.Vulkan
                 usage |= ImageUsageFlags.ColorAttachmentBit;
             }
 
+            bool supportsMsStorage = capabilities.SupportsShaderStorageImageMultisample;
+
             if (format.IsImageCompatible() && (supportsMsStorage || !target.IsMultisample()))
             {
                 usage |= ImageUsageFlags.StorageBit;
+            }
+
+            if (capabilities.SupportsAttachmentFeedbackLoop &&
+                (usage & (ImageUsageFlags.DepthStencilAttachmentBit | ImageUsageFlags.ColorAttachmentBit)) != 0)
+            {
+                usage |= ImageUsageFlags.AttachmentFeedbackLoopBitExt;
             }
 
             return usage;
@@ -508,6 +529,55 @@ namespace Ryujinx.Graphics.Vulkan
 
                 _lastModificationAccess = AccessFlags.None;
             }
+        }
+
+        public void AddBinding(TextureView view)
+        {
+            // Assumes a view only has a first level.
+
+            int index = view.FirstLevel * _depthOrLayers + view.FirstLayer;
+            int layers = view.Layers;
+
+            for (int i = 0; i < layers; i++)
+            {
+                ref TextureSliceInfo info = ref _slices[index++];
+
+                info.BindCount++;
+            }
+
+            _bindCount++;
+        }
+
+        public void ClearBindings()
+        {
+            if (_bindCount != 0)
+            {
+                Array.Clear(_slices, 0, _slices.Length);
+
+                _bindCount = 0;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsBound(TextureView view)
+        {
+            if (_bindCount != 0)
+            {
+                int index = view.FirstLevel * _depthOrLayers + view.FirstLayer;
+                int layers = view.Layers;
+
+                for (int i = 0; i < layers; i++)
+                {
+                    ref TextureSliceInfo info = ref _slices[index++];
+
+                    if (info.BindCount != 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         public void IncrementViewsCount()

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.Graphics.Vulkan
         private readonly ulong _size;
 
         private int _bindCount;
-        private TextureSliceInfo[] _slices;
+        private readonly TextureSliceInfo[] _slices;
 
         public VkFormat VkFormat { get; }
 

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -369,6 +369,17 @@ namespace Ryujinx.Graphics.Vulkan
                 features2.PNext = &supportedFeaturesAttachmentFeedbackLoopLayout;
             }
 
+            PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT supportedFeaturesDynamicAttachmentFeedbackLoopLayout = new()
+            {
+                SType = StructureType.PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesExt,
+                PNext = features2.PNext,
+            };
+
+            if (physicalDevice.IsDeviceExtensionPresent("VK_EXT_attachment_feedback_loop_dynamic_state"))
+            {
+                features2.PNext = &supportedFeaturesDynamicAttachmentFeedbackLoopLayout;
+            }
+
             PhysicalDeviceVulkan12Features supportedPhysicalDeviceVulkan12Features = new()
             {
                 SType = StructureType.PhysicalDeviceVulkan12Features,
@@ -556,6 +567,21 @@ namespace Ryujinx.Graphics.Vulkan
                 };
 
                 pExtendedFeatures = &featuresAttachmentFeedbackLoopLayout;
+            }
+
+            PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT featuresDynamicAttachmentFeedbackLoopLayout;
+
+            if (physicalDevice.IsDeviceExtensionPresent("VK_EXT_attachment_feedback_loop_dynamic_state") &&
+                supportedFeaturesDynamicAttachmentFeedbackLoopLayout.AttachmentFeedbackLoopDynamicState)
+            {
+                featuresDynamicAttachmentFeedbackLoopLayout = new()
+                {
+                    SType = StructureType.PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesExt,
+                    PNext = pExtendedFeatures,
+                    AttachmentFeedbackLoopDynamicState = true,
+                };
+
+                pExtendedFeatures = &featuresDynamicAttachmentFeedbackLoopLayout;
             }
 
             var enabledExtensions = _requiredExtensions.Union(_desirableExtensions.Intersect(physicalDevice.DeviceExtensions)).ToArray();

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -45,6 +45,7 @@ namespace Ryujinx.Graphics.Vulkan
             "VK_KHR_8bit_storage",
             "VK_KHR_maintenance2",
             "VK_EXT_attachment_feedback_loop_layout",
+            "VK_EXT_attachment_feedback_loop_dynamic_state",
         };
 
         private static readonly string[] _requiredExtensions = {

--- a/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -44,6 +44,7 @@ namespace Ryujinx.Graphics.Vulkan
             "VK_EXT_4444_formats",
             "VK_KHR_8bit_storage",
             "VK_KHR_maintenance2",
+            "VK_EXT_attachment_feedback_loop_layout",
         };
 
         private static readonly string[] _requiredExtensions = {
@@ -357,6 +358,17 @@ namespace Ryujinx.Graphics.Vulkan
                 features2.PNext = &supportedFeaturesDepthClipControl;
             }
 
+            PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT supportedFeaturesAttachmentFeedbackLoopLayout = new()
+            {
+                SType = StructureType.PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesExt,
+                PNext = features2.PNext,
+            };
+
+            if (physicalDevice.IsDeviceExtensionPresent("VK_EXT_attachment_feedback_loop_layout"))
+            {
+                features2.PNext = &supportedFeaturesAttachmentFeedbackLoopLayout;
+            }
+
             PhysicalDeviceVulkan12Features supportedPhysicalDeviceVulkan12Features = new()
             {
                 SType = StructureType.PhysicalDeviceVulkan12Features,
@@ -529,6 +541,21 @@ namespace Ryujinx.Graphics.Vulkan
                 };
 
                 pExtendedFeatures = &featuresDepthClipControl;
+            }
+
+            PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT featuresAttachmentFeedbackLoopLayout;
+
+            if (physicalDevice.IsDeviceExtensionPresent("VK_EXT_attachment_feedback_loop_layout") &&
+                supportedFeaturesAttachmentFeedbackLoopLayout.AttachmentFeedbackLoopLayout)
+            {
+                featuresAttachmentFeedbackLoopLayout = new()
+                {
+                    SType = StructureType.PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesExt,
+                    PNext = pExtendedFeatures,
+                    AttachmentFeedbackLoopLayout = true,
+                };
+
+                pExtendedFeatures = &featuresAttachmentFeedbackLoopLayout;
             }
 
             var enabledExtensions = _requiredExtensions.Union(_desirableExtensions.Intersect(physicalDevice.DeviceExtensions)).ToArray();

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -243,6 +243,11 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDeviceDepthClipControlFeaturesExt,
             };
 
+            PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT featuresAttachmentFeedbackLoop = new()
+            {
+                SType = StructureType.PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesExt,
+            };
+
             PhysicalDevicePortabilitySubsetFeaturesKHR featuresPortabilitySubset = new()
             {
                 SType = StructureType.PhysicalDevicePortabilitySubsetFeaturesKhr,
@@ -277,6 +282,14 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 featuresDepthClipControl.PNext = features2.PNext;
                 features2.PNext = &featuresDepthClipControl;
+            }
+
+            bool supportsAttachmentFeedbackLoop = _physicalDevice.IsDeviceExtensionPresent("VK_EXT_attachment_feedback_loop_layout");
+
+            if (supportsAttachmentFeedbackLoop)
+            {
+                featuresAttachmentFeedbackLoop.PNext = features2.PNext;
+                features2.PNext = &featuresAttachmentFeedbackLoop;
             }
 
             bool usePortability = _physicalDevice.IsDeviceExtensionPresent("VK_KHR_portability_subset");
@@ -401,6 +414,7 @@ namespace Ryujinx.Graphics.Vulkan
                 _physicalDevice.IsDeviceExtensionPresent("VK_NV_viewport_array2"),
                 _physicalDevice.IsDeviceExtensionPresent(ExtExternalMemoryHost.ExtensionName),
                 supportsDepthClipControl && featuresDepthClipControl.DepthClipControl,
+                supportsAttachmentFeedbackLoop && featuresAttachmentFeedbackLoop.AttachmentFeedbackLoopLayout,
                 propertiesSubgroup.SubgroupSize,
                 supportedSampleCounts,
                 portabilityFlags,

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -7,6 +7,7 @@ using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Controller.Motion;
 using Ryujinx.Common.Configuration.Hid.Keyboard;
+using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.Logging.Targets;
 using Ryujinx.Common.SystemInterop;
@@ -462,6 +463,8 @@ namespace Ryujinx.Headless.SDL2
             GraphicsConfig.MaxAnisotropy = option.MaxAnisotropy;
             GraphicsConfig.ShadersDumpPath = option.GraphicsShadersDumpPath;
             GraphicsConfig.EnableMacroHLE = !option.DisableMacroHLE;
+
+            DriverUtilities.InitDriverConfig(option.BackendThreading == BackendThreading.Off);
 
             while (true)
             {

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -1,4 +1,4 @@
-using CommandLine;
+﻿using CommandLine;
 using LibHac.Tools.FsSystem;
 using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Common;

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using LibHac.Tools.FsSystem;
 using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Common;

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -117,8 +117,8 @@ namespace Ryujinx.Ava
             // Logging system information.
             PrintSystemInfo();
 
-            // Enable OGL multithreading on the driver, when available.
-            DriverUtilities.ToggleOGLThreading(ConfigurationState.Instance.Graphics.BackendThreading == BackendThreading.Off);
+            // Enable OGL multithreading on the driver, and some other flags.
+            DriverUtilities.InitDriverConfig(ConfigurationState.Instance.Graphics.BackendThreading == BackendThreading.Off);
 
             // Check if keys exists.
             if (!File.Exists(Path.Combine(AppDataManager.KeysDirPath, "prod.keys")))


### PR DESCRIPTION
This PR allows the Vulkan backend to detect attachment feedback loops. These are currently used in the following ways:

- Partial use of VK_EXT_attachment_feedback_loop_layout
  - All renderable textures have AttachmentFeedbackLoopBitExt
  - Compile pipelines with Color/DepthStencil feedback loop flags when present
- Support using FragmentBarrier for feedback loops (fixes regressions from https://github.com/Ryujinx/Ryujinx/pull/7012 )

Generally trying to fix issues with RDNA3 GPUs, but I don't have one so it's more of a wild guess.

### API complaints

Feedback loops are very poorly considered by Vulkan and its validation layers, and the addition of the `VK_EXT_attachment_feedback_loop_layout` extension hasn't really helped much. Original specification for Vulkan prohibited attachment feedback loops entirely, simply saying they are entirely disallowed. Software written with other APIs in mind, however, require feedback loops to function properly. Up until recently, the way this issue has been dealt with is for the "general" image layout to unofficially allow feedback loops on desktop GPU drivers. While this isn't to spec, it gives developers access to this capability of the GPU. AMD took the specification very literally and ran - they decided to make the general layout for render targets incompatible with feedback loops.

Feedback loop detection existed in the Vulkan validation layers for a long time, where it was subsequently ignored by everyone writing compatibility layers before the extension was introduced. You'll be shocked to find out that after the extension started being implemented, the validation for feedback loops was actually _entirely removed_ because it wasn't working properly. This leaves no way to check if you're detecting feedback loops properly, and what Vulkan really wants from you, especially in weirder cases like sampling from a depth texture that is read-only. See validation layers issue 8096, I'm not linking it because making anyone related to Vulkan standards read this section would probably count as harassment.

Information on what constitutes a feedback loop appears here:
https://vulkan.lunarg.com/doc/view/1.3.250.1/windows/1.3-extensions/vkspec.html#renderpass-feedbackloop
I only found this a few days ago. I'm not sure when it materialized but it is useful, even if it doesn't mention what source stages and access a "pipeline barrier" for an attachment loop would actually have. It's also kind of weird around what counts as a "read-only" access, since you can disable depth write but still give the render pass a store action, and previous draws in the pass can also write when the current draw doesn't, etc.

There is no information anywhere about `VK_DEPENDENCY_FEEDBACK_LOOP_BIT_EXT`. The validation layers have no meaningful checks relating to it. DXVK doesn't even use this flag. What does it do, where do you define it? I have no idea, so I'm simply not using it.

Vulkan specification states that "VK_IMAGE_LAYOUT_GENERAL supports all types of device access.". For this reason, I've implemented parts of the feedback loop extension that tell the GPU when a texture _will be used_ in a feedback loop: usage flags, pipeline flags, extension enable flag. It's possible it also requires the dependency flag on the render pass, but I have no idea since nothing really mentions what it's for. If a layout transition is _required_ to do this, it's nullifying the whole point of the general layout even existing. Usage is random and unpredicatable in Ryujinx, so the general layout is normally our best bet, and the best performing on desktop.

### TODO
- ~~AMD GPUs may need layout transitions for it to properly allow textures to be used in feedback loops.~~
  - The proprietary driver doesn't, RADV does.
- ~~Use dynamic state for feedback loops. The background pipeline will always miss since feedback loop state isn't known on the GPU project.~~
- How is the barrier dependency flag used? (DXVK just ignores it, there's no vulkan validation...)
- Add subpass dependencies to fix validation errors (external dependency for attachment->sample mid-pass?)
- ~~Silk.NET needs to be updated for this extension, so we need to deal with issues finding the MoltenVK binary. It would help if we could submit our own lookup paths.~~
  - Resolved via manually overriding path resolvers. Not pretty but sidesteps the issue for now. We can consider properly setting up loading mvk via libvulkan when we are able to update to the latest version.

### RDNA3 Testing
This PR is draft because I want to know if what I've got right now is enough to prevent the issue seen in https://github.com/Ryujinx/Ryujinx/issues/5306 , on both RADV and the Windows driver.

If it isn't avoided, then I can follow up with a change that switches the layout of images used in feedback loops, but I'd rather not do this as it can cause other issues.