### PR TITLE
Add support for sampler sRGB disable

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -14,6 +14,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         public bool IsDisposed { get; private set; }
 
         /// <summary>
+        /// True if the sampler has sRGB conversion enabled, false otherwise.
+        /// </summary>
+        public bool IsSrgb { get; }
+
+        /// <summary>
         /// Host sampler object.
         /// </summary>
         private readonly ISampler _hostSampler;
@@ -30,6 +35,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="descriptor">The Maxwell sampler descriptor</param>
         public Sampler(GpuContext context, SamplerDescriptor descriptor)
         {
+            IsSrgb = descriptor.UnpackSrgb();
+
             MinFilter minFilter = descriptor.UnpackMinFilter();
             MagFilter magFilter = descriptor.UnpackMagFilter();
 

--- a/src/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
@@ -114,6 +114,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Unpacks the sampler sRGB format flag.
+        /// </summary>
+        /// <returns>True if the has sampler is sRGB conversion enabled, false otherwise</returns>
+        public readonly bool UnpackSrgb()
+        {
+            return (Word0 & (1 << 13)) != 0;
+        }
+
+        /// <summary>
         /// Unpacks and converts the maximum anisotropy value used for texture anisotropic filtering.
         /// </summary>
         /// <returns>The maximum anisotropy</returns>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -187,7 +187,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             (TexturePool texturePool, SamplerPool samplerPool) = GetPools();
 
-            return (texturePool.Get(textureId), samplerPool.Get(samplerId));
+            Sampler sampler = samplerPool?.Get(samplerId);
+
+            return (texturePool.Get(textureId, sampler?.IsSrgb ?? true), sampler);
         }
 
         /// <summary>
@@ -508,11 +510,11 @@ namespace Ryujinx.Graphics.Gpu.Image
                 state.TextureHandle = textureId;
                 state.SamplerHandle = samplerId;
 
-                ref readonly TextureDescriptor descriptor = ref texturePool.GetForBinding(textureId, out Texture texture);
+                Sampler sampler = samplerPool?.Get(samplerId);
+
+                ref readonly TextureDescriptor descriptor = ref texturePool.GetForBinding(textureId, sampler?.IsSrgb ?? true, out Texture texture);
 
                 specStateMatches &= specState.MatchesTexture(stage, index, descriptor);
-
-                Sampler sampler = samplerPool?.Get(samplerId);
 
                 ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
                 ISampler hostSampler = sampler?.GetHostSampler(texture);


### PR DESCRIPTION
This builds on the support added on #7311 for creating views aliases of a texture pool entry to implement the sRGB bit on samplers. When this bit is set to zero, the texture format is not sRGB. In other words, for a texture to be sRGB, both t he sampler and the texture must have their respective sRGB bits set to 1.

This fixes the image being too dark on Sphin and the Cursed Mummy and Charge Kid.
Before:
![image](https://github.com/user-attachments/assets/16816bd7-a8e5-4265-9282-a660ba203443)
![image](https://github.com/user-attachments/assets/2608771c-889f-444e-bcc4-f5556086eab9)
After:
![image](https://github.com/user-attachments/assets/5e00b09e-1d0e-4c91-9e03-f6d58256dced)
![image](https://github.com/user-attachments/assets/0a66da52-982e-4504-afef-0806c1ea5704)
Other OpenGL games might be affected (not Tomb Raider, I already tested). NVN games should not be affected since they always set the sRGB bit to 1 in the sampler.