### PR TITLE
Fix deadlock in background translation thread shutdown

### DIFF
--- a/src/ARMeilleure/Translation/TranslatorQueue.cs
+++ b/src/ARMeilleure/Translation/TranslatorQueue.cs
@@ -80,7 +80,10 @@ namespace ARMeilleure.Translation
                         return true;
                     }
 
-                    Monitor.Wait(Sync);
+                    if (!_disposed)
+                    {
+                        Monitor.Wait(Sync);
+                    }
                 }
             }
 


### PR DESCRIPTION
TryDequeue checks for _disposed before taking the lock.  If another thread calls Dispose before it takes the lock, it won't get woken up by the PulseAll call, and will deadlock in Monitor.Wait.

Double-checking _disposed with the lock taken should avoid this.

Various users have been reporting deadlocks in testing when building from nix: https://github.com/NixOS/nixpkgs/issues/325857

This seems to happen more when the system is under load.  I was able to reproduce it by calling `dotnet test` in a loop while running artificial load.

When it deadlocks, the relevant thread stacks are:

```
      ~~~~ 2c67f2
         1 System.Threading.Thread.Join()
         1 ARMeilleure.Translation.Translator.Execute(ExecutionContext, UInt64)
         1 Ryujinx.Tests.Cpu.CpuTest.ExecuteOpcodes(Boolean)
         1 Ryujinx.Tests.Cpu.CpuTest.SingleOpcode(UInt32, UInt64, UInt64, UInt64, UInt64, UInt64, V128, V128, V128, V128, V128, V128, V128, V128, Boolean, Boolean, Boolean, Boolean, Int32, Int32, Boolean)
         1 Ryujinx.Tests.Cpu.CpuTestCcmpImm.Ccmp_64bit(UInt32, UInt64, UInt32, UInt32, UInt32)
         1 (dynamicClass).Ccmp_64bit(Object, Span<Object>)
         1 System.Reflection.MethodBaseInvoker.InvokeWithManyArgs(Object, BindingFlags, Binder, Object[], CultureInfo)
         1 NUnit.Framework.Internal.Reflect.InvokeMethod(MethodInfo, Object, Object[])
         1 NUnit.Framework.Internal.MethodWrapper.Invoke(Object, Object[])
         1 NUnit.Framework.Internal.Commands.TestMethodCommand.InvokeTestMethod(TestExecutionContext)
         1 NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext)
         1 NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext)
         1 NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand+<>c__DisplayClass1_0.<Execute>b__0()
         1 NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext, Action)
         1 NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.Execute(TestExecutionContext)
         1 NUnit.Framework.Internal.Execution.SimpleWorkItem+<>c__DisplayClass4_0.<PerformWork>b__0()
         1 NUnit.Framework.Internal.ContextUtils+<>c__DisplayClass1_0<System.__Canon>.<DoIsolated>b__0(Object)
         1 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object)
         1 NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback, Object)
         1 NUnit.Framework.Internal.ContextUtils.DoIsolated(Func<__Canon>)
         1 NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
         1 NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
         1 NUnit.Framework.Internal.Execution.WorkItem.Execute()
         1 NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem, ParallelExecutionStrategy)
         1 NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem)
         1 NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()
         1 NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()
         1 NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
         1 NUnit.Framework.Internal.Execution.WorkItem.Execute()
         1 NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem, ParallelExecutionStrategy)
         1 NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem)
         1 NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()
         1 NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()
         1 NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
         1 NUnit.Framework.Internal.Execution.WorkItem.Execute()
         1 NUnit.Framework.Internal.Execution.TestWorker.TestWorkerThreadProc()
      ~~~~ 2cc437
         1 ARMeilleure.Translation.TranslatorQueue.TryDequeue(RejitRequest ByRef)
         1 ARMeilleure.Translation.Translator.BackgroundTranslate()
    3 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object)
```

And the detailed trace for the worker thread shows that it's in the monitor:

```
OS Thread Id: 0x2cc437 (17)
        Child SP               IP Call Site
00007FE180FFF960 00007fe2032960ce [HelperMethodFrame_1OBJ: 00007fe180fff960] System.Threading.Monitor.ObjWait(Int32, System.Object)
00007FE180FFFA90 00007FE1880403E5 ARMeilleure.Translation.TranslatorQueue.TryDequeue(ARMeilleure.Translation.RejitRequest ByRef)
00007FE180FFFAE0 00007FE188040236 ARMeilleure.Translation.Translator.BackgroundTranslate()
00007FE180FFFB40 00007FE1872DBB11 System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object) [/_/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs @ 179]
00007FE180FFFCD0 00007fe202e9fcc7 [DebuggerU2MCatchHandlerFrame: 00007fe180fffcd0]
```