### PR TITLE
Fix incorrect depth texture 3D flag

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -415,7 +415,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 #pragma warning disable CS0649 // Field is never assigned to
         public int Width;
         public int Height;
-        public int Depth;
+        public ushort Depth;
+        public ushort Flags;
+
+        public readonly bool UnpackIsLayered()
+        {
+            return (Flags & 1) == 0;
+        }
 #pragma warning restore CS0649
     }
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -468,13 +468,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             int gobBlocksInY = dsState.MemoryLayout.UnpackGobBlocksInY();
             int gobBlocksInZ = dsState.MemoryLayout.UnpackGobBlocksInZ();
 
+            layered &= size.UnpackIsLayered();
+
             Target target;
 
-            if (dsState.MemoryLayout.UnpackIsTarget3D())
-            {
-                target = Target.Texture3D;
-            }
-            else if ((samplesInX | samplesInY) != 1)
+            if ((samplesInX | samplesInY) != 1)
             {
                 target = size.Depth > 1 && layered
                     ? Target.Texture2DMultisampleArray


### PR DESCRIPTION
The official documentation indicates that there is no 3D bit for depth texture. Before, it was ignoring one bit located next to the depth value (which was causing the texture to have an incorrect size) and using an inexistent bit as the bit that indicates the texture is 3D.

Fixes a crash in Neverwinter Nights: Enhanced Edition.
![image](https://github.com/user-attachments/assets/2969c161-8870-472c-93b8-3ea1612ebf0d)
Lighting is broken, seems to be the same problem as a few other OpenGL games where the depth attachment is never cleared.