### PR TITLE
Fix quads draws after DrawTexture on Vulkan

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -636,9 +636,9 @@ namespace Ryujinx.Graphics.Vulkan
                 var oldStencilTestEnable = _newState.StencilTestEnable;
                 var oldDepthTestEnable = _newState.DepthTestEnable;
                 var oldDepthWriteEnable = _newState.DepthWriteEnable;
-                var oldTopology = _newState.Topology;
                 var oldViewports = DynamicState.Viewports;
                 var oldViewportsCount = _newState.ViewportsCount;
+                var oldTopology = _topology;
 
                 _newState.CullMode = CullModeFlags.None;
                 _newState.StencilTestEnable = false;
@@ -658,7 +658,7 @@ namespace Ryujinx.Graphics.Vulkan
                 _newState.StencilTestEnable = oldStencilTestEnable;
                 _newState.DepthTestEnable = oldDepthTestEnable;
                 _newState.DepthWriteEnable = oldDepthWriteEnable;
-                _newState.Topology = oldTopology;
+                SetPrimitiveTopology(oldTopology);
 
                 DynamicState.SetViewports(ref oldViewports, oldViewportsCount);
 


### PR DESCRIPTION
This fixes a bug where topology conversion would not be done for unsupported topologies after a `DrawTexture` operation, until `SetPrimitiveType` is called again. This happens because the internal `_topology` field is not restored, so the draw function does now know that the topology is unsupported anymore.

Fixes rendering on FUZE4 when using Vulkan.
Before:
![image](https://github.com/user-attachments/assets/d244dde8-bc2a-4c6e-853c-cb2eb8caf29e)
After:
![image](https://github.com/user-attachments/assets/f795a3f3-f4d4-4a2a-8761-a1f2ed792bcc)
Might fix similar issues in other games, but this is a rare combination.