### PR TITLE
Shader: Assume the only remaining source is the right one when all others are undefined

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 7320;
+        private const uint CodeGenVersion = 7331;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
@@ -138,6 +138,8 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                 // Ensure that conditions met for that branch are also met for the current one.
                 // Prefer the latest sources for the phi node.
 
+                int undefCount = 0;
+
                 for (int i = phiNode.SourcesCount - 1; i >= 0; i--)
                 {
                     BasicBlock phiBlock = phiNode.GetBlock(i);
@@ -157,6 +159,26 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                         if (match != phiSource)
                         {
                             return match;
+                        }
+                    }
+                    else if (phiSource.Type == OperandType.Undefined)
+                    {
+                        undefCount++;
+                    }
+                }
+
+                // If all sources but one are all undefined, we can assume that the one
+                // that is not undefined is the right one.
+
+                if (undefCount == phiNode.SourcesCount - 1)
+                {
+                    for (int i = phiNode.SourcesCount - 1; i >= 0; i--)
+                    {
+                        Operand phiSource = phiNode.GetSource(i);
+
+                        if (phiSource.Type != OperandType.Undefined)
+                        {
+                            return phiSource;
                         }
                     }
                 }

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
@@ -167,7 +167,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     }
                 }
 
-                // If all sources but one are all undefined, we can assume that the one
+                // If all sources but one are undefined, we can assume that the one
                 // that is not undefined is the right one.
 
                 if (undefCount == phiNode.SourcesCount - 1)


### PR DESCRIPTION
When all sources but one of a phi operation are undefined, we can assume that the one that is not undefined is the right one, when looking for handles or global memory addresses. This assumption is valid as long the shader is not accessing uninitialized registers, but if it does I beleive the behaviour would be unpredictable anyway.

This fixes some bindless elimination failures in Romancing Saga 2 demo.
Before:
![image](https://github.com/user-attachments/assets/38dda3f0-7241-4586-807b-3f35dbb2bf76)
After:
![image](https://github.com/user-attachments/assets/622d338c-31f7-41e5-84fc-18f657605e73)