### PR TITLE
sdl: set app name

### DIFF
--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -53,6 +53,7 @@ namespace Ryujinx.SDL2.Common
                     return;
                 }
 
+                SDL_SetHint(SDL_HINT_APP_NAME, "Ryujinx");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");


### PR DESCRIPTION
Ryujinx was not hinting application name, so on some platforms (e.g. Linux) volume control shows Ryujinx as 'SDL Application'. This can cause confusion.

This commit fixes name in volume control applets on some platforms.

see: https://wiki.libsdl.org/SDL2/SDL_HINT_APP_NAME

# Changes

```diff
$ wpctl status > /tmp/before.txt
$ # After this patch
$ wpctl status > /tmp/after.txt
$ diff -u /tmp/before.txt /tmp/after.txt
-        83. SDL Application                                            
-             86. output_FR       > Generic Analog:playback_FR	[active]
-             87. output_FL       > Generic Analog:playback_FL	[active]
+        83. Ryujinx                                                    
+             86. output_FR       > Generic Analog:playback_FR	[active]
+             87. output_FL       > Generic Analog:playback_FL	[active]
```