### PR TITLE
Replace shaderc.net with Silk.NET.Shaderc

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,8 +37,8 @@
     <PackageVersion Include="Ryujinx.GtkSharp" Version="3.24.24.59-ryujinx" />
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.30.0-build32" />
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
-    <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="Silk.NET.Shaderc" Version="2.21.0" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.21.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.21.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.21.0" />

--- a/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
+++ b/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" />
-    <PackageReference Include="shaderc.net" />
+    <PackageReference Include="Silk.NET.Shaderc" />
     <PackageReference Include="Silk.NET.Vulkan" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" />


### PR DESCRIPTION
This replaces the `shdaerc.net` dependency with `Silk.NET.Shaderc`. It was extracted from #5854.