### PR TITLE
Implement fast DMA texture to texture copy

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -276,8 +276,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     dstBaseOffset += dstStride * (yCount - 1);
                 }
 
-                ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (ulong)srcBaseOffset, srcSize, true);
-
                 // If remapping is disabled, we always copy the components directly, in order.
                 // If it's enabled, but the mapping is just XYZW, we also copy them in order.
                 bool isIdentityRemap = !remap ||
@@ -288,6 +286,46 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
+
+                // Check if the source texture exists on the GPU, if it does, do a GPU side copy.
+                // Otherwise, we would need to flush the source texture which is costly.
+                // We don't expect the source to be linear in such cases, as linear source usually indicates buffer or CPU written data.
+
+                if (completeSource && completeDest && !srcLinear && isIdentityRemap)
+                {
+                    var source = memoryManager.Physical.TextureCache.FindTexture(
+                        memoryManager,
+                        srcGpuVa,
+                        srcBpp,
+                        srcStride,
+                        src.Height,
+                        xCount,
+                        yCount,
+                        srcLinear,
+                        src.MemoryLayout.UnpackGobBlocksInY(),
+                        src.MemoryLayout.UnpackGobBlocksInZ());
+
+                    if (source != null && source.Height == yCount)
+                    {
+                        var target = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+                            memoryManager,
+                            source.Info.FormatInfo,
+                            dstGpuVa,
+                            xCount,
+                            yCount,
+                            dstStride,
+                            dstLinear,
+                            dst.MemoryLayout.UnpackGobBlocksInY(),
+                            dst.MemoryLayout.UnpackGobBlocksInZ());
+
+                        target.SynchronizeMemory();
+                        source.HostTexture.CopyTo(target.HostTexture, 0, 0);
+                        target.SignalModified();
+                        return;
+                    }
+                }
+
+                ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (ulong)srcBaseOffset, srcSize, true);
 
                 // Try to set the texture data directly,
                 // but only if we are doing a complete copy,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -307,6 +307,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                     if (source != null && source.Height == yCount)
                     {
+                        source.SynchronizeMemory();
+
                         var target = memoryManager.Physical.TextureCache.FindOrCreateTexture(
                             memoryManager,
                             source.Info.FormatInfo,
@@ -318,7 +320,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                             dst.MemoryLayout.UnpackGobBlocksInY(),
                             dst.MemoryLayout.UnpackGobBlocksInZ());
 
-                        target.SynchronizeMemory();
+                        if (source.ScaleFactor != target.ScaleFactor)
+                        {
+                            target.PropagateScale(source);
+                        }
+
                         source.HostTexture.CopyTo(target.HostTexture, 0, 0);
                         target.SignalModified();
                         return;

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -351,6 +351,53 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Tries to find an existing texture, or create a new one if not found.
         /// </summary>
         /// <param name="memoryManager">GPU memory manager where the texture is mapped</param>
+        /// <param name="formatInfo">Format of the texture</param>
+        /// <param name="gpuAddress">GPU virtual address of the texture</param>
+        /// <param name="xCount">Texture width in bytes</param>
+        /// <param name="yCount">Texture height</param>
+        /// <param name="stride">Texture stride if linear, otherwise ignored</param>
+        /// <param name="isLinear">Indicates if the texture is linear or block linear</param>
+        /// <param name="gobBlocksInY">GOB blocks in Y for block linear textures</param>
+        /// <param name="gobBlocksInZ">GOB blocks in Z for 3D block linear textures</param>
+        /// <returns>The texture</returns>
+        public Texture FindOrCreateTexture(
+            MemoryManager memoryManager,
+            FormatInfo formatInfo,
+            ulong gpuAddress,
+            int xCount,
+            int yCount,
+            int stride,
+            bool isLinear,
+            int gobBlocksInY,
+            int gobBlocksInZ)
+        {
+            TextureInfo info = new(
+                gpuAddress,
+                xCount / formatInfo.BytesPerPixel,
+                yCount,
+                1,
+                1,
+                1,
+                1,
+                stride,
+                isLinear,
+                gobBlocksInY,
+                gobBlocksInZ,
+                1,
+                Target.Texture2D,
+                formatInfo);
+
+            Texture texture = FindOrCreateTexture(memoryManager, TextureSearchFlags.ForCopy, info, 0, sizeHint: new Size(xCount, yCount, 1));
+
+            texture?.SynchronizeMemory();
+
+            return texture;
+        }
+
+        /// <summary>
+        /// Tries to find an existing texture, or create a new one if not found.
+        /// </summary>
+        /// <param name="memoryManager">GPU memory manager where the texture is mapped</param>
         /// <param name="colorState">Color buffer texture to find or create</param>
         /// <param name="layered">Indicates if the texture might be accessed with a non-zero layer index</param>
         /// <param name="discard">Indicates that the sizeHint region's data will be overwritten</param>


### PR DESCRIPTION
This change allows DMA copies between two textures to happen in the GPU in some cases.
This generally has a performance advantage, even if the destination data will be accessed in the CPU In the future, first because we don't need to block GPU processing and wait until the flush is complete, and second because we don't need to pay the cost of linear to block linear followed by block linear to linear conversion (which would also happen on CPU).

This gives a massive performance improvement on Castlevania Dominus Collection (more than 2x faster on my machine).
Before:

https://github.com/user-attachments/assets/2fac1261-64e5-4e19-89eb-664cd5057d1c

After:

https://github.com/user-attachments/assets/6333daa4-670f-4769-a931-8c7ba00184e0

This will need to be tested extensively to ensure there are no regressions.