### PR TITLE
Implement support for shader ATOM.EXCH instruction

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 7131;
+        private const uint CodeGenVersion = 7320;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -222,30 +222,14 @@ namespace Ryujinx.Graphics.Shader.Instructions
                         context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
                     }
                     break;
-                case AtomOp.And:
-                    if (type == AtomSize.S32 || type == AtomSize.U32)
+                case AtomOp.Min:
+                    if (type == AtomSize.S32)
                     {
-                        res = context.AtomicAnd(storageKind, e0, e1, value);
+                        res = context.AtomicMinS32(storageKind, e0, e1, value);
                     }
-                    else
+                    else if (type == AtomSize.U32)
                     {
-                        context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
-                    }
-                    break;
-                case AtomOp.Xor:
-                    if (type == AtomSize.S32 || type == AtomSize.U32)
-                    {
-                        res = context.AtomicXor(storageKind, e0, e1, value);
-                    }
-                    else
-                    {
-                        context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
-                    }
-                    break;
-                case AtomOp.Or:
-                    if (type == AtomSize.S32 || type == AtomSize.U32)
-                    {
-                        res = context.AtomicOr(storageKind, e0, e1, value);
+                        res = context.AtomicMinU32(storageKind, e0, e1, value);
                     }
                     else
                     {
@@ -266,19 +250,41 @@ namespace Ryujinx.Graphics.Shader.Instructions
                         context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
                     }
                     break;
-                case AtomOp.Min:
-                    if (type == AtomSize.S32)
+                case AtomOp.And:
+                    if (type == AtomSize.S32 || type == AtomSize.U32)
                     {
-                        res = context.AtomicMinS32(storageKind, e0, e1, value);
-                    }
-                    else if (type == AtomSize.U32)
-                    {
-                        res = context.AtomicMinU32(storageKind, e0, e1, value);
+                        res = context.AtomicAnd(storageKind, e0, e1, value);
                     }
                     else
                     {
                         context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
                     }
+                    break;
+                case AtomOp.Or:
+                    if (type == AtomSize.S32 || type == AtomSize.U32)
+                    {
+                        res = context.AtomicOr(storageKind, e0, e1, value);
+                    }
+                    else
+                    {
+                        context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
+                    }
+                    break;
+                case AtomOp.Xor:
+                    if (type == AtomSize.S32 || type == AtomSize.U32)
+                    {
+                        res = context.AtomicXor(storageKind, e0, e1, value);
+                    }
+                    else
+                    {
+                        context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
+                    }
+                    break;
+                case AtomOp.Exch:
+                    res = context.AtomicSwap(storageKind, e0, e1, value);
+                    break;
+                default:
+                    context.TranslatorContext.GpuAccessor.Log($"Invalid atomic operation: {op}.");
                     break;
             }
 

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -281,7 +281,14 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     }
                     break;
                 case AtomOp.Exch:
-                    res = context.AtomicSwap(storageKind, e0, e1, value);
+                    if (type == AtomSize.S32 || type == AtomSize.U32)
+                    {
+                        res = context.AtomicSwap(storageKind, e0, e1, value);
+                    }
+                    else
+                    {
+                        context.TranslatorContext.GpuAccessor.Log($"Invalid reduction type: {type}.");
+                    }
                     break;
                 default:
                     context.TranslatorContext.GpuAccessor.Log($"Invalid atomic operation: {op}.");


### PR DESCRIPTION
This implements the `atomicExchange` shader operation, which was missing for some reason. The other operations were re-ordered to follow the enum order. Also added a log message to warn when a operation is invalid/unsupported. The only operations missing now are increment, decrement and "safe add".

Fixes missing reflections on Lollipop Chainsaw RePOP.
Before:
![image](https://github.com/user-attachments/assets/d87d8336-b900-427c-b74c-e11c5264c99a)
After:
![image](https://github.com/user-attachments/assets/6c5ea4a5-c9b4-4c27-a65c-298dd585ce81)
