### PR TITLE
Use "GC.SuppressFinalize(this)"

### DIFF
--- a/src/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
@@ -229,6 +229,7 @@ namespace Ryujinx.Audio.Backends.SDL2
         public override void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceSession.cs
@@ -446,6 +446,8 @@ namespace Ryujinx.Audio.Backends.SoundIo
             {
                 Dispose(true);
             }
+
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Audio/Common/AudioDeviceSession.cs
+++ b/src/Ryujinx.Audio/Common/AudioDeviceSession.cs
@@ -485,6 +485,7 @@ namespace Ryujinx.Audio.Common
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BackgroundDiskCacheWriter.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/BackgroundDiskCacheWriter.cs
@@ -125,6 +125,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -674,6 +674,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -1168,6 +1168,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -12,7 +12,7 @@ using SamplerCreateInfo = Ryujinx.Graphics.GAL.SamplerCreateInfo;
 
 namespace Ryujinx.Graphics.Vulkan
 {
-    class DescriptorSetUpdater
+    class DescriptorSetUpdater : IDisposable
     {
         private const ulong StorageBufferMaxMirrorable = 0x2000;
 

--- a/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -1735,6 +1735,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1709,6 +1709,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCache.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCache.cs
@@ -102,6 +102,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCache.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCache.cs
@@ -6,7 +6,7 @@ using System.Collections.ObjectModel;
 
 namespace Ryujinx.Graphics.Vulkan
 {
-    class PipelineLayoutCache
+    class PipelineLayoutCache : IDisposable
     {
         private readonly struct PlceKey : IEquatable<PlceKey>
         {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Vulkan
 {
-    class PipelineLayoutCacheEntry
+    class PipelineLayoutCacheEntry : IDisposable
     {
         private const int MaxPoolSizesPerSet = 8;
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutCacheEntry.cs
@@ -378,6 +378,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -752,6 +752,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/StagingBuffer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/StagingBuffer.cs
@@ -292,6 +292,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -1112,6 +1112,7 @@ namespace Ryujinx.Graphics.Vulkan
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         public void Release()

--- a/src/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Window.cs
@@ -665,6 +665,7 @@ namespace Ryujinx.Graphics.Vulkan
         public override void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Window.cs
@@ -665,7 +665,6 @@ namespace Ryujinx.Graphics.Vulkan
         public override void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Horizon/Sdk/OsTypes/Event.cs
+++ b/src/Ryujinx.Horizon/Sdk/OsTypes/Event.cs
@@ -56,6 +56,7 @@ namespace Ryujinx.Horizon.Sdk.OsTypes
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Horizon/Sdk/Sf/Hipc/ServerManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Hipc/ServerManager.cs
@@ -192,6 +192,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ryujinx.Horizon/ServiceTable.cs
+++ b/src/Ryujinx.Horizon/ServiceTable.cs
@@ -22,7 +22,7 @@ using System.Threading;
 
 namespace Ryujinx.Horizon
 {
-    public class ServiceTable
+    public class ServiceTable : IDisposable
     {
         private int _readyServices;
         private int _totalServices;

--- a/src/Ryujinx.Horizon/ServiceTable.cs
+++ b/src/Ryujinx.Horizon/ServiceTable.cs
@@ -16,6 +16,7 @@ using Ryujinx.Horizon.Sdk.Arp;
 using Ryujinx.Horizon.Srepo;
 using Ryujinx.Horizon.Usb;
 using Ryujinx.Horizon.Wlan;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -88,6 +89,7 @@ namespace Ryujinx.Horizon
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
If I understood correctly, when implementing the `IDisposable` interface to manage both managed and unmanaged resources, you typically call `GC.SuppressFinalize(this)` in your `Dispose` method to prevent the garbage collector from calling the finalizer, since you've already released the resources manually.