### PR TITLE
GPU: Ensure all clip distances are initialized when used

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 7331;
+        private const uint CodeGenVersion = 7353;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -190,7 +190,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (stage == ShaderStage.Vertex)
             {
-                InitializePositionOutput(context);
+                InitializeVertexOutputs(context);
             }
 
             UInt128 usedAttributes = context.TranslatorContext.AttributeUsage.NextInputAttributesComponents;
@@ -236,11 +236,19 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
-        private static void InitializePositionOutput(EmitterContext context)
+        private static void InitializeVertexOutputs(EmitterContext context)
         {
             for (int c = 0; c < 4; c++)
             {
                 context.Store(StorageKind.Output, IoVariable.Position, null, Const(c), ConstF(c == 3 ? 1f : 0f));
+            }
+
+            if (context.Program.ClipDistancesWritten != 0)
+            {
+                for (int i = 0; i < 8; i++)
+                {
+                    context.Store(StorageKind.Output, IoVariable.ClipDistance, null, Const(i), ConstF(0f));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes an issue with some AMD GPUs and drivers where uninitialized clip distance seemingly contained random values instead of 0, either resulting in geometry not drawing at all or seemingly clipping against nothing.

In future, we could limit the size of the clip distances array to the highest index of clip distance that is used, and only have to initialize up to that. For now, this works.