### PR TITLE
Update MacOS Bundle Version Strings

### DIFF
--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -40,11 +40,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1</string>
+    <string>%%RYUJINX_BUILD_VERSION%%</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>1.1.0</string>
+    <string>%%RYUJINX_BUILD_VERSION%%</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>CSResourcesFileMapped</key>


### PR DESCRIPTION
Updates app bundle version to be consistent with the app build version.

![image](https://github.com/user-attachments/assets/2960cfc1-5d9f-46f5-a847-7f20c6e3f50b)
![image](https://github.com/user-attachments/assets/a7cf0d66-0682-4018-b778-362200d1ddad)
![image](https://github.com/user-attachments/assets/a2cc8154-aded-488d-9752-2f6fc6a1be9a)
