### PR TITLE
Add raw screenshot gamepad button

### DIFF
--- a/src/Ryujinx.Common/Configuration/Hid/LeftJoyconCommonConfig.cs
+++ b/src/Ryujinx.Common/Configuration/Hid/LeftJoyconCommonConfig.cs
@@ -3,6 +3,7 @@ namespace Ryujinx.Common.Configuration.Hid
     public class LeftJoyconCommonConfig<TButton>
     {
         public TButton ButtonMinus { get; set; }
+        public TButton ButtonScreenshot { get; set; }
         public TButton ButtonL { get; set; }
         public TButton ButtonZl { get; set; }
         public TButton ButtonSl { get; set; }

--- a/src/Ryujinx.Gtk3/Input/GTK3/GTK3Keyboard.cs
+++ b/src/Ryujinx.Gtk3/Input/GTK3/GTK3Keyboard.cs
@@ -166,6 +166,7 @@ namespace Ryujinx.Input.GTK3
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadLeft, (Key)_configuration.LeftJoycon.DpadLeft));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadRight, (Key)_configuration.LeftJoycon.DpadRight));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Minus, (Key)_configuration.LeftJoycon.ButtonMinus));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Misc1, (Key)_configuration.LeftJoycon.ButtonScreenshot));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftShoulder, (Key)_configuration.LeftJoycon.ButtonL));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger, (Key)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (Key)_configuration.LeftJoycon.ButtonSr));

--- a/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
@@ -84,6 +84,7 @@ namespace Ryujinx.UI.Windows
         [GUI] ToggleButton _dpadLeft;
         [GUI] ToggleButton _dpadRight;
         [GUI] ToggleButton _minus;
+        [GUI] ToggleButton _screenshot;
         [GUI] ToggleButton _l;
         [GUI] ToggleButton _zL;
         [GUI] ToggleButton _rStick;
@@ -165,6 +166,7 @@ namespace Ryujinx.UI.Windows
             _dpadLeft.Clicked += Button_Pressed;
             _dpadRight.Clicked += Button_Pressed;
             _minus.Clicked += Button_Pressed;
+            _screenshot.Clicked += Button_Pressed;
             _l.Clicked += Button_Pressed;
             _zL.Clicked += Button_Pressed;
             _lSl.Clicked += Button_Pressed;
@@ -400,6 +402,7 @@ namespace Ryujinx.UI.Windows
             _dpadLeft.Label = "Unbound";
             _dpadRight.Label = "Unbound";
             _minus.Label = "Unbound";
+            _screenshot.Label = "Unbound";
             _l.Label = "Unbound";
             _zL.Label = "Unbound";
             _lSl.Label = "Unbound";
@@ -460,6 +463,7 @@ namespace Ryujinx.UI.Windows
                     _dpadLeft.Label = keyboardConfig.LeftJoycon.DpadLeft.ToString();
                     _dpadRight.Label = keyboardConfig.LeftJoycon.DpadRight.ToString();
                     _minus.Label = keyboardConfig.LeftJoycon.ButtonMinus.ToString();
+                    _screenshot.Label = keyboardConfig.LeftJoycon.ButtonScreenshot.ToString();
                     _l.Label = keyboardConfig.LeftJoycon.ButtonL.ToString();
                     _zL.Label = keyboardConfig.LeftJoycon.ButtonZl.ToString();
                     _lSl.Label = keyboardConfig.LeftJoycon.ButtonSl.ToString();
@@ -498,6 +502,7 @@ namespace Ryujinx.UI.Windows
                     _dpadLeft.Label = controllerConfig.LeftJoycon.DpadLeft.ToString();
                     _dpadRight.Label = controllerConfig.LeftJoycon.DpadRight.ToString();
                     _minus.Label = controllerConfig.LeftJoycon.ButtonMinus.ToString();
+                    _screenshot.Label = controllerConfig.LeftJoycon.ButtonScreenshot.ToString();
                     _l.Label = controllerConfig.LeftJoycon.ButtonL.ToString();
                     _zL.Label = controllerConfig.LeftJoycon.ButtonZl.ToString();
                     _lSl.Label = controllerConfig.LeftJoycon.ButtonSl.ToString();
@@ -566,6 +571,7 @@ namespace Ryujinx.UI.Windows
                 Enum.TryParse(_dpadLeft.Label,     out Key lDPadLeft);
                 Enum.TryParse(_dpadRight.Label,    out Key lDPadRight);
                 Enum.TryParse(_minus.Label,        out Key lButtonMinus);
+                Enum.TryParse(_screenshot.Label,   out Key lButtonScreenshot);
                 Enum.TryParse(_l.Label,            out Key lButtonL);
                 Enum.TryParse(_zL.Label,           out Key lButtonZl);
                 Enum.TryParse(_lSl.Label,          out Key lButtonSl);
@@ -597,6 +603,7 @@ namespace Ryujinx.UI.Windows
                     LeftJoycon = new LeftJoyconCommonConfig<Key>
                     {
                         ButtonMinus = lButtonMinus,
+                        ButtonScreenshot = lButtonScreenshot,
                         ButtonL = lButtonL,
                         ButtonZl = lButtonZl,
                         ButtonSl = lButtonSl,
@@ -643,6 +650,7 @@ namespace Ryujinx.UI.Windows
                 Enum.TryParse(_lStick.Label,       out ConfigStickInputId   lStick);
                 Enum.TryParse(_lStickButton.Label, out ConfigGamepadInputId lStickButton);
                 Enum.TryParse(_minus.Label,        out ConfigGamepadInputId lButtonMinus);
+                Enum.TryParse(_screenshot.Label,   out ConfigGamepadInputId lButtonScreenshot);
                 Enum.TryParse(_l.Label,            out ConfigGamepadInputId lButtonL);
                 Enum.TryParse(_zL.Label,           out ConfigGamepadInputId lButtonZl);
                 Enum.TryParse(_lSl.Label,          out ConfigGamepadInputId lButtonSl);
@@ -710,6 +718,7 @@ namespace Ryujinx.UI.Windows
                     LeftJoycon = new LeftJoyconCommonConfig<ConfigGamepadInputId>
                     {
                         ButtonMinus = lButtonMinus,
+                        ButtonScreenshot = lButtonScreenshot,
                         ButtonL = lButtonL,
                         ButtonZl = lButtonZl,
                         ButtonSl = lButtonSl,
@@ -997,6 +1006,7 @@ namespace Ryujinx.UI.Windows
                             DpadLeft = Key.Left,
                             DpadRight = Key.Right,
                             ButtonMinus = Key.Minus,
+                            ButtonScreenshot = Key.Unbound, // keyboard already has a default screenshot configured via ConfigurationState.Hid.Hotkeys.Screenshot, so no gamepad mapping needed
                             ButtonL = Key.E,
                             ButtonZl = Key.Q,
                             ButtonSl = Key.Unbound,
@@ -1057,6 +1067,7 @@ namespace Ryujinx.UI.Windows
                             DpadLeft = ConfigGamepadInputId.DpadLeft,
                             DpadRight = ConfigGamepadInputId.DpadRight,
                             ButtonMinus = ConfigGamepadInputId.Minus,
+                            ButtonScreenshot = ConfigGamepadInputId.Misc1,
                             ButtonL = ConfigGamepadInputId.LeftShoulder,
                             ButtonZl = ConfigGamepadInputId.LeftTrigger,
                             ButtonSl = ConfigGamepadInputId.Unbound,

--- a/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.glade
+++ b/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.glade
@@ -475,6 +475,31 @@
                                             <property name="top_attach">4</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                            <object class="GtkLabel">
+                                                <property name="width_request">80</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Screenshot</property>
+                                            </object>
+                                            <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">6</property>
+                                            </packing>
+                                        </child>
+                                        <child>
+                                            <object class="GtkToggleButton" id="_screenshot">
+                                                <property name="label" translatable="yes"> </property>
+                                                <property name="width_request">70</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                            </object>
+                                            <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">6</property>
+                                            </packing>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -161,6 +161,7 @@ namespace Ryujinx.Headless.SDL2
                             DpadLeft = Key.Left,
                             DpadRight = Key.Right,
                             ButtonMinus = Key.Minus,
+                            ButtonScreenshot = Key.Unbound, // keyboard already has a default screenshot configured via ConfigurationState.Hid.Hotkeys.Screenshot, so no gamepad mapping needed
                             ButtonL = Key.E,
                             ButtonZl = Key.Q,
                             ButtonSl = Key.Unbound,
@@ -221,6 +222,7 @@ namespace Ryujinx.Headless.SDL2
                             DpadLeft = ConfigGamepadInputId.DpadLeft,
                             DpadRight = ConfigGamepadInputId.DpadRight,
                             ButtonMinus = ConfigGamepadInputId.Minus,
+                            ButtonScreenshot = ConfigGamepadInputId.Misc1,
                             ButtonL = ConfigGamepadInputId.LeftShoulder,
                             ButtonZl = ConfigGamepadInputId.LeftTrigger,
                             ButtonSl = ConfigGamepadInputId.Unbound,

--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -244,6 +244,7 @@ namespace Ryujinx.Input.SDL2
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadLeft, (GamepadButtonInputId)_configuration.LeftJoycon.DpadLeft));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadRight, (GamepadButtonInputId)_configuration.LeftJoycon.DpadRight));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Minus, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonMinus));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Misc1, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonScreenshot));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftShoulder, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonL));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonSr));

--- a/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
@@ -372,6 +372,7 @@ namespace Ryujinx.Input.SDL2
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadLeft, (Key)_configuration.LeftJoycon.DpadLeft));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadRight, (Key)_configuration.LeftJoycon.DpadRight));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Minus, (Key)_configuration.LeftJoycon.ButtonMinus));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Misc1, (Key)_configuration.LeftJoycon.ButtonScreenshot));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftShoulder, (Key)_configuration.LeftJoycon.ButtonL));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger, (Key)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (Key)_configuration.LeftJoycon.ButtonSr));

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -888,6 +888,7 @@ namespace Ryujinx.UI.Common.Configuration
                         DpadLeft = Key.Left,
                         DpadRight = Key.Right,
                         ButtonMinus = Key.Minus,
+                        ButtonScreenshot = Key.Unbound, // keyboard already has a default screenshot configured via ConfigurationState.Hid.Hotkeys.Screenshot, so no gamepad mapping needed
                         ButtonL = Key.E,
                         ButtonZl = Key.Q,
                         ButtonSl = Key.Unbound,
@@ -1117,6 +1118,7 @@ namespace Ryujinx.UI.Common.Configuration
                             DpadLeft = Key.Left,
                             DpadRight = Key.Right,
                             ButtonMinus = Key.Minus,
+                            ButtonScreenshot = Key.Unbound, // keyboard already has a default screenshot configured via ConfigurationState.Hid.Hotkeys.Screenshot, so no gamepad mapping needed
                             ButtonL = Key.E,
                             ButtonZl = Key.Q,
                             ButtonSl = Key.Unbound,

--- a/src/Ryujinx/Assets/Locales/de_DE.json
+++ b/src/Ryujinx/Assets/Locales/de_DE.json
@@ -233,6 +233,8 @@
   "ControllerSettingsDPadDown": "Runter",
   "ControllerSettingsDPadLeft": "Links",
   "ControllerSettingsDPadRight": "Rechts",
+  "ControllerSettingsRawScreenshot": "Unbearbeiteter Screenshot",
+  "ControllerSettingsRawScreenshotTooltip": "Macht ein Bildschirmfoto, ohne das Spiel zu informieren, sodass keine Wasserzeichen hinzugefügt werden.",
   "ControllerSettingsStickButton": "Button",
   "ControllerSettingsStickUp": "Hoch",
   "ControllerSettingsStickDown": "Runter",

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -234,6 +234,8 @@
   "ControllerSettingsDPadDown": "Down",
   "ControllerSettingsDPadLeft": "Left",
   "ControllerSettingsDPadRight": "Right",
+  "ControllerSettingsRawScreenshot": "Raw Screenshot",
+  "ControllerSettingsRawScreenshotTooltip": "Takes a screenshot without informing the game, so no watermarks will be added.",
   "ControllerSettingsStickButton": "Button",
   "ControllerSettingsStickUp": "Up",
   "ControllerSettingsStickDown": "Down",

--- a/src/Ryujinx/Input/AvaloniaKeyboard.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboard.cs
@@ -128,6 +128,7 @@ namespace Ryujinx.Ava.Input
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadLeft,            (Key)_configuration.LeftJoycon.DpadLeft));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.DpadRight,           (Key)_configuration.LeftJoycon.DpadRight));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Minus,               (Key)_configuration.LeftJoycon.ButtonMinus));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Misc1,               (Key)_configuration.LeftJoycon.ButtonScreenshot));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftShoulder,        (Key)_configuration.LeftJoycon.ButtonL));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger,         (Key)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (Key)_configuration.LeftJoycon.ButtonSr));

--- a/src/Ryujinx/UI/Models/Input/GamepadInputConfig.cs
+++ b/src/Ryujinx/UI/Models/Input/GamepadInputConfig.cs
@@ -178,6 +178,17 @@ namespace Ryujinx.Ava.UI.Models.Input
             }
         }
 
+        private GamepadInputId _buttonScreenshot;
+        public GamepadInputId ButtonScreenshot
+        {
+            get => _buttonScreenshot;
+            set
+            {
+                _buttonScreenshot = value;
+                OnPropertyChanged();
+            }
+        }
+
         private GamepadInputId _buttonL;
         public GamepadInputId ButtonL
         {
@@ -440,6 +451,7 @@ namespace Ryujinx.Ava.UI.Models.Input
                 DpadRight = controllerInput.LeftJoycon.DpadRight;
                 ButtonL = controllerInput.LeftJoycon.ButtonL;
                 ButtonMinus = controllerInput.LeftJoycon.ButtonMinus;
+                ButtonScreenshot = controllerInput.LeftJoycon.ButtonScreenshot;
                 LeftButtonSl = controllerInput.LeftJoycon.ButtonSl;
                 LeftButtonSr = controllerInput.LeftJoycon.ButtonSr;
                 ButtonZl = controllerInput.LeftJoycon.ButtonZl;
@@ -502,6 +514,7 @@ namespace Ryujinx.Ava.UI.Models.Input
                     DpadRight = DpadRight,
                     ButtonL = ButtonL,
                     ButtonMinus = ButtonMinus,
+                    ButtonScreenshot = ButtonScreenshot,
                     ButtonSl = LeftButtonSl,
                     ButtonSr = LeftButtonSr,
                     ButtonZl = ButtonZl,

--- a/src/Ryujinx/UI/Models/Input/KeyboardInputConfig.cs
+++ b/src/Ryujinx/UI/Models/Input/KeyboardInputConfig.cs
@@ -381,6 +381,7 @@ namespace Ryujinx.Ava.UI.Models.Input
                     DpadRight = DpadRight,
                     ButtonL = ButtonL,
                     ButtonMinus = ButtonMinus,
+                    ButtonScreenshot = Key.Unbound,  // keyboard screenshot configured via ConfigurationState.Hid.Hotkeys.Screenshot, so no gamepad mapping needed
                     ButtonZl = ButtonZl,
                     ButtonSl = LeftButtonSl,
                     ButtonSr = LeftButtonSr,

--- a/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
@@ -545,6 +545,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
                         DpadLeft = Key.Left,
                         DpadRight = Key.Right,
                         ButtonMinus = Key.Minus,
+                        ButtonScreenshot = Key.Unbound, // keyboard already has a default screenshot configured via ConfigurationState.Hid.Hotkeys.Screenshot, so no gamepad mapping needed
                         ButtonL = Key.E,
                         ButtonZl = Key.Q,
                         ButtonSl = Key.Unbound,
@@ -605,6 +606,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
                         DpadLeft = ConfigGamepadInputId.DpadLeft,
                         DpadRight = ConfigGamepadInputId.DpadRight,
                         ButtonMinus = ConfigGamepadInputId.Minus,
+                        ButtonScreenshot = ConfigGamepadInputId.Misc1,
                         ButtonL = ConfigGamepadInputId.LeftShoulder,
                         ButtonZl = ConfigGamepadInputId.LeftTrigger,
                         ButtonSl = ConfigGamepadInputId.Unbound,

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml
@@ -311,6 +311,36 @@
                         </StackPanel>
                     </StackPanel>
                 </Border>
+                <!-- Screenshot -->
+                <Border
+                    BorderBrush="{DynamicResource ThemeControlBorderColor}"
+                    BorderThickness="1"
+                    IsVisible="{Binding IsLeft}"
+                    Margin="0,5,0,0"
+                    CornerRadius="5">
+                    <StackPanel
+                        Margin="10"
+                        Orientation="Vertical">
+                        <!-- Raw Screenshot -->
+                        <StackPanel
+                            Margin="0,0,0,4"
+                            Orientation="Horizontal">
+                            <TextBlock
+                                Margin="0,0,10,0"
+                                Width="120"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Text="{locale:Locale ControllerSettingsRawScreenshot}"
+                                ToolTip.Tip="{locale:Locale ControllerSettingsRawScreenshotTooltip}"
+                                TextAlignment="Center" />
+                            <ToggleButton Name="ButtonScreenshot">
+                                <TextBlock
+                                    Text="{Binding Config.ButtonScreenshot, Converter={StaticResource Key}}"
+                                    TextAlignment="Center" />
+                            </ToggleButton>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
             </StackPanel>
             <!-- Triggers & Side Buttons -->
             <StackPanel

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -84,6 +84,9 @@ namespace Ryujinx.Ava.UI.Views.Input
                                     case "ButtonMinus":
                                         viewModel.Config.ButtonMinus = buttonValue.AsHidType<GamepadInputId>();
                                         break;
+                                    case "ButtonScreenshot":
+                                        viewModel.Config.ButtonScreenshot = buttonValue.AsHidType<GamepadInputId>();
+                                        break;
                                     case "LeftStickButton":
                                         viewModel.Config.LeftStickButton = buttonValue.AsHidType<GamepadInputId>();
                                         break;


### PR DESCRIPTION
This triggers the same raw screenshot as the keyboard hotkey, i.e. the game is not informed of the intent to screenshot, so it cannot add watermarks etc.

The button can be configured using both the regular UI and GTK.

Includes English and German translations.

An alternate approach is proposed in draft PR #4503: Allow triggering all hotkeys using the gamepad.

Re: #5952