### PR TITLE
Do not try to create a texture pool if shader does not use textures

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -743,7 +743,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 constantBufferUsePerStageMask &= ~(1 << index);
             }
 
-            if (checkTextures)
+            if (checkTextures && _allTextures.Length > 0)
             {
                 TexturePool pool = channel.TextureManager.GetTexturePool(poolState.TexturePoolGpuVa, poolState.TexturePoolMaximumId);
 


### PR DESCRIPTION
If the shader does not use textures, we don't need to try creating a texture pool when checking if a shader in the cache matches. This was causing a crash on some games when they were loaded with a shader cache because the texture pool might not exist yet.

Fixes #7192.
Fixes #7378.