### PR TITLE
Vulkan: Update Silk.NET to 2.21

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,9 +39,9 @@
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
+    <PackageVersion Include="Silk.NET.Vulkan" Version="2.21.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.21.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.21.0" />
     <PackageVersion Include="SkiaSharp" Version="2.88.7" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />

--- a/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -122,7 +122,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Range = (uint)size,
             };
 
-            _gd.Api.CreateBufferView(_device, bufferViewCreateInfo, null, out var bufferView).ThrowOnError();
+            _gd.Api.CreateBufferView(_device, in bufferViewCreateInfo, null, out var bufferView).ThrowOnError();
 
             return new Auto<DisposableBufferView>(new DisposableBufferView(_gd.Api, _device, bufferView), this, _waitable, _buffer);
         }
@@ -153,7 +153,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PipelineStageFlags.AllCommandsBit,
                     DependencyFlags.DeviceGroupBit,
                     1,
-                    memoryBarrier,
+                    in memoryBarrier,
                     0,
                     null,
                     0,
@@ -770,7 +770,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0,
                 null,
                 1,
-                memoryBarrier,
+                in memoryBarrier,
                 0,
                 null);
         }

--- a/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -221,7 +221,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PBufferBinds = &bufferBind
                 };
 
-                gd.Api.QueueBindSparse(gd.Queue, 1, bindSparseInfo, default).ThrowOnError();
+                gd.Api.QueueBindSparse(gd.Queue, 1, in bindSparseInfo, default).ThrowOnError();
             }
 
             var holder = new BufferHolder(gd, _device, buffer, (int)size, storageAllocations);

--- a/src/Ryujinx.Graphics.Vulkan/BufferState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferState.cs
@@ -25,7 +25,10 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 var buffer = _buffer.Get(cbs, _offset, _size, true).Value;
 
-                gd.TransformFeedbackApi.CmdBindTransformFeedbackBuffers(cbs.CommandBuffer, binding, 1, buffer, (ulong)_offset, (ulong)_size);
+                ulong offset = (ulong)_offset;
+                ulong size = (ulong)_size;
+
+                gd.TransformFeedbackApi.CmdBindTransformFeedbackBuffers(cbs.CommandBuffer, binding, 1, in buffer, in offset, in size);
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/CommandBufferPool.cs
+++ b/src/Ryujinx.Graphics.Vulkan/CommandBufferPool.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Graphics.Vulkan
                     Level = CommandBufferLevel.Primary,
                 };
 
-                api.AllocateCommandBuffers(device, allocateInfo, out CommandBuffer);
+                api.AllocateCommandBuffers(device, in allocateInfo, out CommandBuffer);
 
                 Dependants = new List<IAuto>();
                 Waitables = new List<MultiFenceHolder>();
@@ -83,7 +83,7 @@ namespace Ryujinx.Graphics.Vulkan
                         CommandPoolCreateFlags.ResetCommandBufferBit,
             };
 
-            api.CreateCommandPool(device, commandPoolCreateInfo, null, out _pool).ThrowOnError();
+            api.CreateCommandPool(device, in commandPoolCreateInfo, null, out _pool).ThrowOnError();
 
             // We need at least 2 command buffers to get texture data in some cases.
             _totalCommandBuffers = isLight ? 2 : MaxCommandBuffers;
@@ -253,7 +253,7 @@ namespace Ryujinx.Graphics.Vulkan
                             SType = StructureType.CommandBufferBeginInfo,
                         };
 
-                        _api.BeginCommandBuffer(entry.CommandBuffer, commandBufferBeginInfo).ThrowOnError();
+                        _api.BeginCommandBuffer(entry.CommandBuffer, in commandBufferBeginInfo).ThrowOnError();
 
                         return new CommandBufferScoped(this, entry.CommandBuffer, cursor);
                     }
@@ -311,7 +311,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                         lock (_queueLock)
                         {
-                            _api.QueueSubmit(_queue, 1, sInfo, entry.Fence.GetUnsafe()).ThrowOnError();
+                            _api.QueueSubmit(_queue, 1, in sInfo, entry.Fence.GetUnsafe()).ThrowOnError();
                         }
                     }
                 }

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetCollection.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PBufferInfo = &bufferInfo,
                 };
 
-                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
             }
         }
 
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PBufferInfo = pBufferInfo,
                 };
 
-                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
             }
         }
 
@@ -84,7 +84,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PImageInfo = &imageInfo,
                 };
 
-                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
             }
         }
 
@@ -107,7 +107,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PImageInfo = pImageInfo,
                 };
 
-                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
             }
         }
 
@@ -144,7 +144,7 @@ namespace Ryujinx.Graphics.Vulkan
                             PImageInfo = pImageInfo,
                         };
 
-                        _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                        _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
 
                         i += count - 1;
                     }
@@ -166,7 +166,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PTexelBufferView = &texelBufferView,
                 };
 
-                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
             }
         }
 
@@ -200,7 +200,7 @@ namespace Ryujinx.Graphics.Vulkan
                             PTexelBufferView = pTexelBufferView + i,
                         };
 
-                        _holder.Api.UpdateDescriptorSets(_holder.Device, 1, writeDescriptorSet, 0, null);
+                        _holder.Api.UpdateDescriptorSets(_holder.Device, 1, in writeDescriptorSet, 0, null);
                     }
 
                     i += count;

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetManager.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetManager.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Vulkan
                         PPoolSizes = pPoolsSize,
                     };
 
-                    Api.CreateDescriptorPool(device, descriptorPoolCreateInfo, null, out _pool).ThrowOnError();
+                    Api.CreateDescriptorPool(device, in descriptorPoolCreateInfo, null, out _pool).ThrowOnError();
                 }
             }
 

--- a/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -250,7 +250,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Layers = Layers,
             };
 
-            api.CreateFramebuffer(_device, framebufferCreateInfo, null, out var framebuffer).ThrowOnError();
+            api.CreateFramebuffer(_device, in framebufferCreateInfo, null, out var framebuffer).ThrowOnError();
             return new Auto<DisposableFramebuffer>(new DisposableFramebuffer(api, _device, framebuffer), null, _attachments);
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/HostMemoryAllocator.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HostMemoryAllocator.cs
@@ -115,7 +115,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PNext = &importInfo,
                 };
 
-                Result result = _api.AllocateMemory(_device, memoryAllocateInfo, null, out var deviceMemory);
+                Result result = _api.AllocateMemory(_device, in memoryAllocateInfo, null, out var deviceMemory);
 
                 if (result < Result.Success)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
@@ -220,7 +220,7 @@ namespace Ryujinx.Graphics.Vulkan
                 MemoryTypeIndex = (uint)MemoryTypeIndex,
             };
 
-            _api.AllocateMemory(_device, memoryAllocateInfo, null, out var deviceMemory).ThrowOnError();
+            _api.AllocateMemory(_device, in memoryAllocateInfo, null, out var deviceMemory).ThrowOnError();
 
             IntPtr hostPointer = IntPtr.Zero;
 

--- a/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKInitialization.cs
@@ -1,3 +1,4 @@
+using Silk.NET.Core.Loader;
 using Silk.NET.Vulkan;
 using System;
 using System.Runtime.InteropServices;
@@ -28,6 +29,22 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
             config.ResumeLostDevice = true;
 
             vkSetMoltenVKConfigurationMVK(IntPtr.Zero, config, configSize);
+        }
+
+        public static void InitializeResolver()
+        {
+            Func<string, string[]> mvkResolver = (string path) =>
+            {
+                if (path.EndsWith("libvulkan.dylib")) 
+                {
+                    path = path.Substring(0, path.Length - "libvulkan.dylib".Length) + "libMoltenVK.dylib";
+                    return [ path ];
+                }
+
+                return Array.Empty<string>();
+            };
+
+            ((DefaultPathResolver)PathResolver.Default).Resolvers.Insert(0, mvkResolver);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKInitialization.cs
@@ -9,6 +9,8 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
     [SupportedOSPlatform("macos")]
     public static partial class MVKInitialization
     {
+        private const string VulkanLib = "libvulkan.dylib";
+
         [LibraryImport("libMoltenVK.dylib")]
         private static partial Result vkGetMoltenVKConfigurationMVK(IntPtr unusedInstance, out MVKConfiguration config, in IntPtr configSize);
 
@@ -31,20 +33,19 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
             vkSetMoltenVKConfigurationMVK(IntPtr.Zero, config, configSize);
         }
 
+        private static string[] Resolver(string path)
+        {
+            if (path.EndsWith(VulkanLib))
+            {
+                path = path[..^VulkanLib.Length] + "libMoltenVK.dylib";
+                return [path];
+            }
+            return Array.Empty<string>();
+        }
+
         public static void InitializeResolver()
         {
-            Func<string, string[]> mvkResolver = (string path) =>
-            {
-                if (path.EndsWith("libvulkan.dylib")) 
-                {
-                    path = path.Substring(0, path.Length - "libvulkan.dylib".Length) + "libMoltenVK.dylib";
-                    return [ path ];
-                }
-
-                return Array.Empty<string>();
-            };
-
-            ((DefaultPathResolver)PathResolver.Default).Resolvers.Insert(0, mvkResolver);
+            ((DefaultPathResolver)PathResolver.Default).Resolvers.Insert(0, Resolver);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PipelineCacheCreateInfo,
             };
 
-            gd.Api.CreatePipelineCache(device, pipelineCacheCreateInfo, null, out PipelineCache).ThrowOnError();
+            gd.Api.CreatePipelineCache(device, in pipelineCacheCreateInfo, null, out PipelineCache).ThrowOnError();
 
             _descriptorSetUpdater = new DescriptorSetUpdater(gd, device);
             _vertexBufferUpdater = new VertexBufferUpdater(gd);
@@ -1628,7 +1628,7 @@ namespace Ryujinx.Graphics.Vulkan
                     ClearValueCount = 1,
                 };
 
-                Gd.Api.CmdBeginRenderPass(CommandBuffer, renderPassBeginInfo, SubpassContents.Inline);
+                Gd.Api.CmdBeginRenderPass(CommandBuffer, in renderPassBeginInfo, SubpassContents.Inline);
                 RenderPassActive = true;
             }
         }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -116,7 +116,7 @@ namespace Ryujinx.Graphics.Vulkan
                     DependencyCount = 1,
                 };
 
-                gd.Api.CreateRenderPass(device, renderPassCreateInfo, null, out var renderPass).ThrowOnError();
+                gd.Api.CreateRenderPass(device, in renderPassCreateInfo, null, out var renderPass).ThrowOnError();
 
                 return new DisposableRenderPass(gd.Api, device, renderPass);
             }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
@@ -91,7 +91,7 @@ namespace Ryujinx.Graphics.Vulkan
                         Flags = flags,
                     };
 
-                    gd.Api.CreateDescriptorSetLayout(device, descriptorSetLayoutCreateInfo, null, out layouts[setIndex]).ThrowOnError();
+                    gd.Api.CreateDescriptorSetLayout(device, in descriptorSetLayoutCreateInfo, null, out layouts[setIndex]).ThrowOnError();
                 }
             }
 

--- a/src/Ryujinx.Graphics.Vulkan/Queries/BufferedQuery.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Queries/BufferedQuery.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
                     PipelineStatistics = flags,
                 };
 
-                gd.Api.CreateQueryPool(device, queryPoolCreateInfo, null, out _queryPool).ThrowOnError();
+                gd.Api.CreateQueryPool(device, in queryPoolCreateInfo, null, out _queryPool).ThrowOnError();
             }
 
             var buffer = gd.BufferManager.Create(gd, sizeof(long), forConditionalRendering: true);

--- a/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/RenderPassHolder.cs
@@ -125,7 +125,7 @@ namespace Ryujinx.Graphics.Vulkan
                     DependencyCount = 1,
                 };
 
-                gd.Api.CreateRenderPass(device, renderPassCreateInfo, null, out var renderPass).ThrowOnError();
+                gd.Api.CreateRenderPass(device, in renderPassCreateInfo, null, out var renderPass).ThrowOnError();
 
                 _renderPass = new Auto<DisposableRenderPass>(new DisposableRenderPass(gd.Api, device, renderPass));
             }

--- a/src/Ryujinx.Graphics.Vulkan/SamplerHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/SamplerHolder.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Graphics.Vulkan
                 samplerCreateInfo.BorderColor = BorderColor.FloatCustomExt;
             }
 
-            gd.Api.CreateSampler(device, samplerCreateInfo, null, out var sampler).ThrowOnError();
+            gd.Api.CreateSampler(device, in samplerCreateInfo, null, out var sampler).ThrowOnError();
 
             _sampler = new Auto<DisposableSampler>(new DisposableSampler(gd.Api, device, sampler));
         }

--- a/src/Ryujinx.Graphics.Vulkan/Shader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Shader.cs
@@ -64,7 +64,7 @@ namespace Ryujinx.Graphics.Vulkan
                         PCode = (uint*)pCode,
                     };
 
-                    api.CreateShaderModule(device, shaderModuleCreateInfo, null, out _module).ThrowOnError();
+                    api.CreateShaderModule(device, in shaderModuleCreateInfo, null, out _module).ThrowOnError();
                 }
 
                 CompileStatus = ProgramLinkStatus.Success;

--- a/src/Ryujinx.Graphics.Vulkan/TextureCopy.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureCopy.cs
@@ -88,7 +88,7 @@ namespace Ryujinx.Graphics.Vulkan
                     DstOffsets = dstOffsets,
                 };
 
-                api.CmdBlitImage(commandBuffer, srcImage, ImageLayout.General, dstImage, ImageLayout.General, 1, region, filter);
+                api.CmdBlitImage(commandBuffer, srcImage, ImageLayout.General, dstImage, ImageLayout.General, 1, in region, filter);
 
                 copySrcLevel++;
                 copyDstLevel++;
@@ -320,13 +320,13 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     var region = new ImageResolve(srcSl, new Offset3D(0, 0, srcZ), dstSl, new Offset3D(0, 0, dstZ), extent);
 
-                    api.CmdResolveImage(commandBuffer, srcImage, ImageLayout.General, dstImage, ImageLayout.General, 1, region);
+                    api.CmdResolveImage(commandBuffer, srcImage, ImageLayout.General, dstImage, ImageLayout.General, 1, in region);
                 }
                 else
                 {
                     var region = new ImageCopy(srcSl, new Offset3D(0, 0, srcZ), dstSl, new Offset3D(0, 0, dstZ), extent);
 
-                    api.CmdCopyImage(commandBuffer, srcImage, ImageLayout.General, dstImage, ImageLayout.General, 1, region);
+                    api.CmdCopyImage(commandBuffer, srcImage, ImageLayout.General, dstImage, ImageLayout.General, 1, in region);
                 }
 
                 width = Math.Max(1, width >> 1);
@@ -422,7 +422,7 @@ namespace Ryujinx.Graphics.Vulkan
                     DependencyCount = 1,
                 };
 
-                gd.Api.CreateRenderPass2(device, renderPassCreateInfo, null, out var renderPass).ThrowOnError();
+                gd.Api.CreateRenderPass2(device, in renderPassCreateInfo, null, out var renderPass).ThrowOnError();
 
                 using var rp = new Auto<DisposableRenderPass>(new DisposableRenderPass(gd.Api, device, renderPass));
 
@@ -445,7 +445,7 @@ namespace Ryujinx.Graphics.Vulkan
                     Layers = (uint)src.Layers,
                 };
 
-                gd.Api.CreateFramebuffer(device, framebufferCreateInfo, null, out var framebuffer).ThrowOnError();
+                gd.Api.CreateFramebuffer(device, in framebufferCreateInfo, null, out var framebuffer).ThrowOnError();
                 using var fb = new Auto<DisposableFramebuffer>(new DisposableFramebuffer(gd.Api, device, framebuffer), null, srcView, dstView);
 
                 var renderArea = new Rect2D(null, new Extent2D((uint)src.Info.Width, (uint)src.Info.Height));
@@ -465,7 +465,7 @@ namespace Ryujinx.Graphics.Vulkan
                 // to resolve the depth-stencil texture.
                 // TODO: Do speculative resolve and part of the same render pass as the draw to avoid
                 // ending the current render pass?
-                gd.Api.CmdBeginRenderPass(cbs.CommandBuffer, renderPassBeginInfo, SubpassContents.Inline);
+                gd.Api.CmdBeginRenderPass(cbs.CommandBuffer, in renderPassBeginInfo, SubpassContents.Inline);
                 gd.Api.CmdEndRenderPass(cbs.CommandBuffer);
             }
         }

--- a/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -114,7 +114,7 @@ namespace Ryujinx.Graphics.Vulkan
                 Flags = flags,
             };
 
-            gd.Api.CreateImage(device, imageCreateInfo, null, out _image).ThrowOnError();
+            gd.Api.CreateImage(device, in imageCreateInfo, null, out _image).ThrowOnError();
 
             if (foreignAllocation == null)
             {
@@ -284,7 +284,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0,
                 null,
                 1,
-                barrier);
+                in barrier);
 
             if (useTempCbs)
             {
@@ -401,11 +401,11 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (to)
                 {
-                    _gd.Api.CmdCopyImageToBuffer(commandBuffer, image, ImageLayout.General, buffer, 1, region);
+                    _gd.Api.CmdCopyImageToBuffer(commandBuffer, image, ImageLayout.General, buffer, 1, in region);
                 }
                 else
                 {
-                    _gd.Api.CmdCopyBufferToImage(commandBuffer, buffer, image, ImageLayout.General, 1, region);
+                    _gd.Api.CmdCopyBufferToImage(commandBuffer, buffer, image, ImageLayout.General, 1, in region);
                 }
 
                 offset += mipSize;

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -117,7 +117,7 @@ namespace Ryujinx.Graphics.Vulkan
                     PNext = &imageViewUsage,
                 };
 
-                gd.Api.CreateImageView(device, imageCreateInfo, null, out var imageView).ThrowOnError();
+                gd.Api.CreateImageView(device, in imageCreateInfo, null, out var imageView).ThrowOnError();
                 return new Auto<DisposableImageView>(new DisposableImageView(gd.Api, device, imageView), null, storage.GetImage());
             }
 
@@ -492,7 +492,7 @@ namespace Ryujinx.Graphics.Vulkan
                 dstStageMask,
                 DependencyFlags.None,
                 1,
-                memoryBarrier,
+                in memoryBarrier,
                 0,
                 null,
                 0,
@@ -557,7 +557,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0,
                 null,
                 1,
-                memoryBarrier);
+                in memoryBarrier);
         }
 
         public TextureView GetView(Format format)
@@ -949,11 +949,11 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (to)
                 {
-                    _gd.Api.CmdCopyImageToBuffer(commandBuffer, image, ImageLayout.General, buffer, 1, region);
+                    _gd.Api.CmdCopyImageToBuffer(commandBuffer, image, ImageLayout.General, buffer, 1, in region);
                 }
                 else
                 {
-                    _gd.Api.CmdCopyBufferToImage(commandBuffer, buffer, image, ImageLayout.General, 1, region);
+                    _gd.Api.CmdCopyBufferToImage(commandBuffer, buffer, image, ImageLayout.General, 1, in region);
                 }
 
                 offset += mipSize;
@@ -1010,11 +1010,11 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (to)
             {
-                _gd.Api.CmdCopyImageToBuffer(commandBuffer, image, ImageLayout.General, buffer, 1, region);
+                _gd.Api.CmdCopyImageToBuffer(commandBuffer, image, ImageLayout.General, buffer, 1, in region);
             }
             else
             {
-                _gd.Api.CmdCopyBufferToImage(commandBuffer, buffer, image, ImageLayout.General, 1, region);
+                _gd.Api.CmdCopyBufferToImage(commandBuffer, buffer, image, ImageLayout.General, 1, in region);
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -90,11 +90,9 @@ namespace Ryujinx.Graphics.Vulkan
                 DriverId.SamsungProprietary => "Samsung",
                 DriverId.MesaVenus => "Venus",
                 DriverId.MesaDozen => "Dozen",
-
-                // TODO: Use real enum when we have an up to date Silk.NET.
-                (DriverId)24 => "NVK",
-                (DriverId)25 => "Imagination (Open)",
-                (DriverId)26 => "Honeykrisp",
+                DriverId.MesaNvk => "NVK",
+                DriverId.ImaginationOpenSourceMesa => "Imagination (Open)",
+                DriverId.MesaAgxv => "Honeykrisp",
                 _ => id.ToString(),
             };
         }

--- a/src/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Window.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.Graphics.Vulkan
                 SwizzleComponent.Blue,
                 SwizzleComponent.Alpha);
 
-            _gd.SwapchainApi.CreateSwapchain(_device, swapchainCreateInfo, null, out _swapchain).ThrowOnError();
+            _gd.SwapchainApi.CreateSwapchain(_device, in swapchainCreateInfo, null, out _swapchain).ThrowOnError();
 
             _gd.SwapchainApi.GetSwapchainImages(_device, _swapchain, &imageCount, null);
 
@@ -187,14 +187,14 @@ namespace Ryujinx.Graphics.Vulkan
 
             for (int i = 0; i < _imageAvailableSemaphores.Length; i++)
             {
-                _gd.Api.CreateSemaphore(_device, semaphoreCreateInfo, null, out _imageAvailableSemaphores[i]).ThrowOnError();
+                _gd.Api.CreateSemaphore(_device, in semaphoreCreateInfo, null, out _imageAvailableSemaphores[i]).ThrowOnError();
             }
 
             _renderFinishedSemaphores = new Semaphore[imageCount];
 
             for (int i = 0; i < _renderFinishedSemaphores.Length; i++)
             {
-                _gd.Api.CreateSemaphore(_device, semaphoreCreateInfo, null, out _renderFinishedSemaphores[i]).ThrowOnError();
+                _gd.Api.CreateSemaphore(_device, in semaphoreCreateInfo, null, out _renderFinishedSemaphores[i]).ThrowOnError();
             }
         }
 
@@ -220,7 +220,7 @@ namespace Ryujinx.Graphics.Vulkan
                 SubresourceRange = subresourceRange,
             };
 
-            _gd.Api.CreateImageView(_device, imageCreateInfo, null, out var imageView).ThrowOnError();
+            _gd.Api.CreateImageView(_device, in imageCreateInfo, null, out var imageView).ThrowOnError();
 
             return new TextureView(_gd, _device, new DisposableImageView(_gd.Api, _device, imageView), info, format);
         }
@@ -479,7 +479,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             lock (_gd.QueueLock)
             {
-                _gd.SwapchainApi.QueuePresent(_gd.Queue, presentInfo);
+                _gd.SwapchainApi.QueuePresent(_gd.Queue, in presentInfo);
             }
         }
 
@@ -611,7 +611,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0,
                 null,
                 1,
-                barrier);
+                in barrier);
         }
 
         private void CaptureFrame(TextureView texture, int x, int y, int width, int height, bool isBgra, bool flipX, bool flipY)

--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -4,6 +4,7 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.SystemInterop;
+using Ryujinx.Graphics.Vulkan.MoltenVK;
 using Ryujinx.Modules;
 using Ryujinx.SDL2.Common;
 using Ryujinx.UI;
@@ -110,6 +111,8 @@ namespace Ryujinx
 
             if (OperatingSystem.IsMacOS())
             {
+                MVKInitialization.InitializeResolver();
+
                 string baseDirectory = Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory);
                 string resourcesDataDir;
 

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -1,4 +1,4 @@
-using CommandLine;
+﻿using CommandLine;
 using LibHac.Tools.FsSystem;
 using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Common;
@@ -18,6 +18,7 @@ using Ryujinx.Graphics.Gpu;
 using Ryujinx.Graphics.Gpu.Shader;
 using Ryujinx.Graphics.OpenGL;
 using Ryujinx.Graphics.Vulkan;
+using Ryujinx.Graphics.Vulkan.MoltenVK;
 using Ryujinx.Headless.SDL2.OpenGL;
 using Ryujinx.Headless.SDL2.Vulkan;
 using Ryujinx.HLE;
@@ -86,6 +87,11 @@ namespace Ryujinx.Headless.SDL2
 
                     invoked.WaitOne();
                 };
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                MVKInitialization.InitializeResolver();
             }
 
             Parser.Default.ParseArguments<Options>(args)

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using LibHac.Tools.FsSystem;
 using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Common;

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -7,6 +7,7 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.SystemInterop;
+using Ryujinx.Graphics.Vulkan.MoltenVK;
 using Ryujinx.Modules;
 using Ryujinx.SDL2.Common;
 using Ryujinx.UI.Common;
@@ -79,6 +80,11 @@ namespace Ryujinx.Ava
         {
             // Parse arguments
             CommandLineState.ParseArguments(args);
+
+            if (OperatingSystem.IsMacOS())
+            {
+                MVKInitialization.InitializeResolver();
+            }
 
             // Delete backup files after updating.
             Task.Run(Updater.CleanupUpdate);


### PR DESCRIPTION
Allows use of newer extensions and Vulkan features. We avoided upgrading due to some incompatibilities with how we bundled MoltenVK with the emulator, but I've found a way to work around it for now. We should figure out a way to use the Vulkan loader if we update MVK (needs bounds checks for atomic image storage, and spec compliant occlusion queries).

- Adds MVK linking workaround.
- Resolves warnings caused by a lot of fields changing from `in` to `readonly ref`.